### PR TITLE
Run Python unittests with ./configure --with-python argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
  - sudo apt-get install libxml2-dev
  - ./bootstrap
 
-script: ./configure && make && make check
+script: ./configure --with-python && make && make check

--- a/src/python/Makefile.am
+++ b/src/python/Makefile.am
@@ -21,3 +21,5 @@ all-local:
 
 clean-local:
 	rm -rf $(local_python_lib)
+
+TESTS = test.sh

--- a/src/python/test/DataDictionaryTestCase.py
+++ b/src/python/test/DataDictionaryTestCase.py
@@ -143,7 +143,7 @@ class DataDictionaryTestCase(unittest.TestCase):
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 		self.object.addField( 501 )
@@ -151,21 +151,21 @@ class DataDictionaryTestCase(unittest.TestCase):
 		try:
 			self.object.validate( message )
 			self.failUnless( 1 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 0 )
 
 		message.setField( 5000, "value" )
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 		self.object.checkUserDefinedFields( False )
 		try:
 			self.object.validate( message )
 			self.failUnless( 1 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 0 )
 
 	def test_checkHasValue(self):
@@ -175,7 +175,7 @@ class DataDictionaryTestCase(unittest.TestCase):
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 	def test_checkIsInMessage(self):
@@ -196,14 +196,14 @@ class DataDictionaryTestCase(unittest.TestCase):
 		try:
 			self.object.validate( message )
 			self.failUnless( 1 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 0 )
 
 		message.setField( fix.Symbol("MSFT") )
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 	def test_checkHasRequired(self):
@@ -225,21 +225,21 @@ class DataDictionaryTestCase(unittest.TestCase):
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 		message.getHeader().setField( fix.SenderCompID("SENDER") )
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 		message.setField( fix.TestReqID("1") )
 		try:
 			self.object.validate( message )
 			self.failUnless( 1 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 0 )
 
 		message.getHeader().removeField( fix.SenderCompID().getTag() )
@@ -247,7 +247,7 @@ class DataDictionaryTestCase(unittest.TestCase):
 		try:
 			self.object.validate( message )
 			self.failUnless( 0 )
-		except fix.Exception, e:
+		except fix.Exception as e:
 			self.failUnless( 1 )
 
 if __name__ == '__main__':

--- a/src/python/test/MessageTestCase.py
+++ b/src/python/test/MessageTestCase.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import quickfix as fix
 import quickfix42 as fix42
 import unittest
@@ -54,55 +56,55 @@ class MessageTestCase(unittest.TestCase):
 			self.object.setString( strGood )
 			self.object.setString( strNull )
 			self.object.setString( strNoLengthAndChk, False )
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless( 0 )
 
 		try:
 			self.object.setString( strTrailingCharacter )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strNoChk )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strBadChk )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strBad )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strBadHeaderOrder )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strNoLengthAndChk )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strJunk )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		try:
 			self.object.setString( strEmpty )
 			self.failUnless(0)
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(1)
 
 		dataDictionary = fix.DataDictionary()
@@ -115,7 +117,7 @@ class MessageTestCase(unittest.TestCase):
 
 		try:
 			self.object.setString( strBodyFields, True, dataDictionary )
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless( 0 )
 
 		assert( self.object.getHeader().isSetField( clOrdID ) )
@@ -129,7 +131,7 @@ class MessageTestCase(unittest.TestCase):
 		try:
 			self.object.setString( str, True, dataDictionary )
 			self.assertEquals( str, self.object.toString() )
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			assert( 0 )
 
 	def test_setStringWithHeaderGroup(self):
@@ -139,7 +141,7 @@ class MessageTestCase(unittest.TestCase):
 		try:
 			self.object.setString( str, True, dataDictionary )
 			self.assertEquals( str, self.object.toString() )
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			assert( 0 )
 
 
@@ -150,7 +152,7 @@ class MessageTestCase(unittest.TestCase):
 		try:
 			self.object.setString( str, False )
 			self.assertEquals( expected, self.object.toString() )
-		except fix.InvalidMessage, e:
+		except fix.InvalidMessage as e:
 			self.failUnless(0)
 
         def test_embeddedXml(self):
@@ -167,8 +169,8 @@ class MessageTestCase(unittest.TestCase):
                         self.object.getHeader().getField(xmlData)
 			self.assertEquals( 413, xmlDataLen.getValue() )
 			self.assertEquals( encodedFIXmessage, xmlData.getValue() )
-		except fix.InvalidMessage, e:
-                        print e
+		except fix.InvalidMessage as e:
+                        print(e)
 			assert( 0 )
 
 	def test_reverseRoute(self):

--- a/src/python/test/SessionSettingsTestCase.py
+++ b/src/python/test/SessionSettingsTestCase.py
@@ -13,28 +13,28 @@ class SessionSettingsTestCase(unittest.TestCase):
 		try:
 			self.object.set( sessionID, dictionary )
 			self.failUnless( 0 )
-		except fix.ConfigError, e:
+		except fix.ConfigError as e:
 			self.failUnless( 1 )
 
 		dictionary.setString( fix.CONNECTION_TYPE, "badvalue" )
 		try:
 			self.object.set( sessionID, dictionary );
 			self.failUnless( 0 );
-		except fix.ConfigError, e:
+		except fix.ConfigError as e:
 			self.failUnless( 1 )
 
 		dictionary.setString( fix.CONNECTION_TYPE, "initiator" )
 		try:
 			self.object.set( sessionID, dictionary );
 			self.failUnless( 1 );
-		except fix.ConfigError, e:
+		except fix.ConfigError as e:
 			self.failUnless( 0 )
 
 		sessionID = fix.SessionID( "FIX4.2", "SenderCompID", "TargetCompID" )
 		try:
 			self.object.set( sessionID, dictionary );
 			self.failUnless( 0 );
-		except fix.ConfigError, e:
+		except fix.ConfigError as e:
 			self.failUnless( 1 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
If python bindings are created, the Python unittest script `test.sh` is executed on `make check`.

Also, all Python unittests were modified to be Python 2/3 compatible.