### PR TITLE
Make Initiator::stop thread-safe

### DIFF
--- a/src/C++/Initiator.cpp
+++ b/src/C++/Initiator.cpp
@@ -231,7 +231,13 @@ void Initiator::stop( bool force )
 
   std::vector<Session*> enabledSessions;
 
-  SessionIDs connected = m_connected;
+  SessionIDs connected;
+
+  {
+    Locker l(m_mutex);
+    connected = m_connected;
+  }
+
   SessionIDs::iterator i = connected.begin();
   for ( ; i != connected.end(); ++i )
   {


### PR DESCRIPTION
Through a simple brute-force connect and disconnect test, I was able to cause a thread crash.

This is because m_connections can be modified by other threads while Initiator::stop is attempting to copy from it.

Making the copy take place with the mutex locked covers this hole.

There is at least one other issue with this function, however. There is a cancel that a client connection can be forcefully shut because there is nothing preventing _m_connections_ from changing once the entries are copied to _connected_. As such, a connection can be established, and not gracefully logged off before "the plug is pulled". The initiator should really have a "stopping" state that allows existing connections to be wound up, but no new ones from being created.