### PR TITLE
Use group instead of component in header

### DIFF
--- a/spec/FIX43.xml
+++ b/spec/FIX43.xml
@@ -3951,7 +3951,7 @@
   <field number='533' name='TotalAffectedOrders' type='INT' />
   <field number='534' name='NoAffectedOrders' type='NUMINGROUP' />
   <field number='535' name='AffectedOrderID' type='STRING' />
-  <field number='536' name='AffectedSecondaryOrderID' type='STIRNG' />
+  <field number='536' name='AffectedSecondaryOrderID' type='STRING' />
   <field number='537' name='QuoteType' type='INT'>
    <value enum='0' description='INDICATIVE' />
    <value enum='1' description='TRADEABLE' />

--- a/spec/FIX44.xml
+++ b/spec/FIX44.xml
@@ -26,7 +26,11 @@
   <field name='XmlData' required='N' />
   <field name='MessageEncoding' required='N' />
   <field name='LastMsgSeqNumProcessed' required='N' />
-  <component name='Hop' required='N' />
+  <group name='NoHops' required='N'>
+   <field name='HopCompID' required='N' />
+   <field name='HopSendingTime' required='N' />
+   <field name='HopRefID' required='N' />
+  </group>
  </header>
  <messages>
   <message name='Heartbeat' msgtype='0' msgcat='admin'>
@@ -3704,13 +3708,6 @@
    <group name='NoNestedPartySubIDs' required='N'>
     <field name='NestedPartySubID' required='N' />
     <field name='NestedPartySubIDType' required='N' />
-   </group>
-  </component>
-  <component name='Hop'>
-   <group name='NoHops' required='N'>
-    <field name='HopCompID' required='N' />
-    <field name='HopSendingTime' required='N' />
-    <field name='HopRefID' required='N' />
    </group>
   </component>
   <component name='NstdPtys2SubGrp'>

--- a/spec/FIXT11.xml
+++ b/spec/FIXT11.xml
@@ -27,7 +27,11 @@
     <field name='XmlData' required='N'/>
     <field name='MessageEncoding' required='N'/>
     <field name='LastMsgSeqNumProcessed' required='N'/>
-    <component name='HopGrp' required='N'/>
+    <group name='NoHops' required='N'>
+     <field name='HopCompID' required='N' />
+     <field name='HopSendingTime' required='N' />
+     <field name='HopRefID' required='N' />
+    </group>
     <field name='ApplVerID' required='N'/>
     <field name='CstmApplVerID' required='N'/>
   </header>
@@ -81,13 +85,6 @@
     </message>
   </messages>
   <components>
-    <component name='HopGrp'>
-      <group name='NoHops' required='N'>
-        <field name='HopCompID' required='N'/>
-        <field name='HopSendingTime' required='N'/>
-        <field name='HopRefID' required='N'/>
-      </group>
-    </component>
     <component name='MsgTypeGrp'>
       <group name='NoMsgTypes' required='N'>
         <field name='RefMsgType' required='N'/>

--- a/src/C++/Message.h
+++ b/src/C++/Message.h
@@ -44,18 +44,64 @@ static int const headerOrder[] =
     FIELD::MsgType
   };
 
-class Header : public FieldMap 
+class Header : public FieldMap
 {
 public:
   Header() : FieldMap(message_order( message_order::header ) )
   {}
+
+  void addGroup( const FIX::Group& group )
+  { FieldMap::addGroup( group.field(), group ); }
+
+  void replaceGroup( unsigned num, const FIX::Group& group )
+  { FieldMap::replaceGroup( num, group.field(), group ); }
+
+  Group& getGroup( unsigned num, FIX::Group& group ) const throw( FieldNotFound )
+  { group.clear();
+    return static_cast < Group& >
+      ( FieldMap::getGroup( num, group.field(), group ) );
+  }
+
+  void removeGroup( unsigned num, const FIX::Group& group )
+  { FieldMap::removeGroup( num, group.field() ); }
+  void removeGroup( const FIX::Group& group )
+  { FieldMap::removeGroup( group.field() ); }
+
+  bool hasGroup( const FIX::Group& group ) const
+  { return FieldMap::hasGroup( group.field() ); }
+  bool hasGroup( unsigned num, const FIX::Group& group ) const
+  { return FieldMap::hasGroup( num, group.field() ); }
+
 };
 
