### PR TITLE
Config option MicrosecondsInTimeStamp default false

### DIFF
--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -433,10 +433,10 @@ public:
 class UtcTimeStampField : public FieldBase
 {
 public:
-  explicit UtcTimeStampField( int field, const UtcTimeStamp& data, bool showMilliseconds = false )
-: FieldBase( field, UtcTimeStampConvertor::convert( data, showMilliseconds ) ) {}
-  UtcTimeStampField( int field, bool showMilliseconds = false )
-: FieldBase( field, UtcTimeStampConvertor::convert( UtcTimeStamp(), showMilliseconds ) ) {}
+  explicit UtcTimeStampField( int field, const UtcTimeStamp& data, bool showMilliseconds = false, bool showMicroseconds = false )
+: FieldBase( field, UtcTimeStampConvertor::convert( data, showMilliseconds, showMicroseconds ) ) {}
+  UtcTimeStampField( int field, bool showMilliseconds = false, bool showMicroseconds = false )
+: FieldBase( field, UtcTimeStampConvertor::convert( UtcTimeStamp(), showMilliseconds, showMicroseconds ) ) {}
 
   void setValue( const UtcTimeStamp& value )
     { setString( UtcTimeStampConvertor::convert( value ) ); }
@@ -487,10 +487,10 @@ public:
 class UtcTimeOnlyField : public FieldBase
 {
 public:
-  explicit UtcTimeOnlyField( int field, const UtcTimeOnly& data, bool showMilliseconds = false )
-: FieldBase( field, UtcTimeOnlyConvertor::convert( data, showMilliseconds ) ) {}
-  UtcTimeOnlyField( int field, bool showMilliseconds = false )
-: FieldBase( field, UtcTimeOnlyConvertor::convert( UtcTimeOnly(), showMilliseconds ) ) {}
+  explicit UtcTimeOnlyField( int field, const UtcTimeOnly& data, bool showMilliseconds = false, bool showMicroseconds = false )
+: FieldBase( field, UtcTimeOnlyConvertor::convert( data, showMilliseconds, showMicroseconds ) ) {}
+  UtcTimeOnlyField( int field, bool showMilliseconds = false, bool showMicroseconds = false )
+: FieldBase( field, UtcTimeOnlyConvertor::convert( UtcTimeOnly(), showMilliseconds, showMicroseconds ) ) {}
 
   void setValue( const UtcTimeOnly& value )
     { setString( UtcTimeOnlyConvertor::convert( value ) ); }

--- a/src/C++/FileLog.h
+++ b/src/C++/FileLog.h
@@ -80,9 +80,9 @@ public:
   void backup();
 
   void onIncoming( const std::string& value )
-  { m_messages << UtcTimeStampConvertor::convert(UtcTimeStamp(), m_millisecondsInTimeStamp) << " : " << value << std::endl; }
+  { m_messages << UtcTimeStampConvertor::convert(UtcTimeStamp(), m_millisecondsInTimeStamp, m_microsecondsInTimeStamp) << " : " << value << std::endl; }
   void onOutgoing( const std::string& value )
-  { m_messages << UtcTimeStampConvertor::convert(UtcTimeStamp(), m_millisecondsInTimeStamp) << " : " << value << std::endl; }
+  { m_messages << UtcTimeStampConvertor::convert(UtcTimeStamp(), m_millisecondsInTimeStamp, m_microsecondsInTimeStamp) << " : " << value << std::endl; }
   void onEvent( const std::string& value )
   {
     UtcTimeStamp now;
@@ -95,6 +95,11 @@ public:
   void setMillisecondsInTimeStamp ( bool value )
   { m_millisecondsInTimeStamp = value; }
 
+  bool getMicrosecondsInTimeStamp() const
+  { return m_microsecondsInTimeStamp; }
+  void setMicrosecondsInTimeStamp ( bool value )
+  { m_microsecondsInTimeStamp = value; }
+
 private:
   std::string generatePrefix( const SessionID& sessionID );
   void init( std::string path, std::string backupPath, const std::string& prefix );
@@ -106,6 +111,7 @@ private:
   std::string m_fullPrefix;
   std::string m_fullBackupPrefix;
   bool m_millisecondsInTimeStamp;
+  bool m_microsecondsInTimeStamp;
 };
 }
 

--- a/src/C++/HttpConnection.cpp
+++ b/src/C++/HttpConnection.cpp
@@ -511,6 +511,11 @@ void HttpConnection::processSession
       pSession->setMillisecondsInTimeStamp( copy.getParameter(MILLISECONDS_IN_TIMESTAMP) != "0" );
       copy.removeParameter(MILLISECONDS_IN_TIMESTAMP);
     }
