### PR TITLE
Time code in Quickfix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,10 @@ AC_CHECK_LIB(c,shutdown,true,AC_CHECK_LIB(socket,shutdown))
 AC_CHECK_LIB(c,inet_addr,true,AC_CHECK_LIB(nsl,inet_addr))
 AC_CHECK_LIB(c,nanosleep,true,AC_CHECK_LIB(rt,nanosleep))
 AC_CHECK_LIB(compat,ftime)
+AC_CHECK_FUNC([clock_gettime], [AC_DEFINE([HAVE_CLOCK_GETTIME], [1],
+                               [Define if clock_gettime exists.])])
+AC_CHECK_FUNC([clock_get_time], [AC_DEFINE([__MACH__], [1],
+                               [Define if clock_get_time exists.])])
 
 AC_MSG_CHECKING([which threading environment to use])
 # each host OS needs special threading flags

--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -399,31 +399,64 @@ public:
 };
 
 /// Field that contains a UTC time stamp value
-class UtcTimeStampField : public FieldBase
-{
-public:
-  explicit UtcTimeStampField( int field, const UtcTimeStamp& data, bool showMilliseconds = false )
-: FieldBase( field, UtcTimeStampConvertor::convert( data, showMilliseconds ) ) {}
-  UtcTimeStampField( int field, bool showMilliseconds = false )
-: FieldBase( field, UtcTimeStampConvertor::convert( UtcTimeStamp(), showMilliseconds ) ) {}
+  class UtcTimeStampField : public FieldBase
+  {
+  public:
+    explicit UtcTimeStampField( int field, const UtcTimeStamp& data, bool showMilliseconds = false )
+        : FieldBase( field, UtcTimeStampConvertor::convert( data, showMilliseconds ) )
+    {
+      // Nothing here...
+    }
 
-  void setValue( const UtcTimeStamp& value )
-    { setString( UtcTimeStampConvertor::convert( value ) ); }
-  UtcTimeStamp getValue() const throw ( IncorrectDataFormat )
-    { try
-      { return UtcTimeStampConvertor::convert( getString() ); }
-      catch( FieldConvertError& )
-      { throw IncorrectDataFormat( getTag(), getString() ); } }
-  operator UtcTimeStamp() const
-    { return getValue(); }
+    explicit UtcTimeStampField( int field, const UtcTimeStamp& data, UtcTimeStampConvertor::PRECISION minortimePrecision )
+        : FieldBase( field, UtcTimeStampConvertor::convertWithPrecision( data, minortimePrecision ) )
+    {
+      // Nothing here...
+    }
 
-  bool operator<( const UtcTimeStampField& rhs ) const
-    { return getValue() < rhs.getValue(); }
-  bool operator==( const UtcTimeStampField& rhs ) const
-    { return getValue() == rhs.getValue(); }
-  bool operator!=( const UtcTimeStampField& rhs ) const
-    { return getValue() != rhs.getValue(); }
-};
+    UtcTimeStampField( int field, bool showMilliseconds = false )
+        : FieldBase( field, UtcTimeStampConvertor::convert( UtcTimeStamp(), showMilliseconds ) )
+    {
+      // Nothing here...
+    }
+
+
+    void setValue( const UtcTimeStamp& value )
+    {
+      setString( UtcTimeStampConvertor::convert( value ) );
+    }
+
+    UtcTimeStamp getValue() const throw ( IncorrectDataFormat )
+    {
+      try {
+        return UtcTimeStampConvertor::convert( getString() );
+      }
+      catch( FieldConvertError& ) {
+        throw IncorrectDataFormat( getTag(), getString() );
+      }
+
+    }
+
+    operator UtcTimeStamp() const
+    {
+      return getValue();
+    }
+
+    bool operator<( const UtcTimeStampField& rhs ) const
+    {
+      return getValue() < rhs.getValue();
+    }
+
+    bool operator==( const UtcTimeStampField& rhs ) const
+    {
+      return getValue() == rhs.getValue();
+    }
+
+    bool operator!=( const UtcTimeStampField& rhs ) const
+    {
+      return getValue() != rhs.getValue();
+    }
+  };
 
 /// Field that contains a UTC date value
 class UtcDateField : public FieldBase
