### PR TITLE
Fix QuickfixRuby.cpp compilation by passing CXXFLAGS

### DIFF
--- a/src/C++/PostgreSQLLog.cpp
+++ b/src/C++/PostgreSQLLog.cpp
@@ -236,7 +236,7 @@ void PostgreSQLLog::insert( const std::string& table, const std::string value )
   time.getHMS( hour, minute, second, millis );
 
   char sqlTime[ 24 ];
-  STRING_SPRINTF( sqlTime, "%d-%02d-%02d %02d:%02d:%02d.%003d",
+  STRING_SPRINTF( sqlTime, "%d-%02d-%02d %02d:%02d:%02d.%03d",
            year, month, day, hour, minute, second, millis );
   
   char* valueCopy = new char[ (value.size() * 2) + 1 ];

--- a/src/ruby/extconf.rb
+++ b/src/ruby/extconf.rb
@@ -3,6 +3,7 @@ dir_config("quickfix", ["../..", "../../include", "../C++"], "../../lib")
 have_library("quickfix")
 CONFIG["CC"] = ENV['CXX']
 CONFIG["CXXFLAGS"] = ENV['CXXFLAGS']
+$CXXFLAGS += " " + ENV['CXXFLAGS']]
 CONFIG["LIBS"] += ENV['LIBS'] if ENV['LIBS'] != nil
 
 if( ENV['CXX'] != nil )


### PR DESCRIPTION
Additionally fix storing of time in PostgreSQLLog.

Updating of extconf.rb should resolve #128 and #74 
Note that changes from #132 may be required.