### PR TITLE
Avoid double lookups

### DIFF
--- a/src/C++/FieldMap.h
+++ b/src/C++/FieldMap.h
@@ -83,9 +83,9 @@ public:
           m_fields.insert( Fields::value_type( field.getTag(), field ) );
       else
       {
-          Fields::iterator i = m_fields.find( field.getTag() );
-          if( i == m_fields.end() )
-              m_fields.insert( Fields::value_type( field.getTag(), field ) );
+          Fields::iterator i = m_fields.lower_bound( field.getTag() );
+          if( i == m_fields.end() || m_fields.key_comp()( field.getTag(), i->first ) )
+              m_fields.insert( i, Fields::value_type( field.getTag(), field ) );
           else
               i->second = field;
       }

--- a/src/C++/Message.h
+++ b/src/C++/Message.h
@@ -218,21 +218,17 @@ public:
 
   bool isAdmin() const
   { 
-    if( m_header.isSetField(FIELD::MsgType) )
-    {
-      const MsgType& msgType = FIELD_GET_REF( m_header, MsgType );
+    MsgType msgType;
+    if( m_header.getFieldIfSet( msgType ) )
       return isAdminMsgType( msgType );
-    }
     return false;
   }
 
   bool isApp() const
   { 
-    if( m_header.isSetField(FIELD::MsgType) )
-    {
-      const MsgType& msgType = FIELD_GET_REF( m_header, MsgType );
+    MsgType msgType;
+    if( m_header.getFieldIfSet( msgType ) )
       return !isAdminMsgType( msgType );
-    }
     return false;
   }
 


### PR DESCRIPTION
In `FieldMap.h` we avoid double lookup by using `lower_bound` to get an iterator to an element with a tag _not less_ than the given tag, so if the tags are not equal we can use that iterator as a hint in the subsequent insertion.

In `Message.h`, by having a non-throwing version of `getFieldPtr`, we avoid two lookups done by `isSetField` and subsequent `getFieldRef`.
