### PR TITLE
Add a line to replace restricted characters from enum descriptions with ...

### DIFF
--- a/spec/Processor.rb
+++ b/spec/Processor.rb
@@ -291,6 +291,7 @@ class Processor
       field.elements.each("value") { |value|
         enum = value.attributes["enum"]
         description = value.attributes["description"]
+        description = description.gsub(/[^0-9A-Z]/i, '_')
         values[description] = enum
       }
 


### PR DESCRIPTION
...'_'

This edit resolves issues when parsing a FIX.xml data dictionary that includes characters not allowed in c++ or .NET variable names, such as space or forward slash.

here is an example that breaks the original code https://www.tradingtechnologies.com/Documents/DevCenter%20Documents/FIX42.xml