@@ -542,6 +575,7 @@ NAME() : TOK##Field(NUM, false) {} \
 NAME(bool showMilliseconds) : TOK##Field(NUM, showMilliseconds) {} \
 NAME(const TYPE& value) : TOK##Field(NUM, value) {} \
 NAME(const TYPE& value, bool showMilliseconds) : TOK##Field(NUM, value, showMilliseconds) {} \
+NAME(const TYPE& value, UtcTimeStampConvertor::PRECISION minortimePrecision) : TOK##Field(NUM, value, minortimePrecision) {} \
 }
 
 #define DEFINE_FIELD_TIMECLASS( NAME, TOK, TYPE ) \

--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -122,7 +122,6 @@ inline char* integer_to_string( char* buf, const size_t len, signed_int t )
 
   return p;
 }
-//  integer_to_string_padded( result, 5, year, 4 );
 
 inline char* integer_to_string_padded
 ( char* buf, const size_t len, signed_int t,

--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -610,18 +610,11 @@ struct UtcTimeStampConvertor
 
       if (minortimePrecision == MILLISECONDS)
         integer_to_string_padded(result + 18, 4, value.getMillisecond(), 3);
-      if (minortimePrecision == MICROSECONDS)
+      else if (minortimePrecision == MICROSECONDS)
         integer_to_string_padded(result + 18, 7, value.getMicrosecond(), 6);
-      if (minortimePrecision == NANOSECONDS)
+      else if (minortimePrecision == NANOSECONDS)
         integer_to_string_padded(result + 18, 10, value.getNanosecond(), 9);
     }
-
-      /*
-      if( integer_to_string_padded ( result + 18, 4, millis, 3 )
-          != result + 18 )
-      {
-        throw FieldConvertError();
-      }*/
 
     return std::string(result);
   }
@@ -793,9 +786,9 @@ struct UtcTimeOnlyConvertor
 
       if (minortimePrecision == UtcTimeStampConvertor::PRECISION::MILLISECONDS)
         integer_to_string_padded(result + 9, 4, value.getMillisecond(), 3);
-      if (minortimePrecision == UtcTimeStampConvertor::PRECISION::MICROSECONDS)
+      else if (minortimePrecision == UtcTimeStampConvertor::PRECISION::MICROSECONDS)
         integer_to_string_padded(result + 9, 7, value.getMicrosecond(), 6);
-      if (minortimePrecision == UtcTimeStampConvertor::PRECISION::NANOSECONDS)
+      else if (minortimePrecision == UtcTimeStampConvertor::PRECISION::NANOSECONDS)
         integer_to_string_padded(result + 9, 10, value.getNanosecond(), 9);
     }
 

--- a/src/C++/FieldTypes.cpp
+++ b/src/C++/FieldTypes.cpp
@@ -29,18 +29,39 @@
 # include <sys/timeb.h>
 #endif
 
