### PR TITLE
Fix overflow in IntConvertor

### DIFF
--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -37,14 +37,18 @@ namespace FIX
 typedef int signed_int;
 typedef unsigned int unsigned_int;
 
-#define UNSIGNED_VALUE_OF( x ) unsigned_int( x < 0 ? -x : x )
+inline unsigned_int unsigned_value_of( signed int x )
+{
+  auto y = static_cast<unsigned_int>( x );
+  return x < 0 ? -y : y;
+}
 
 #define IS_SPACE( x ) ( x == ' ' )
 #define IS_DIGIT( x ) ( unsigned_int( x - '0' ) < 10 )
 
 inline int number_of_symbols_in( const signed_int value )
 {
-  unsigned_int number = UNSIGNED_VALUE_OF( value );
+  unsigned_int number = unsigned_value_of( value );
 
   int symbols = 0;
 
@@ -97,7 +101,7 @@ inline char* integer_to_string( char* buf, const size_t len, signed_int t )
 
   *--p = '\0';
   
-  unsigned_int number = UNSIGNED_VALUE_OF( t );
+  unsigned_int number = unsigned_value_of( t );
 
   while( number > 99 )
   {

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -111,7 +111,7 @@ TEST(integerConvertTo)
   CHECK_EQUAL( "-12345678", IntConvertor::convert( -12345678 ) );
   CHECK_EQUAL( "-123456789", IntConvertor::convert( -123456789 ) );
   CHECK_EQUAL( "-2147483647", IntConvertor::convert( -2147483647 ) );
-  //CHECK_EQUAL( "-2147483648", IntConvertor::convert( MIN_INT ) );
+  CHECK_EQUAL( "-2147483648", IntConvertor::convert( MIN_INT ) );
 }
 
 TEST(integerConvertFrom)


### PR DESCRIPTION
The negation of INT_MIN causes an overflow. If we cast first, both cast and negation of unsigned quantity are well-defined and the result is what we expect. Fixes #82.