### PR TITLE
Current host index method support for SocketInitiator and ThreadedSocketInitiator

### DIFF
--- a/src/C++/SocketInitiator.cpp
+++ b/src/C++/SocketInitiator.cpp
@@ -228,6 +228,15 @@ void SocketInitiator::onTimeout( SocketConnector& )
     i->second->onTimeout();
 }
 
+int SocketInitiator::currentHostIndex(const SessionID &s) const
+{
+  SessionToHostNum::const_iterator i = m_sessionToHostNum.find( s );
+  if ( i != m_sessionToHostNum.end() )
+    return i->second-1;
+  else
+    return 0;
+}
+
 void SocketInitiator::getHost( const SessionID& s, const Dictionary& d,
                                std::string& address, short& port )
 {

--- a/src/C++/SocketInitiator.h
+++ b/src/C++/SocketInitiator.h
@@ -40,7 +40,7 @@ public:
                    const SessionSettings& ) throw( ConfigError );
   SocketInitiator( Application&, MessageStoreFactory&,
                    const SessionSettings&, LogFactory& ) throw( ConfigError );
-
+  int currentHostIndex(const SessionID& s) const;
   virtual ~SocketInitiator();
 
 private:

--- a/src/C++/ThreadedSocketInitiator.cpp
+++ b/src/C++/ThreadedSocketInitiator.cpp
@@ -235,6 +235,15 @@ THREAD_PROC ThreadedSocketInitiator::socketThread( void* p )
   return 0;
 }
 
+int ThreadedSocketInitiator::currentHostIndex(const SessionID &s) const
+{
+    SessionToHostNum::const_iterator i = m_sessionToHostNum.find( s );
+    if ( i != m_sessionToHostNum.end() )
+        return i->second-1;
+    else
+        return 0;
+}
+
 void ThreadedSocketInitiator::getHost( const SessionID& s, const Dictionary& d,
                                        std::string& address, short& port )
 {

--- a/src/C++/ThreadedSocketInitiator.h
+++ b/src/C++/ThreadedSocketInitiator.h
@@ -45,6 +45,7 @@ public:
                            const SessionSettings&,
                            LogFactory& ) throw( ConfigError );
 
+  int currentHostIndex(const SessionID& s) const;
   virtual ~ThreadedSocketInitiator();
 
 private:


### PR DESCRIPTION
Method to get current socket index from socket initiators.
This would be very helpful if e.g. you have different username/password pair for different hosts.
Then you can do something like this:

``` c++
void Application::toAdmin(FIX::Message &message, const FIX::SessionID &session)
{
    if (message.getHeader().getField( FIX::FIELD::MsgType ) == FIX44::Logon::MsgType()) {
        int hostNum = m_initiator->currentHostIndex(session);
        if (m_credentials.size() < hostNum+1) 
            throw FIX::Exception("No user/password for this host");
        std::string username = m_credentials[hostNum].login;
        std::string password = m_credentials[hostNum].password;
        message.getHeader().setField(FIX::Username(username));
        message.getHeader().setField(FIX::Password(password));
    }
}
```