+#ifdef __MACH__
+# include <mach/clock.h>
+# include <mach/mach.h>
+#endif
+
 namespace FIX {
 
 DateTime DateTime::nowUtc()
 {
-#if defined( HAVE_FTIME )
+#if defined( HAVE_CLOCK_GETTIME )
+    struct timespec tspec;
+    clock_gettime(CLOCK_REALTIME, &tspec );
+    return fromUtcTimeT( static_cast<time_t>(tspec.tv_sec), static_cast<int>(tspec.tv_nsec));
+#elif defined( __MACH__ )
+    struct timespec ts;
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+
+    ts.tv_sec = mts.tv_sec;
+    ts.tv_nsec = mts.tv_nsec;
+    return fromUtcTimeT(static_cast<time_t>(ts.tv_sec), static_cast<int>(ts.tv_nsec));
+#elif defined( HAVE_FTIME )
     timeb tb;
     ftime (&tb);
-    return fromUtcTimeT (tb.time, tb.millitm);
+    return fromUtcTimeT (tb.time,  static_cast<int>(tb.millitm * NANOSECONDS_PER_MILLISECOND));
 #elif defined( _POSIX_SOURCE )
     struct timeval tv;
     gettimeofday (&tv, 0);
-    return fromUtcTimeT( tv.tv_sec, tv.tv_usec / 1000 );
+    return fromUtcTimeT( tv.tv_sec,  static_cast<int>(tv.tv_usec * NANOSECONDS_PER_MICROSECOND) );
 #else
     return fromUtcTimeT( ::time (0), 0 );
 #endif
@@ -48,14 +69,30 @@ DateTime DateTime::nowUtc()
 
 DateTime DateTime::nowLocal()
 {
-#if defined( HAVE_FTIME )
+#if defined( HAVE_CLOCK_GETTIME )
+    struct timespec tspec;
+    clock_gettime(CLOCK_REALTIME, &tspec );
+    return fromLocalTimeT( static_cast<time_t>(tspec.tv_sec),  static_cast<int>(tspec.tv_nsec));
+#elif defined( __MACH__ )
+    struct timespec ts;
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+
+    ts.tv_sec = mts.tv_sec;
+    ts.tv_nsec = mts.tv_nsec;
+    return fromUtcTimeT(static_cast<time_t>(ts.tv_sec), static_cast<int>(ts.tv_nsec));
+#elif defined( HAVE_FTIME )
     timeb tb;
     ftime (&tb);
-    return fromLocalTimeT( tb.time, tb.millitm );
+    return fromLocalTimeT( tb.time,  static_cast<int>(tb.millitm * NANOSECONDS_PER_MILLISECOND));
 #elif defined( _POSIX_SOURCE )
     struct timeval tv;
     gettimeofday (&tv, 0);
-    return fromLocalTimeT( tv.tv_sec, tv.tv_usec / 1000 );
+    return fromLocalTimeT( tv.tv_sec,  static_cast<int>(tv.tv_usec * NANOSECONDS_PER_MICROSECOND) );
 #else
     return fromLocalTimeT( ::time (0), 0 );
 #endif

--- a/src/C++/FieldTypes.h
+++ b/src/C++/FieldTypes.h
@@ -53,7 +53,7 @@ struct DateTime
   long long m_time;
 
   /// Magic numbers
-  enum : int
+  enum 
   {
     NANOSECONDS_PER_MICROSECOND  = 1000,
     NANOSECONDS_PER_MILLISECOND  = 1000000,
@@ -69,12 +69,9 @@ struct DateTime
     JULIAN_19700101 = 2440588
   };
 
-  enum : long long
-  {
-    NANOSECONDS_PER_DAY          = static_cast<long long>(SECONDS_PER_DAY) * static_cast<long long>(NANOSECONDS_PER_SECOND),
-    NANOSECONDS_PER_HOUR         = static_cast<long long>(SECONDS_PER_HOUR) * static_cast<long long>(NANOSECONDS_PER_SECOND),
-    NANOSECONDS_PER_MINUTE       = static_cast<long long>(SECONDS_PER_MINUTE) * static_cast<long long>(NANOSECONDS_PER_SECOND)
-  };
+  long long NANOSECONDS_PER_DAY = static_cast<long long>(SECONDS_PER_DAY) * static_cast<long long>(NANOSECONDS_PER_SECOND);
+  long long NANOSECONDS_PER_HOUR = static_cast<long long>(SECONDS_PER_HOUR) * static_cast<long long>(NANOSECONDS_PER_SECOND);
+  long long NANOSECONDS_PER_MINUTE = static_cast<long long>(SECONDS_PER_MINUTE) * static_cast<long long>(NANOSECONDS_PER_SECOND);
 
   /// Default constructor - initializes to zero
   DateTime () : m_date (0), m_time (0) {}
@@ -142,7 +139,7 @@ struct DateTime
     return (static_cast<int>(m_time / NANOSECONDS_PER_SECOND) % SECONDS_PER_MINUTE);
   }
 
-  /// Return the nanosecond portion of the time
+  /// Return the millisecond portion of the time
   inline int getMillisecond() const
   {
     return static_cast<int>((m_time % static_cast<long long>(NANOSECONDS_PER_SECOND)) / 
@@ -156,7 +153,7 @@ struct DateTime
                                       static_cast<long long>(NANOSECONDS_PER_MICROSECOND));
   }
 
-  /// Return the microsecond portion of the time
+  /// Return the nanosecond portion of the time
   inline int getNanosecond() const
   {
     return static_cast<int>((m_time % static_cast<long long>(NANOSECONDS_PER_SECOND)));
@@ -178,13 +175,6 @@ struct DateTime
     minute = (secondFromMidnight / SECONDS_PER_MINUTE) % MINUTES_PER_HOUR;
     second = secondFromMidnight % SECONDS_PER_MINUTE;
     nanosecond = static_cast<int>(m_time % static_cast<long long>(NANOSECONDS_PER_SECOND));
-    /*
-    int ticks = m_time / MILLIS_PER_SEC;
-    hour = ticks / SECONDS_PER_HOUR;
-    minute = (ticks / SECONDS_PER_MIN) % MINUTES_PER_HOUR;
-    second = ticks % SECONDS_PER_MIN;
-    nanosecond = m_time % MILLIS_PER_SEC;
-    */
   }
 
   /// Calculate the weekday of the date (Sunday is 1, Saturday is 7)

--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -98,6 +98,7 @@ void Session::insertSendingTime( Header& header )
     showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;
 
   header.setField( SendingTime(now, showMilliseconds && m_millisecondsInTimeStamp) );
+  //header.setField( SendingTime(now, UtcTimeStampConvertor::PRECISION::NANOSECONDS) );
 }
 
 void Session::insertOrigSendingTime( Header& header, const UtcTimeStamp& when )
@@ -109,6 +110,9 @@ void Session::insertOrigSendingTime( Header& header, const UtcTimeStamp& when )
     showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;
 
   header.setField( OrigSendingTime(when, showMilliseconds && m_millisecondsInTimeStamp) );
+  //header.setField( OrigSendingTime(when, m_precision) );
+  //header.setField( OrigSendingTime(when, UtcTimeStampConvertor::PRECISION::NANOSECONDS) );
+
 }
 
 void Session::fill( Header& header )