+    if( copy.hasParameter(MICROSECONDS_IN_TIMESTAMP) )
+    {
+      pSession->setMicrosecondsInTimeStamp( copy.getParameter(MICROSECONDS_IN_TIMESTAMP) != "0" );
+      copy.removeParameter(MICROSECONDS_IN_TIMESTAMP);
+    }
     if( copy.hasParameter(PERSIST_MESSAGES) )
     {
       pSession->setPersistMessages( copy.getParameter(PERSIST_MESSAGES) != "0" );

--- a/src/C++/Log.h
+++ b/src/C++/Log.h
@@ -117,12 +117,12 @@ class ScreenLog : public Log
 public:
   ScreenLog( bool incoming, bool outgoing, bool event ) 
 : m_prefix( "GLOBAL" ),
-  m_incoming( incoming ), m_outgoing( outgoing ), m_event( event ), m_millisecondsInTimeStamp( true ) {}
+  m_incoming( incoming ), m_outgoing( outgoing ), m_event( event ), m_millisecondsInTimeStamp( true ), m_microsecondsInTimeStamp( false ) {}
 
   ScreenLog( const SessionID& sessionID,
              bool incoming, bool outgoing, bool event )
 : m_prefix( sessionID.toString() ),
-  m_incoming( incoming ), m_outgoing( outgoing ), m_event( event ), m_millisecondsInTimeStamp( true ) {}
+  m_incoming( incoming ), m_outgoing( outgoing ), m_event( event ), m_millisecondsInTimeStamp( true ), m_microsecondsInTimeStamp( false ) {}
 
   void clear() {}
   void backup() {}
@@ -132,7 +132,7 @@ public:
     if ( !m_incoming ) return ;
     Locker l( s_mutex );
     m_time.setCurrent();
-    std::cout << "<" << UtcTimeStampConvertor::convert(m_time, m_millisecondsInTimeStamp)
+    std::cout << "<" << UtcTimeStampConvertor::convert(m_time, m_millisecondsInTimeStamp, m_microsecondsInTimeStamp)
               << ", " << m_prefix
               << ", " << "incoming>" << std::endl
               << "  (" << value << ")" << std::endl;
@@ -143,7 +143,7 @@ public:
     if ( !m_outgoing ) return ;
     Locker l( s_mutex );
     m_time.setCurrent();
-    std::cout << "<" << UtcTimeStampConvertor::convert(m_time, m_millisecondsInTimeStamp)
+    std::cout << "<" << UtcTimeStampConvertor::convert(m_time, m_millisecondsInTimeStamp, m_microsecondsInTimeStamp)
               << ", " << m_prefix
               << ", " << "outgoing>" << std::endl
               << "  (" << value << ")" << std::endl;
@@ -154,7 +154,7 @@ public:
     if ( !m_event ) return ;
     Locker l( s_mutex );
     m_time.setCurrent();
-    std::cout << "<" << UtcTimeStampConvertor::convert(m_time, m_millisecondsInTimeStamp)
+    std::cout << "<" << UtcTimeStampConvertor::convert(m_time, m_millisecondsInTimeStamp, m_microsecondsInTimeStamp)
               << ", " << m_prefix
               << ", " << "event>" << std::endl
               << "  (" << value << ")" << std::endl;
@@ -165,6 +165,11 @@ public:
   void setMillisecondsInTimeStamp ( bool value )
   { m_millisecondsInTimeStamp = value; }
 
+  bool getMicrosecondsInTimeStamp() const
+  { return m_microsecondsInTimeStamp; }
+  void setMicrosecondsInTimeStamp ( bool value )
+  { m_microsecondsInTimeStamp = value; }
+
 private:
   std::string m_prefix;
   UtcTimeStamp m_time;
@@ -173,6 +178,7 @@ private:
   bool m_event;
   static Mutex s_mutex;
   bool m_millisecondsInTimeStamp;
+  bool m_microsecondsInTimeStamp;
 };
 }
 

