### PR TITLE
Fix generation of NPE instead of FieldConvertError + improve tests

### DIFF
--- a/src/C++/Dictionary.cpp
+++ b/src/C++/Dictionary.cpp
@@ -87,7 +87,7 @@ throw( ConfigError, FieldConvertError )
   try
   {
     std::string value = getString(key);
-    if( value.size() < 2 ) throw FieldConvertError(0);
+    if( value.size() < 2 ) throw FieldConvertError();
     std::string abbr = value.substr(0, 2);
     std::transform( abbr.begin(), abbr.end(), abbr.begin(), tolower );
     if( abbr == "su" ) return 1;
@@ -97,7 +97,6 @@ throw( ConfigError, FieldConvertError )
     if( abbr == "th" ) return 5;
     if( abbr == "fr" ) return 6;
     if( abbr == "sa" ) return 7;
-    if( value.size() < 2 ) throw FieldConvertError(0);
   }
   catch ( FieldConvertError& )
   {

--- a/src/C++/test/DictionaryTestCase.cpp
+++ b/src/C++/test/DictionaryTestCase.cpp
@@ -80,6 +80,8 @@ TEST(setGetDay)
   object.setString( "DAY5", "TH" );
   object.setString( "DAY6", "FR" );
   object.setString( "DAY7", "SA" );
+  object.setString( "DAYUNKNOWN", "un" );
+  object.setString( "DAYBAD", "f" );
 
   CHECK_EQUAL( 1, object.getDay( "DAY1" ) );
   CHECK_EQUAL( 2, object.getDay( "DAY2" ) );
@@ -88,6 +90,8 @@ TEST(setGetDay)
   CHECK_EQUAL( 5, object.getDay( "DAY5" ) );
   CHECK_EQUAL( 6, object.getDay( "DAY6" ) );
   CHECK_EQUAL( 7, object.getDay( "DAY7" ) );
+  CHECK_EQUAL( -1, object.getDay( "DAYUNKNOWN" ) );
+  CHECK_THROW( object.getDay( "DAYBAD" ), ConfigError );
 
   object.setDay( "NEXTDAY1", 1 );
   object.setDay( "NEXTDAY2", 2 );
@@ -96,6 +100,7 @@ TEST(setGetDay)
   object.setDay( "NEXTDAY5", 5 );
   object.setDay( "NEXTDAY6", 6 );
   object.setDay( "NEXTDAY7", 7 );
+  object.setDay( "NEXTDAYBAD", 8 );
 
   CHECK_EQUAL( 1, object.getDay( "NEXTDAY1" ) );
   CHECK_EQUAL( 2, object.getDay( "NEXTDAY2" ) );

--- a/test/Reflector.rb
+++ b/test/Reflector.rb
@@ -34,7 +34,7 @@ class Reflector < Array
       line.chomp!
       if line.empty? then
       elsif (/^[IEie]\d{1},/ === line) then
-	cid = line[1].to_i - 48
+	cid = line[1].ord.to_i - 48
 	body = fixify!(fileify!(timeify!(line[3, line.length])))
       else
 	cid = 1


### PR DESCRIPTION
1. Fix generation of NPE instead of FieldConvertError when too short day is requested by Dictionary::getDay
+ unit tests
2. Fix generation of session id in acceptance test runner for ruby 2.0