### PR TITLE
Fixing issue with PossDup messages being ignored

### DIFF
--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -984,9 +984,8 @@ bool Session::verify( const Message& msg, bool checkTooHigh,
       doTargetTooHigh( msg );
       return false;
     }
-    else if ( checkTooLow && isTargetTooLow( *pMsgSeqNum ) )
+    else if ( (checkTooLow && isTargetTooLow( *pMsgSeqNum ) ) && !doTargetTooLow( msg ))
     {
-      doTargetTooLow( msg );
       return false;
     }
 


### PR DESCRIPTION
Logic to check verify messaged flagged as possible duplicates was being ignored.