--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -184,6 +184,11 @@ public:
   void setMillisecondsInTimeStamp ( bool value )
     { m_millisecondsInTimeStamp = value; }
 
+  bool getMicrosecondsInTimeStamp()
+    { return m_microsecondsInTimeStamp; }
+  void setMicrosecondsInTimeStamp ( bool value )
+    { m_microsecondsInTimeStamp = value; }
+
   bool getPersistMessages()
     { return m_persistMessages; }
   void setPersistMessages ( bool value )
@@ -314,6 +319,7 @@ private:
   bool m_resetOnDisconnect;
   bool m_refreshOnLogon;
   bool m_millisecondsInTimeStamp;
+  bool m_microsecondsInTimeStamp;
   bool m_persistMessages;
   bool m_validateLengthAndChecksum;
 

--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -190,6 +190,8 @@ Session* SessionFactory::create( const SessionID& sessionID,
     pSession->setRefreshOnLogon( settings.getBool( REFRESH_ON_LOGON ) );
   if ( settings.has( MILLISECONDS_IN_TIMESTAMP ) )
     pSession->setMillisecondsInTimeStamp( settings.getBool( MILLISECONDS_IN_TIMESTAMP ) );
+  if ( settings.has( MICROSECONDS_IN_TIMESTAMP ) )
+    pSession->setMicrosecondsInTimeStamp( settings.getBool( MICROSECONDS_IN_TIMESTAMP ) );
   if ( settings.has( PERSIST_MESSAGES ) )
     pSession->setPersistMessages( settings.getBool( PERSIST_MESSAGES ) );
   if ( settings.has( VALIDATE_LENGTH_AND_CHECKSUM ) )

--- a/src/C++/SessionSettings.h
+++ b/src/C++/SessionSettings.h
@@ -123,6 +123,7 @@ const char RESET_ON_LOGOUT[] = "ResetOnLogout";
 const char RESET_ON_DISCONNECT[] = "ResetOnDisconnect";
 const char REFRESH_ON_LOGON[] = "RefreshOnLogon";
 const char MILLISECONDS_IN_TIMESTAMP[] = "MillisecondsInTimeStamp";
+const char MICROSECONDS_IN_TIMESTAMP[] = "MicrosecondsInTimeStamp";
 const char HTTP_ACCEPT_PORT[] = "HttpAcceptPort";
 const char PERSIST_MESSAGES[] = "PersistMessages";
 


### PR DESCRIPTION
This is partly working some more work is needed create micro-second timestamps using gettimeofday but just want to be sure i am not duplicating work here if someone else is already working on this.

Can now read microsecond timestamps which was stopping me from getting a logon response for some gateways.

```
from-gateway: {
    "BeginString": "FIX.4.2",
    "BodyLength": "74",
    "CheckSum": "172",
    "EncryptMethod": "NONE",
    "HeartBtInt": "30",
    "MsgSeqNum": "1",
    "MsgType": "LOGON",
    "ResetSeqNumFlag": "YES",
    "SenderCompID": "LLVE_1",
    "SendingTime": "20171019-13:01:49.288155",
    "TargetCompID": "FIX2"
}
```