--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -98,7 +98,6 @@ void Session::insertSendingTime( Header& header )
     showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;
 
   header.setField( SendingTime(now, showMilliseconds && m_millisecondsInTimeStamp) );
-  //header.setField( SendingTime(now, UtcTimeStampConvertor::PRECISION::NANOSECONDS) );
 }
 
 void Session::insertOrigSendingTime( Header& header, const UtcTimeStamp& when )
@@ -110,9 +109,6 @@ void Session::insertOrigSendingTime( Header& header, const UtcTimeStamp& when )
     showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;
 
   header.setField( OrigSendingTime(when, showMilliseconds && m_millisecondsInTimeStamp) );
-  //header.setField( OrigSendingTime(when, m_precision) );
-  //header.setField( OrigSendingTime(when, UtcTimeStampConvertor::PRECISION::NANOSECONDS) );
-
 }
 
 void Session::fill( Header& header )

--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -328,7 +328,6 @@ private:
   static SessionIDs s_sessionIDs;
   static Sessions s_registered;
   static Mutex s_mutex;
-
 };
 }
 

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -233,10 +233,18 @@ TEST(booleanConvertFrom)
 TEST(utcTimeStampConvertTo)
 {
   UtcTimeStamp input;
-  input.setHMS( 12, 5, 6, 555 );
+  input.setHMS( 12, 5, 6, 555123456 );
   input.setYMD( 2000, 4, 26 );
   CHECK_EQUAL( "20000426-12:05:06", UtcTimeStampConvertor::convert( input ) );
   CHECK_EQUAL( "20000426-12:05:06.555", UtcTimeStampConvertor::convert( input,true ) );
+  CHECK_EQUAL( "20000426-12:05:06", UtcTimeStampConvertor::convertWithPrecision( input, 
+                                    UtcTimeStampConvertor::PRECISION::SECONDS ) );
+  CHECK_EQUAL( "20000426-12:05:06.555", UtcTimeStampConvertor::convertWithPrecision( input, 
+                                        UtcTimeStampConvertor::PRECISION::MILLISECONDS ) );
+  CHECK_EQUAL( "20000426-12:05:06.555123", UtcTimeStampConvertor::convertWithPrecision( input, 
+                                           UtcTimeStampConvertor::PRECISION::MICROSECONDS ) );
+  CHECK_EQUAL( "20000426-12:05:06.555123456", UtcTimeStampConvertor::convertWithPrecision( input, 
+                                              UtcTimeStampConvertor::PRECISION::NANOSECONDS ) );
 }
 
 TEST(utcTimeStampConvertFrom)
