### PR TITLE
Add AllowUnknowMsgFields options to c++ library

### DIFF
--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -40,13 +40,13 @@ namespace FIX
 {
 DataDictionary::DataDictionary()
 : m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
-  m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true )
+  m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false )
 {}
 
 DataDictionary::DataDictionary( std::istream& stream )
 throw( ConfigError )
 : m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
-  m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true )
+  m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false )
 {
   readFromStream( stream );
 }
@@ -54,7 +54,7 @@ throw( ConfigError )
 DataDictionary::DataDictionary( const std::string& url )
 throw( ConfigError )
 : m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
-  m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ),
+  m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ),
   m_orderedFieldsArray(0)
 {
   readFromURL( url );
@@ -84,6 +84,7 @@ DataDictionary& DataDictionary::operator=( const DataDictionary& rhs )
   m_checkFieldsOutOfOrder = rhs.m_checkFieldsOutOfOrder;
   m_checkFieldsHaveValues = rhs.m_checkFieldsHaveValues;
   m_checkUserDefinedFields = rhs.m_checkUserDefinedFields;
+  m_allowUnknownMessageFields = rhs.m_allowUnknownMessageFields;
   m_beginString = rhs.m_beginString;
   m_messageFields = rhs.m_messageFields;
   m_requiredFields = rhs.m_requiredFields;

--- a/src/C++/DataDictionary.h
+++ b/src/C++/DataDictionary.h
@@ -303,6 +303,8 @@ public:
   { m_checkFieldsHaveValues = value; }
   void checkUserDefinedFields( bool value )
   { m_checkUserDefinedFields = value; }
+  void allowUnknownMsgFields( bool value )
+  { m_allowUnknownMessageFields = value; }
 
   /// Validate a message.
   static void validate( const Message& message,
@@ -330,7 +332,9 @@ private:
   /// If we need to check for the tag in the dictionary
   bool shouldCheckTag( const FieldBase& field ) const
   {
-    if( !m_checkUserDefinedFields && field.getTag() >= FIELD::UserMin )
+    if( m_allowUnknownMessageFields && field.getTag() < FIELD::UserMin )
+      return false;
+    else if( !m_checkUserDefinedFields && field.getTag() >= FIELD::UserMin )
       return false;
     else
       return true;
@@ -517,6 +521,7 @@ private:
   bool m_checkFieldsOutOfOrder;
   bool m_checkFieldsHaveValues;
   bool m_checkUserDefinedFields;
+  bool m_allowUnknownMessageFields;
   BeginString m_beginString;
   MsgTypeToField m_messageFields;
   MsgTypeToField m_requiredFields;

--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -228,6 +228,8 @@ ptr::shared_ptr<DataDictionary> SessionFactory::createDataDictionary(const Sessi
     pCopyOfDD->checkFieldsHaveValues( settings.getBool( VALIDATE_FIELDS_HAVE_VALUES ) );
   if( settings.has( VALIDATE_USER_DEFINED_FIELDS ) )
     pCopyOfDD->checkUserDefinedFields( settings.getBool( VALIDATE_USER_DEFINED_FIELDS ) );
+  if( settings.has( ALLOW_UNKNOWN_MSG_FIELDS ) )
+    pCopyOfDD->allowUnknownMsgFields( settings.getBool( ALLOW_UNKNOWN_MSG_FIELDS ) );
 
   return pCopyOfDD;
 }

--- a/src/C++/SessionSettings.h
+++ b/src/C++/SessionSettings.h
@@ -71,6 +71,7 @@ const char VALIDATE_LENGTH_AND_CHECKSUM[] = "ValidateLengthAndChecksum";
 const char VALIDATE_FIELDS_OUT_OF_ORDER[] = "ValidateFieldsOutOfOrder";
 const char VALIDATE_FIELDS_HAVE_VALUES[] = "ValidateFieldsHaveValues";
 const char VALIDATE_USER_DEFINED_FIELDS[] = "ValidateUserDefinedFields";
+const char ALLOW_UNKNOWN_MSG_FIELDS[] = "AllowUnknownMsgFields";
 const char LOGON_TIMEOUT[] = "LogonTimeout";
 const char LOGOUT_TIMEOUT[] = "LogoutTimeout";
 const char FILE_STORE_PATH[] = "FileStorePath";

--- a/src/C++/test/DataDictionaryTestCase.cpp
+++ b/src/C++/test/DataDictionaryTestCase.cpp
@@ -233,6 +233,10 @@ TEST_FIXTURE(checkValidTagNumberFixture, checkValidTagNumber)
   message.setField( TooHigh( "value" ) );
   CHECK_THROW( object.validate( message ), InvalidTagNumber );
 
+  object.allowUnknownMsgFields( true );
+  object.validate( message );
+  object.allowUnknownMsgFields( false );
+
   object.addField( 501 );
   object.addMsgField( MsgType_TestRequest, 501 );
   object.validate( message );


### PR DESCRIPTION
Add option for AllowUnknownMsgFields supported in QuickFix Java. 
Updated DataDictionary member function "shouldCheckTag" to return false for all Fields < Fields::UserMin when the option is set