### PR TITLE
Allow unknown tag inside group without breaking group

### DIFF
--- a/src/C++/Message.h
+++ b/src/C++/Message.h
@@ -179,7 +179,8 @@ public:
 
   void setGroup( const std::string& msg, const FieldBase& field,
                  const std::string& string, std::string::size_type& pos,
-                 FieldMap& map, const DataDictionary& dataDictionary );
+                 FieldMap& map, const DataDictionary& dataDictionary,
+                 const field_type type );
 
   /**
    * Set a messages header from a string


### PR DESCRIPTION
If a FIX message is received with an unknown tag inside a repeating group it will break the group and it will only be possible to access fields in the first index of the group.

With this pull request unknown tags inside repeating groups in the body part of the message will not break the group. It will work similar to how unknown tags are treated outside repeating groups. 