-class Trailer : public FieldMap 
+class Trailer : public FieldMap
 {
 public:
   Trailer() : FieldMap(message_order( message_order::trailer ) )
   {}
+
+  void addGroup( const FIX::Group& group )
+  { FieldMap::addGroup( group.field(), group ); }
+
+  void replaceGroup( unsigned num, const FIX::Group& group )
+  { FieldMap::replaceGroup( num, group.field(), group ); }
+
+  Group& getGroup( unsigned num, FIX::Group& group ) const throw( FieldNotFound )
+  { group.clear();
+    return static_cast < Group& >
+      ( FieldMap::getGroup( num, group.field(), group ) );
+  }
+
+  void removeGroup( unsigned num, const FIX::Group& group )
+  { FieldMap::removeGroup( num, group.field() ); }
+  void removeGroup( const FIX::Group& group )
+  { FieldMap::removeGroup( group.field() ); }
+
+  bool hasGroup( const FIX::Group& group ) const
+  { return FieldMap::hasGroup( group.field() ); }
+  bool hasGroup( unsigned num, const FIX::Group& group ) const
+  { return FieldMap::hasGroup( num, group.field() ); }
+
 };
 
 /**
@@ -139,7 +185,7 @@ public:
   /// Get a string representation without making a copy
   std::string& toString( std::string&,
                          int beginStringField = FIELD::BeginString,
-                         int bodyLengthField = FIELD::BodyLength, 
+                         int bodyLengthField = FIELD::BodyLength,
                          int checkSumField = FIELD::CheckSum ) const;
   /// Get a XML representation of the message
   std::string toXML() const;
@@ -202,8 +248,8 @@ public:
     return m_validStructure;
   }
 
-  int bodyLength( int beginStringField = FIELD::BeginString, 
-                  int bodyLengthField = FIELD::BodyLength, 
+  int bodyLength( int beginStringField = FIELD::BeginString,
+                  int bodyLengthField = FIELD::BodyLength,
                   int checkSumField = FIELD::CheckSum ) const
   { return m_header.calculateLength(beginStringField, bodyLengthField, checkSumField)
            + calculateLength(beginStringField, bodyLengthField, checkSumField)
@@ -217,7 +263,7 @@ public:
   }
 
   bool isAdmin() const
-  { 
+  {
     if( m_header.isSetField(FIELD::MsgType) )
     {
       const MsgType& msgType = FIELD_GET_REF( m_header, MsgType );
@@ -227,7 +273,7 @@ public:
   }
 
   bool isApp() const
-  { 
+  {
     if( m_header.isSetField(FIELD::MsgType) )
     {
       const MsgType& msgType = FIELD_GET_REF( m_header, MsgType );
@@ -240,7 +286,7 @@ public:
   { return m_header.isEmpty() && FieldMap::isEmpty() && m_trailer.isEmpty(); }
 
   void clear()
-  { 
+  {
     m_tag = 0;
     m_header.clear();
     FieldMap::clear();
@@ -312,14 +358,14 @@ public:
   void setSessionID( const SessionID& sessionID );
 
 private:
-  FieldBase extractField( 
+  FieldBase extractField(
     const std::string& string, std::string::size_type& pos,
     const DataDictionary* pSessionDD = 0, const DataDictionary* pAppDD = 0,
     const Group* pGroup = 0);
 
-  static bool IsDataField( 
-    int field, 
-    const DataDictionary* pSessionDD, 
+  static bool IsDataField(
+    int field,
+    const DataDictionary* pSessionDD,
     const DataDictionary* pAppDD )
   {
     if( (pSessionDD && pSessionDD->isDataField( field )) ||

--- a/src/C++/fix44/Message.h
+++ b/src/C++/fix44/Message.h
@@ -35,6 +35,15 @@ namespace FIX44
     FIELD_SET(*this, FIX::XmlData);
     FIELD_SET(*this, FIX::MessageEncoding);
     FIELD_SET(*this, FIX::LastMsgSeqNumProcessed);
+    FIELD_SET(*this, FIX::NoHops);
+    class NoHops: public FIX::Group
+    {
+    public:
+    NoHops() : FIX::Group(627,628,FIX::message_order(628,629,630,0)) {}
+      FIELD_SET(*this, FIX::HopCompID);
+      FIELD_SET(*this, FIX::HopSendingTime);
+      FIELD_SET(*this, FIX::HopRefID);
+    };
   };
 
   class Trailer : public FIX::Trailer

--- a/src/C++/fixt11/Message.h
+++ b/src/C++/fixt11/Message.h
@@ -37,6 +37,15 @@ namespace FIXT11
     FIELD_SET(*this, FIX::LastMsgSeqNumProcessed);
     FIELD_SET(*this, FIX::ApplVerID);
     FIELD_SET(*this, FIX::CstmApplVerID);
+    FIELD_SET(*this, FIX::NoHops);
+    class NoHops: public FIX::Group
+    {
+    public:
+    NoHops() : FIX::Group(627,628,FIX::message_order(628,629,630,0)) {}
+      FIELD_SET(*this, FIX::HopCompID);
+      FIELD_SET(*this, FIX::HopSendingTime);
+      FIELD_SET(*this, FIX::HopRefID);
+    };
   };
 
   class Trailer : public FIX::Trailer

--- a/src/C++/test/MessagesTestCase.cpp
+++ b/src/C++/test/MessagesTestCase.cpp
@@ -45,6 +45,7 @@
 #include <fix42/OrderStatusRequest.h>
 #include <fix42/MassQuote.h>
 #include <fix44/NewOrderCross.h>
+#include <fix44/AllocationInstruction.h>
 
 using namespace FIX;
 using namespace FIX42;
@@ -235,6 +236,21 @@ TEST(setStringWithHeaderGroup)
     "627=2\001628=HOP1\001629=20040916-16:19:18.328\001630=ID1\001"
     "628=HOP2\001629=20040916-16:19:18.328\001630=ID2\001"
     "10=079\001";
+
+  object.setString( str, true, &dataDictionary );
+  CHECK_EQUAL( str, object.toString() );
+}
+
+TEST(setStringWithHeaderGroupDefinedInComponent)
+{
+  FIX::Message object;
+  DataDictionary dataDictionary( "../spec/FIX44.xml" );
+  static const char* str =
+    "8=FIX.4.4\0019=152\00135=A\00134=125\00149=BUYSIDE\001"
+    "52=20040916-16:19:18.328\00156=SELLSIDE\001"
+    "627=2\001628=HOP1\001629=20040916-16:19:18.328\001630=ID1\001"
+    "628=HOP2\001629=20040916-16:19:18.328\001630=ID2\001"
+    "10=080\001";
 
   object.setString( str, true, &dataDictionary );
   CHECK_EQUAL( str, object.toString() );
@@ -1024,7 +1040,7 @@ TEST(newOrderListSetString)
   FIX42::NewOrderList object;
 
   DataDictionary dataDictionary( "../spec/FIX42.xml" );
-  
+
   object.setString
     ( "8=FIX.4.2\0019=95\00135=E\00166=1\00168=3\00173=3\001"
       "11=A\00154=1\00155=DELL\00167=1\001"
@@ -1152,7 +1168,7 @@ TEST(newOrderCrossGetString)
   noPartyIDs.set( FIX::PartyID("PARTY2") );
   noPartyIDs.set( FIX::PartyIDSource(FIX::PartyIDSource_PROPRIETARY) );
   noPartyIDs.set( FIX::PartyRole(FIX::PartyRole_CLIENT_ID) );
-  
+
   noSides.addGroup( noPartyIDs );
 
   noSides.set( FIX::OrderQty(100) );
@@ -1206,6 +1222,89 @@ TEST(newOrderCrossSetString)
   FIX::OrderQty orderQty;
   noSides.get( orderQty );
   CHECK_EQUAL( 100, orderQty );
+}
+
+TEST(allocationInstructionParseGetString)
+{
+  AllocationInstruction object;
+
+  object.getHeader().setField(SenderCompID("SENDER"));
+  object.getHeader().setField(TargetCompID("TARGET"));
+  object.getHeader().setField(MsgSeqNum(1));
+  FIX44::Header::NoHops hops;
+  hops.setField(HopCompID("HOP1"));
+  hops.setField(HopRefID(1));
+  object.getHeader().addGroup(hops);
+  hops.setField(HopCompID("HOP2"));
+  hops.setField(HopRefID(2));
+  object.getHeader().addGroup(hops);
+  object.setField(AllocID("Alloc001"));
+  object.setField(AllocTransType(AllocTransType_NEW));
+  object.setField(AllocType(AllocType_CALCULATED));
+  object.setField(AllocNoOrdersType(AllocNoOrdersType_NOT_SPECIFIED));
+  object.setField(Quantity(100));
+  object.setField(AvgPx(23.1));
+  object.setField(TradeDate("20170317"));
+
+  CHECK_EQUAL(
+          "8=FIX.4.4\0019=121\00135=J\00134=1\00149=SENDER\00156=TARGET\001627=2\001"
+          "628=HOP1\001630=1\001628=HOP2\001630=2\0016=23.1\00153=100\00170=Alloc001\001"
+          "71=0\00175=20170317\001626=1\001857=0\00110=159\001", object.toString() );
+}
+
+TEST(allocationInstructionString)
+{
+  AllocationInstruction object;
+  DataDictionary dataDictionary( "../spec/FIX44.xml" );
+
+  object.setString
+    ( "8=FIX.4.4\0019=198\00135=J\00134=1\00149=SENDER\00152=20170317-15:55:23.685\001"
+      "56=TARGET\001627=2\001628=HOP1\001629=20170317-15:55:23.685\001630=1\001"
+      "628=HOP2\001629=20170317-15:55:23.685\001630=2\0016=23.1\00153=100\001"
+      "70=Alloc001\00171=0\00175=20170317\001626=1\001857=0\00110=196\001",
+      true, &dataDictionary );
+
+  FIX::SenderCompID senderCompID;
+  FIX::TargetCompID targetCompID;
+  FIX::SendingTime sendingTime;
+  FIX::MsgSeqNum msgSeqNum;
+  FIX::HopCompID hopCompID;
+  FIX::HopSendingTime hopSendingTime;
+  FIX::HopRefID hopRefID;
+
+  CHECK_EQUAL( "SENDER", object.getHeader().get(senderCompID));
+  CHECK_EQUAL( "TARGET", object.getHeader().get(targetCompID));
+  CHECK_EQUAL( "20170317-15:55:23.685", object.getHeader().get(sendingTime).getString());
+  CHECK_EQUAL( 1, object.getHeader().get(msgSeqNum));
+
+  FIX44::Header::NoHops noHops;
+  object.getHeader().getGroup( 1, noHops );
+  CHECK_EQUAL( "HOP1", noHops.get(hopCompID) );
+  CHECK_EQUAL( "20170317-15:55:23.685", noHops.getField(hopSendingTime).getString() );
+  CHECK_EQUAL( 1, noHops.get(hopRefID) );
+
+  object.getHeader().getGroup( 2, noHops );
+  CHECK_EQUAL( "HOP2", noHops.get(hopCompID) );
+  CHECK_EQUAL( "20170317-15:55:23.685", noHops.getField(hopSendingTime).getString() );
+  CHECK_EQUAL( 2, noHops.get(hopRefID) );
+
+  FIX::AllocID allocID;
+  FIX::AllocTransType allocTransType;
+  FIX::AllocType allocType;
+  FIX::AllocNoOrdersType allocNoOrdersType;
+  FIX::Quantity quantity;
+  FIX::AvgPx avgPx;
+  FIX::TradeDate tradeDate;
+  CHECK_EQUAL( "Alloc001", object.get(allocID) );
+  CHECK_EQUAL( AllocTransType_NEW, object.get(allocTransType) );
+  CHECK_EQUAL( AllocType_CALCULATED, object.get(allocType) );
+  CHECK_EQUAL( AllocNoOrdersType_NOT_SPECIFIED, object.get(allocNoOrdersType) );
+  CHECK_EQUAL( 100, object.get(quantity) );
+  CHECK_EQUAL( 23.1, object.get(avgPx) );
+  CHECK_EQUAL( "20170317", object.get(tradeDate) );
+
+  FIX::CheckSum checkSum;
+  CHECK_EQUAL( 196, object.getTrailer().get(checkSum) );
 }
 
 }

--- a/src/C++/test/MessagesTestCase.cpp
+++ b/src/C++/test/MessagesTestCase.cpp
@@ -1249,7 +1249,7 @@ TEST(allocationInstructionParseGetString)
   CHECK_EQUAL(
           "8=FIX.4.4\0019=121\00135=J\00134=1\00149=SENDER\00156=TARGET\001627=2\001"
           "628=HOP1\001630=1\001628=HOP2\001630=2\0016=23.1\00153=100\00170=Alloc001\001"
-          "71=0\00175=20170317\001626=1\001857=0\00110=159\001", object.toString() );
+          "71=0\00175=20170317\001626=1\001857=0\00110=159\001", object.toString());
 }
 
 TEST(allocationInstructionString)


### PR DESCRIPTION
Fixes issue #134 

* Replaced component element with group element in header for FIX44.xml and FIXT11.xml
* Added member functions for add, remove and replace repeating group in header and trailer (already existed for body).
* Added unit test that serialize and deserialize message with hops repeating group set in header.