@@ -266,9 +274,17 @@ TEST(utcTimeStampConvertFrom)
 TEST(utcTimeOnlyConvertTo)
 {
   UtcTimeOnly input;
-  input.setHMS( 12, 5, 6, 555 );
+  input.setHMS( 12, 5, 6, 555123456 );
   CHECK_EQUAL( "12:05:06", UtcTimeOnlyConvertor::convert( input ) );
   CHECK_EQUAL( "12:05:06.555", UtcTimeOnlyConvertor::convert( input,true ) );
+  CHECK_EQUAL( "12:05:06", UtcTimeOnlyConvertor::convertWithPrecision( input, 
+                                    UtcTimeStampConvertor::PRECISION::SECONDS ) );
+  CHECK_EQUAL( "12:05:06.555", UtcTimeOnlyConvertor::convertWithPrecision( input, 
+                               UtcTimeStampConvertor::PRECISION::MILLISECONDS ) );
+  CHECK_EQUAL( "12:05:06.555123", UtcTimeOnlyConvertor::convertWithPrecision( input, 
+                                  UtcTimeStampConvertor::PRECISION::MICROSECONDS ) );
+  CHECK_EQUAL( "12:05:06.555123456", UtcTimeOnlyConvertor::convertWithPrecision( input, 
+                                     UtcTimeStampConvertor::PRECISION::NANOSECONDS ) );
 }
 
 TEST(utcTimeOnlyConvertFrom)

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -1227,9 +1227,9 @@ struct disconnectBeforeStartTimeFixture : public acceptorFixture
   disconnectBeforeStartTimeFixture()
   {
     startTime.setCurrent();
-    startTime += 100;
+    startTime += 100000000;
     endTime.setCurrent();
-    endTime += 400;
+    endTime += 400000000;
 
     acceptorFixture::createSession( 0 );
   }


### PR DESCRIPTION
Hello,

I've update the time code in Quickfix to be based on nanosecond resolution. I've also amended the way Quickfix get's time from the operating system to make clock_gettime and clock_get_time options. The new code is completely compatible with the rest of the existing code. So one can now do things like:

void Session::insertSendingTime( Header& header )
{
UtcTimeStamp now;
bool showMilliseconds = false;
if( m_sessionID.getBeginString() == BeginString_FIXT11 )
showMilliseconds = true;
else
showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;

header.setField( SendingTime(now, showMilliseconds && m_millisecondsInTimeStamp) ); // <— Old approach (still works fine)
//header.setField( SendingTime(now, UtcTimeStampConvertor::PRECISION::NANOSECONDS) ); // <— New approach (with higher resolution)
}

I've also made Quickfix liberal in what it receives. So it can now access timestamps with ms, us or ns resolution without throwing a wobble. I understand OMX in Scandinavia already send the higher resolution timestamp.

Finally I removed a couple of major bugs in the existing code.

The code is here: https://github.com/lasselj/quickfix

All the best,

Lasse
