### PR TITLE
Minor compile tweaks to support gcc 3.4.6

### DIFF
--- a/UnitTest++/Makefile
+++ b/UnitTest++/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS ?= -g -Wall -W -Winline -Wno-unused-private-field -Wno-overloaded-virtual -ansi 
+CXXFLAGS ?= -g -Wall -W -Winline -Wno-overloaded-virtual -ansi 
 LDFLAGS ?= 
 SED = sed
 MV = mv

--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,8 @@ fi
 
 CFLAGS="$CFLAGS $SHAREDFLAGS"
 AC_SUBST(CFLAGS)
-CXXFLAGS="$CXXFLAGS $SHAREDFLAGS -std=c++0x"
+CXXFLAGS="$CXXFLAGS $SHAREDFLAGS"
+AX_CHECK_COMPILE_FLAG([-std=c++0x], [CXXFLAGS="$CXXFLAGS $SHAREDFLAGS -std=c++0x"])
 AC_SUBST(CXXFLAGS)
 
 
@@ -187,12 +188,6 @@ else AC_MSG_RESULT(no)
     AC_MSG_ERROR(unable to find set_terminate in std or global namespace))
 fi
 
-AC_MSG_CHECKING(for typeinfo in the global namespace)
-AC_TRY_COMPILE(
-	[#include <typeinfo>],
-	[const typeinfo& ty = typeid(typeinfo);],
-	typeinfo_is_global=true, typeinfo_is_global=false)
-
 AC_MSG_CHECKING(for std::tr1::shared_ptr)
 AC_TRY_COMPILE(
 	[#include <tr1/memory>],
@@ -210,6 +205,21 @@ AC_TRY_COMPILE(
 	AC_DEFINE(HAVE_STD_SHARED_PTR, 1,
 	The system supports std::shared_ptr),
 	AC_MSG_RESULT(no))
+
+AC_MSG_CHECKING(for boost::shared_ptr)
+AC_TRY_COMPILE(
+        [#include <boost/shared_ptr.hpp>],
+        [boost::shared_ptr<int> ptr;],
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_BOOST_SHARED_PTR, 1,
+        The system supports boost::shared_ptr),
+        AC_MSG_RESULT(no))
+
+AC_MSG_CHECKING(for typeinfo in the global namespace)
+AC_TRY_COMPILE(
+	[#include <typeinfo>],
+	[const typeinfo& ty = typeid(typeinfo);],
+	typeinfo_is_global=true, typeinfo_is_global=false)
 
 if test $typeinfo_is_global = true
 then AC_MSG_RESULT(yes)

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,72 @@
+# ===========================================================================
+#   http://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler or
+#   gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION.
+#   Please keep this macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 1
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.59)dnl for _AC_LANG_PREFIX
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_IF([test x"AS_VAR_GET(CACHEVAR)" = xyes],
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -474,7 +474,7 @@ int DataDictionary::addXMLComponentFields( DOMDocument* pDoc, DOMNode* pNode,
   DOMNodePtr pComponentNode =
     pDoc->getNode("/fix/components/component[@name='" + name + "']");
   if(pComponentNode.get() == 0)
-    throw ConfigError("Component not found");
+    throw ConfigError("Component not found: " + name);
 
   DOMNodePtr pComponentFieldNode = pComponentNode->getFirstChildNode();
   while(pComponentFieldNode.get())

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -103,6 +103,9 @@ typedef int ssize_t;
 #elif defined(HAVE_STD_TR1_SHARED_PTR)
   #include <tr1/memory>
   namespace ptr = std::tr1;
+#elif defined(HAVE_BOOST_SHARED_PTR)
+  #include <boost/shared_ptr.hpp>
+  namespace ptr = boost;
 #else
   namespace ptr = std;
 #endif

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -615,7 +615,7 @@ TEST_FIXTURE(acceptorFixture, callDisconnect)
 TEST_FIXTURE(sessionFixture, doesSessionExist)
 {
   DataDictionaryProvider provider;
-  provider.addTransportDataDictionary( BeginString("FIX.4.2"), std::shared_ptr<DataDictionary>(new DataDictionary()) );
+  provider.addTransportDataDictionary( BeginString("FIX.4.2"), ptr::shared_ptr<DataDictionary>(new DataDictionary()) );
 
   Session * pSession1 = new Session
     ( *this, factory, SessionID( BeginString( "FIX.4.2" ),
@@ -686,7 +686,7 @@ TEST_FIXTURE(sessionFixture, doesSessionExist)
 TEST_FIXTURE(sessionFixture, lookupSession)
 {
   DataDictionaryProvider provider;
-  provider.addTransportDataDictionary( BeginString("FIX.4.2"), std::shared_ptr<DataDictionary>(new DataDictionary()) );
+  provider.addTransportDataDictionary( BeginString("FIX.4.2"), ptr::shared_ptr<DataDictionary>(new DataDictionary()) );
 
   Session* pSession1 = new Session
     ( *this, factory, SessionID( BeginString( "FIX.4.2" ),
@@ -741,7 +741,7 @@ TEST_FIXTURE(sessionFixture, lookupSession)
 TEST_FIXTURE(sessionFixture, registerSession)
 {
   DataDictionaryProvider provider;
-  provider.addTransportDataDictionary( BeginString("FIX.4.2"), std::shared_ptr<DataDictionary>(new DataDictionary()) );
+  provider.addTransportDataDictionary( BeginString("FIX.4.2"), ptr::shared_ptr<DataDictionary>(new DataDictionary()) );
 
   Session* pSession = new Session
     ( *this, factory, SessionID( BeginString( "FIX.4.2" ),

--- a/src/at.cpp
+++ b/src/at.cpp
@@ -17,6 +17,12 @@
 **
 ****************************************************************************/
 
+#ifdef _MSC_VER
+#pragma warning( disable : 4503 )
+#else
+#include "config.h"
+#endif
+
 #include "ThreadedSocketAcceptor.h"
 #include "SocketAcceptor.h"
 #include "SessionSettings.h"
@@ -27,10 +33,6 @@
 #include <memory>
 #include "getopt-repl.h"
 #include "at_application.h"
-
-#ifdef _MSC_VER
-#pragma warning( disable : 4503 )
-#endif
 
 typedef std::auto_ptr < FIX::Acceptor > AcceptorPtr;
 


### PR DESCRIPTION
 - Change old reference of std::shared_ptr to ptr::shared_ptr
 - Check compile option "-std=c++0x", and only use if supported.
 - Use boost::shared_ptr if std, or std::tr1

