### PR TITLE
Support files with size higher than 2GB

### DIFF
--- a/src/C++/FileStore.h
+++ b/src/C++/FileStore.h
@@ -100,7 +100,7 @@ public:
   void refresh() throw ( IOException );
 
 private:
-  typedef std::pair < int, int > OffsetSize;
+  typedef std::pair < fpos_t, int > OffsetSize;
   typedef std::map < int, OffsetSize > NumToOffset;
 
   void open( bool deleteFile );


### PR DESCRIPTION
This patch allows quickfix to work properly with files larger than 2GB - this resolves issues with ResendRequests
