### PR TITLE
Use C++ compiler for allocator existance testing

### DIFF
--- a/m4/ax_allocator.m4
+++ b/m4/ax_allocator.m4
@@ -12,6 +12,8 @@ AC_ARG_WITH(allocator,
 )
 ALLOCATOR=$with_allocator
 
+AC_LANG_CPLUSPLUS
+
 # check for debug allocator
 if test "x$with_allocator" == "xdebug"
 then


### PR DESCRIPTION
Every test in m4/ax_allocator.m4 relies on C++ compiler. On my machine (Ubuntu 13.04) those tests run with C compiler and eventually compilation errors are produced.
