### PR TITLE
Re-typedef FieldMap::g_iterator and FieldMap::iterator to be non-const

### DIFF
--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -160,7 +160,7 @@ void DataDictionary::iterate( const FieldMap& map, const MsgType& msgType ) cons
 {
   int lastField = 0;
 
-  FieldMap::iterator i;
+  FieldMap::const_iterator i;
   for ( i = map.begin(); i != map.end(); ++i )
   {
     const FieldBase& field = i->second;

--- a/src/C++/DataDictionary.h
+++ b/src/C++/DataDictionary.h
@@ -492,7 +492,7 @@ private:
         throw RequiredTagMissing( *iF );
     }
 
-    FieldMap::g_iterator groups;
+    FieldMap::g_const_iterator groups;
     for( groups = body.g_begin(); groups != body.g_end(); ++groups )
     {
       int delim;

--- a/src/C++/FieldMap.h
+++ b/src/C++/FieldMap.h
@@ -56,9 +56,9 @@ public:
                      ALLOCATOR<std::pair<const int, std::vector< FieldMap* > > > > Groups;
 #endif
 
-  typedef Fields::const_iterator iterator;
-  typedef iterator const_iterator;
-  typedef Groups::const_iterator g_iterator;
+  typedef Fields::iterator iterator;
+  typedef Fields::const_iterator const_iterator;
+  typedef Groups::iterator g_iterator;
   typedef Groups::const_iterator g_const_iterator;
 
   FieldMap( const message_order& order =
@@ -211,10 +211,14 @@ public:
 
   int calculateTotal( int checkSumField = FIELD::CheckSum ) const;
 
-  iterator begin() const { return m_fields.begin(); }
-  iterator end() const { return m_fields.end(); }
-  g_iterator g_begin() const { return m_groups.begin(); }
-  g_iterator g_end() const { return m_groups.end(); }
+  iterator begin() { return m_fields.begin(); }
+  iterator end() { return m_fields.end(); }
+  const_iterator begin() const { return m_fields.begin(); }
+  const_iterator end() const { return m_fields.end(); }
+  g_iterator g_begin() { return m_groups.begin(); }
+  g_iterator g_end() { return m_groups.end(); }
+  g_const_iterator g_begin() const { return m_groups.begin(); }
+  g_const_iterator g_end() const { return m_groups.end(); }
 
 private:
   Fields m_fields;

--- a/src/C++/Message.cpp
+++ b/src/C++/Message.cpp
@@ -224,7 +224,7 @@ std::string& Message::toXML( std::string& str ) const
 std::string Message::toXMLFields(const FieldMap& fields, int space) const
 {
   std::stringstream stream;
-  FieldMap::iterator i;
+  FieldMap::const_iterator i;
   std::string name;
   for(i = fields.begin(); i != fields.end(); ++i)
   {
@@ -247,7 +247,7 @@ std::string Message::toXMLFields(const FieldMap& fields, int space) const
     stream << "</field>" << std::endl;
   }
 
-  FieldMap::g_iterator j;
+  FieldMap::g_const_iterator j;
   for(j = fields.g_begin(); j != fields.g_end(); ++j)
   {
     std::vector<FieldMap*>::const_iterator k;


### PR DESCRIPTION
And add non-const overloads for begin and end that return these non-const iterators

This changes QuickFIX to match the standard library containers that also supply const and non-const begin and end.

This will be a breaking change for those that rely on FieldMap::iterator and FieldMap::g_iterator to be const iterators. Within the QuickFIX codebase, this was two places.

It appears this was the intention from the start, as without these changes FieldMap::const_iterator and FieldMap::const_g_iterator were not used at all.

To fix any breaking changes, the user should change any declaration that uses FieldMap::iterator or FieldMap::g_iterator to instead use FieldMap::const_iterator or FieldMap::g_const_iterator. This should not have an impact of non-const lvalues.