### PR TITLE
Fix typo in FIX43.xml. Closes #52.

### DIFF
--- a/spec/FIX43.xml
+++ b/spec/FIX43.xml
@@ -3951,7 +3951,7 @@
   <field number='533' name='TotalAffectedOrders' type='INT' />
   <field number='534' name='NoAffectedOrders' type='NUMINGROUP' />
   <field number='535' name='AffectedOrderID' type='STRING' />
-  <field number='536' name='AffectedSecondaryOrderID' type='STIRNG' />
+  <field number='536' name='AffectedSecondaryOrderID' type='STRING' />
   <field number='537' name='QuoteType' type='INT'>
    <value enum='0' description='INDICATIVE' />
    <value enum='1' description='TRADEABLE' />

--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -37,7 +37,7 @@ namespace FIX
 typedef int signed_int;
 typedef unsigned int unsigned_int;
 
-#define UNSIGNED_VALUE_OF( x ) unsigned_int( x < 0 ? -x : x )
+#define UNSIGNED_VALUE_OF( x ) unsigned_int( x < 0 ? -(long long)x : x )
 
 #define IS_SPACE( x ) ( x == ' ' )
 #define IS_DIGIT( x ) ( unsigned_int( x - '0' ) < 10 )


### PR DESCRIPTION
Fix typo in FIX43.xml. Closes #52. Fixes a broken unit test with gcc 4.9 -O2 due to undefined behaviour of abs(INT_MIN).