### PR TITLE
Added vs17 files and fixed building issue

### DIFF
--- a/UnitTest++/UnitTest++_vs17.vcxproj
+++ b/UnitTest++/UnitTest++_vs17.vcxproj
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}</ProjectGuid>
+    <RootNamespace>UnitTest</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectName>UnitTest++_vs17</ProjectName>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>false</WholeProgramOptimization>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)lib\debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">obj\$(ProjectName)\$(Configuration)\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)lib\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">obj\$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MinimalRebuild>true</MinimalRebuild>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <Optimization>MinSpace</Optimization>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;_CRT_SECURE_NO_DEPRECATE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ExceptionHandling>Async</ExceptionHandling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="src\Win32\TimeHelpers.cpp" />
+    <ClCompile Include="src\AssertException.cpp" />
+    <ClCompile Include="src\Checks.cpp" />
+    <ClCompile Include="src\CurrentTest.cpp" />
+    <ClCompile Include="src\DeferredTestReporter.cpp" />
+    <ClCompile Include="src\DeferredTestResult.cpp" />
+    <ClCompile Include="src\MemoryOutStream.cpp" />
+    <ClCompile Include="src\ReportAssert.cpp" />
+    <ClCompile Include="src\Test.cpp" />
+    <ClCompile Include="src\TestDetails.cpp" />
+    <ClCompile Include="src\TestList.cpp" />
+    <ClCompile Include="src\TestReporter.cpp" />
+    <ClCompile Include="src\TestReporterStdout.cpp" />
+    <ClCompile Include="src\TestResults.cpp" />
+    <ClCompile Include="src\TestRunner.cpp" />
+    <ClCompile Include="src\TimeConstraint.cpp" />
+    <ClCompile Include="src\XmlTestReporter.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\Win32\TimeHelpers.h" />
+    <ClInclude Include="src\AssertException.h" />
+    <ClInclude Include="src\CheckMacros.h" />
+    <ClInclude Include="src\Checks.h" />
+    <ClInclude Include="src\Config.h" />
+    <ClInclude Include="src\CurrentTest.h" />
+    <ClInclude Include="src\DeferredTestReporter.h" />
+    <ClInclude Include="src\DeferredTestResult.h" />
+    <ClInclude Include="src\ExecuteTest.h" />
+    <ClInclude Include="src\MemoryOutStream.h" />
+    <ClInclude Include="src\ReportAssert.h" />
+    <ClInclude Include="src\Test.h" />
+    <ClInclude Include="src\TestDetails.h" />
+    <ClInclude Include="src\TestList.h" />
+    <ClInclude Include="src\TestMacros.h" />
+    <ClInclude Include="src\TestReporter.h" />
+    <ClInclude Include="src\TestReporterStdout.h" />
+    <ClInclude Include="src\TestResults.h" />
+    <ClInclude Include="src\TestRunner.h" />
+    <ClInclude Include="src\TestSuite.h" />
+    <ClInclude Include="src\TimeConstraint.h" />
+    <ClInclude Include="src\TimeHelpers.h" />
+    <ClInclude Include="src\UnitTest++.h" />
+    <ClInclude Include="src\XmlTestReporter.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/build_vs17.bat
+++ b/build_vs17.bat
@@ -1,0 +1,13 @@
+echo off
+
+set TARGET=%1
+set CONFIGURATION=%2
+set NET_VERSION=%3
+
+if "%1" == "" set TARGET=Build
+if "%2" == "" set CONFIGURATION=Release
+if "%3" == "" set NET_VERSION=v4.5
+
+set BUILD_CMD=MSBuild.exe quickfix_vs17.sln /t:%TARGET% /p:Configuration=%CONFIGURATION%;TargetFrameworkVersion=%NET_VERSION%
+echo Build command: %BUILD_CMD%
+%BUILD_CMD%

--- a/examples/executor/C++/example_executor_cpp_vs17.vcxproj
+++ b/examples/executor/C++/example_executor_cpp_vs17.vcxproj
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>example_executor_cpp</ProjectName>
+    <ProjectGuid>{AC97D259-3231-4575-8CA5-BF9EF79B5A87}</ProjectGuid>
+    <RootNamespace>example_executor_cpp</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)bin\debug\executor_cpp\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)bin\release\executor_cpp\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">executor_cpp</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">executor_cpp</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/executor_cpp.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Debug/executor_cpp.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/executor_cpp_debug.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/executor_cpp.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Release/executor_cpp.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/executor_cpp.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Application.cpp" />
+    <ClCompile Include="executor.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Application.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\C++\quickfix_vs17.vcxproj">
+      <Project>{d5d558ea-bbac-4862-a946-d3881bace3b7}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/examples/ordermatch/example_ordermatch_vs17.vcxproj
+++ b/examples/ordermatch/example_ordermatch_vs17.vcxproj
@@ -1,0 +1,148 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>example_ordermatch</ProjectName>
+    <ProjectGuid>{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}</ProjectGuid>
+    <RootNamespace>example_ordermatch</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)bin\release\ordermatch\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)bin\debug\ordermatch\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ordermatch</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ordermatch</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/ordermatch.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Release/ordermatch.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/ordermatch.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/ordermatch.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Debug/ordermatch.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/ordermatch_debug.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Application.cpp" />
+    <ClCompile Include="Market.cpp" />
+    <ClCompile Include="ordermatch.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Application.h" />
+    <ClInclude Include="IDGenerator.h" />
+    <ClInclude Include="Market.h" />
+    <ClInclude Include="Order.h" />
+    <ClInclude Include="OrderMatcher.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\C++\quickfix_vs17.vcxproj">
+      <Project>{d5d558ea-bbac-4862-a946-d3881bace3b7}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/examples/tradeclient/example_tradeclient_vs17.vcxproj
+++ b/examples/tradeclient/example_tradeclient_vs17.vcxproj
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>example_tradeclient</ProjectName>
+    <ProjectGuid>{760375AB-01FD-4E38-A778-FAA2A27F8C41}</ProjectGuid>
+    <RootNamespace>example_tradeclient</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)bin\release\tradeclient\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)bin\debug\tradeclient\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">tradeclient</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">tradeclient</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/tradeclient.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Release/tradeclient.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/tradeclient.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/tradeclient.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Debug/tradeclient.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/tradeclient_debug.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="Application.cpp" />
+    <ClCompile Include="tradeclient.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Application.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\C++\quickfix_vs17.vcxproj">
+      <Project>{d5d558ea-bbac-4862-a946-d3881bace3b7}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/examples/tradeclientgui/banzai/build.bat
+++ b/examples/tradeclientgui/banzai/build.bat
@@ -2,7 +2,7 @@
 
 REM set up classpath
 set JAR=../../../lib/jar
-set CLASSPATH=%JAR%/ant.jar;%JAR%/optional.jar;%JAR%/lib/junit.jar;%JAR%/lib/crimson.jar;%JAVA_HOME%/lib/tools.jar
+set CLASSPATH=%JAR%/ant.jar;%JAR%/optional/;%JAR%/junit.jar;%JAR%/crimson.jar;%JAVA_HOME%/lib/tools.jar
 
 REM call ant
 java org.apache.tools.ant.Main %*

--- a/examples/tradeclientgui/banzai/src/Banzai.java
+++ b/examples/tradeclientgui/banzai/src/Banzai.java
@@ -54,7 +54,11 @@ public class Banzai {
         BanzaiApplication application =
             new BanzaiApplication(orderTableModel, executionTableModel);
         SessionSettings settings =
-            new SessionSettings(new FileInputStream("cfg/banzai.cfg"));
+            new SessionSettings(new FileInputStream(
+				System.getProperty("os.name").toLowerCase().indexOf("win") >= 0 ?
+					"../../../bin/cfg/banzai.cfg" :
+					"cfg/banzai.cfg"
+					));
         MessageStoreFactory messageStoreFactory =
             new FileStoreFactory(settings);
         LogFactory logFactory =

--- a/examples/tradeclientgui/banzai/test.bat
+++ b/examples/tradeclientgui/banzai/test.bat
@@ -1,6 +1,6 @@
-SET LIB_PATH=..\..\..\lib
+SET LIB_PATH=..\..\..\lib\jar
 
 del /s/q logs
 
-java -Djava.library.path=%LIB_PATH% -classpath %LIB_PATH%\junit.jar;%LIB_PATH%\log4j.jar;%LIB_PATH%\quickfix.jar;.\build;. junit.textui.TestRunner %1
+java -Djava.library.path=%LIB_PATH% -classpath %LIB_PATH%\junit.jar;%LIB_PATH%\log4j.jar;%LIB_PATH%\quickfixj-all-1.4.0.jar;%LIB_PATH%\slf4j-api-1.5.3.jar;%LIB_PATH%\slf4j-jdk14-1.5.3.jar;%LIB_PATH%\mina-core-1.0.3.jar;%LIB_PATH%\backport-util-concurrent-3.0.jar;.\build;. junit.textui.TestRunner %1
 

--- a/examples/tradeclientgui/banzai/test/BanzaiTest.java
+++ b/examples/tradeclientgui/banzai/test/BanzaiTest.java
@@ -56,7 +56,11 @@ public class BanzaiTest extends TestCase {
 
         server = Runtime.getRuntime().exec
 
-            ("..\\..\\..\\bin\\ordermatch_debug -f cfg\\ordermatch.cfg", null);
+            (
+			System.getProperty("os.name").toLowerCase().indexOf("win") >= 0 ?
+					"..\\..\\..\\bin\\debug\\ordermatch\\ordermatch.exe -f ..\\..\\..\\bin\\cfg\\ordermatch.cfg" :
+					"..\\..\\..\\bin\\ordermatch_debug -f cfg\\ordermatch.cfg"
+			, null);
 
         banzai = new Banzai();
 

--- a/quickfix_vs17.sln
+++ b/quickfix_vs17.sln
@@ -1,0 +1,133 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Express 2013 for Windows Desktop
+VisualStudioVersion = 12.0.21005.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example_executor_cpp", "examples\executor\C++\example_executor_cpp_vs17.vcxproj", "{AC97D259-3231-4575-8CA5-BF9EF79B5A87}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example_ordermatch", "examples\ordermatch\example_ordermatch_vs17.vcxproj", "{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "example_tradeclient", "examples\tradeclient\example_tradeclient_vs17.vcxproj", "{760375AB-01FD-4E38-A778-FAA2A27F8C41}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "quickfix", "src\C++\quickfix_vs17.vcxproj", "{D5D558EA-BBAC-4862-A946-D3881BACE3B7}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_acceptance", "src\test_acceptance_vs17.vcxproj", "{63CC102A-A3CD-43CC-9535-A91E67256360}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_performance", "src\test_performance_vs17.vcxproj", "{4E6CE474-47A1-4AC8-8161-9CD214664EBB}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_unit", "src\test_unit_vs17.vcxproj", "{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6} = {64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_acceptance_runner", "test\atrun\test_acceptance_runner_vs17.vcxproj", "{A58C8BD5-3602-4886-80A0-CD4FFED42144}"
+	ProjectSection(ProjectDependencies) = postProject
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6} = {64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnitTest++_vs17", "UnitTest++\UnitTest++_vs17.vcxproj", "{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|Mixed Platforms = Debug|Mixed Platforms
+		Debug|Win32 = Debug|Win32
+		Release|Any CPU = Release|Any CPU
+		Release|Mixed Platforms = Release|Mixed Platforms
+		Release|Win32 = Release|Win32
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Debug|Win32.ActiveCfg = Debug|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Debug|Win32.Build.0 = Debug|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Release|Any CPU.ActiveCfg = Release|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Release|Win32.ActiveCfg = Release|Win32
+		{AC97D259-3231-4575-8CA5-BF9EF79B5A87}.Release|Win32.Build.0 = Release|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Debug|Win32.ActiveCfg = Debug|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Debug|Win32.Build.0 = Debug|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Release|Any CPU.ActiveCfg = Release|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Release|Win32.ActiveCfg = Release|Win32
+		{CBFECC67-2F3D-49F9-8450-BF47FBB766DF}.Release|Win32.Build.0 = Release|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Debug|Win32.ActiveCfg = Debug|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Debug|Win32.Build.0 = Debug|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Release|Any CPU.ActiveCfg = Release|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Release|Win32.ActiveCfg = Release|Win32
+		{760375AB-01FD-4E38-A778-FAA2A27F8C41}.Release|Win32.Build.0 = Release|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Debug|Win32.ActiveCfg = Debug|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Debug|Win32.Build.0 = Debug|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Release|Any CPU.ActiveCfg = Release|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Release|Win32.ActiveCfg = Release|Win32
+		{D5D558EA-BBAC-4862-A946-D3881BACE3B7}.Release|Win32.Build.0 = Release|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Debug|Win32.ActiveCfg = Debug|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Debug|Win32.Build.0 = Debug|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Release|Any CPU.ActiveCfg = Release|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Release|Win32.ActiveCfg = Release|Win32
+		{63CC102A-A3CD-43CC-9535-A91E67256360}.Release|Win32.Build.0 = Release|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Debug|Win32.ActiveCfg = Debug|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Debug|Win32.Build.0 = Debug|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Release|Any CPU.ActiveCfg = Release|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Release|Win32.ActiveCfg = Release|Win32
+		{4E6CE474-47A1-4AC8-8161-9CD214664EBB}.Release|Win32.Build.0 = Release|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Debug|Win32.ActiveCfg = Debug|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Debug|Win32.Build.0 = Debug|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Release|Any CPU.ActiveCfg = Release|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Release|Win32.ActiveCfg = Release|Win32
+		{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}.Release|Win32.Build.0 = Release|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Debug|Win32.ActiveCfg = Debug|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Debug|Win32.Build.0 = Debug|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Release|Any CPU.ActiveCfg = Release|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Release|Win32.ActiveCfg = Release|Win32
+		{A58C8BD5-3602-4886-80A0-CD4FFED42144}.Release|Win32.Build.0 = Release|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Debug|Any CPU.ActiveCfg = Debug|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Debug|Mixed Platforms.ActiveCfg = Debug|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Debug|Mixed Platforms.Build.0 = Debug|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Debug|Win32.ActiveCfg = Debug|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Debug|Win32.Build.0 = Debug|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Release|Any CPU.ActiveCfg = Release|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Release|Mixed Platforms.ActiveCfg = Release|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Release|Mixed Platforms.Build.0 = Release|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Release|Win32.ActiveCfg = Release|Win32
+		{64A4FEFE-0461-4E95-8CC1-91EF5F57DBC6}.Release|Win32.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/C++/quickfix_vs15.vcxproj
+++ b/src/C++/quickfix_vs15.vcxproj
@@ -675,6 +675,7 @@
     <ClCompile Include="DataDictionary.cpp" />
     <ClCompile Include="DataDictionaryProvider.cpp" />
     <ClCompile Include="Dictionary.cpp" />
+    <ClCompile Include="FieldConvertors.cpp" />
     <ClCompile Include="FieldMap.cpp" />
     <ClCompile Include="FieldTypes.cpp" />
     <ClCompile Include="FileLog.cpp" />

--- a/src/C++/quickfix_vs17.vcxproj
+++ b/src/C++/quickfix_vs17.vcxproj
@@ -1,0 +1,841 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\config_windows.h" />
+    <ClInclude Include="..\stdafx.h" />
+    <ClInclude Include="Acceptor.h" />
+    <ClInclude Include="Application.h" />
+    <ClInclude Include="AtomicCount.h" />
+    <ClInclude Include="DatabaseConnectionID.h" />
+    <ClInclude Include="DatabaseConnectionPool.h" />
+    <ClInclude Include="DataDictionary.h" />
+    <ClInclude Include="DataDictionaryProvider.h" />
+    <ClInclude Include="Dictionary.h" />
+    <ClInclude Include="DOMDocument.h" />
+    <ClInclude Include="Event.h" />
+    <ClInclude Include="Exceptions.h" />
+    <ClInclude Include="Field.h" />
+    <ClInclude Include="FieldConvertors.h" />
+    <ClInclude Include="FieldMap.h" />
+    <ClInclude Include="FieldNumbers.h" />
+    <ClInclude Include="Fields.h" />
+    <ClInclude Include="FieldTypes.h" />
+    <ClInclude Include="FileLog.h" />
+    <ClInclude Include="FileStore.h" />
+    <ClInclude Include="fix40\Advertisement.h" />
+    <ClInclude Include="fix40\Allocation.h" />
+    <ClInclude Include="fix40\DontKnowTrade.h" />
+    <ClInclude Include="fix40\Email.h" />
+    <ClInclude Include="fix40\ExecutionReport.h" />
+    <ClInclude Include="fix40\Heartbeat.h" />
+    <ClInclude Include="fix40\ListCancelRequest.h" />
+    <ClInclude Include="fix40\ListExecute.h" />
+    <ClInclude Include="fix40\ListStatus.h" />
+    <ClInclude Include="fix40\ListStatusRequest.h" />
+    <ClInclude Include="fix40\Logon.h" />
+    <ClInclude Include="fix40\Logout.h" />
+    <ClInclude Include="fix40\Message.h" />
+    <ClInclude Include="fix40\MessageCracker.h" />
+    <ClInclude Include="fix40\NewOrderList.h" />
+    <ClInclude Include="fix40\NewOrderSingle.h" />
+    <ClInclude Include="fix40\News.h" />
+    <ClInclude Include="fix40\OrderCancelReject.h" />
+    <ClInclude Include="fix40\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix40\OrderCancelRequest.h" />
+    <ClInclude Include="fix40\OrderStatusRequest.h" />
+    <ClInclude Include="fix40\Quote.h" />
+    <ClInclude Include="fix40\QuoteRequest.h" />
+    <ClInclude Include="fix40\Reject.h" />
+    <ClInclude Include="fix40\ResendRequest.h" />
+    <ClInclude Include="fix40\SequenceReset.h" />
+    <ClInclude Include="fix40\TestRequest.h" />
+    <ClInclude Include="fix41\Advertisement.h" />
+    <ClInclude Include="fix41\Allocation.h" />
+    <ClInclude Include="fix41\DontKnowTrade.h" />
+    <ClInclude Include="fix41\Email.h" />
+    <ClInclude Include="fix41\ExecutionReport.h" />
+    <ClInclude Include="fix41\Heartbeat.h" />
+    <ClInclude Include="fix41\ListCancelRequest.h" />
+    <ClInclude Include="fix41\ListExecute.h" />
+    <ClInclude Include="fix41\ListStatus.h" />
+    <ClInclude Include="fix41\ListStatusRequest.h" />
+    <ClInclude Include="fix41\Logon.h" />
+    <ClInclude Include="fix41\Logout.h" />
+    <ClInclude Include="fix41\Message.h" />
+    <ClInclude Include="fix41\MessageCracker.h" />
+    <ClInclude Include="fix41\NewOrderList.h" />
+    <ClInclude Include="fix41\NewOrderSingle.h" />
+    <ClInclude Include="fix41\News.h" />
+    <ClInclude Include="fix41\OrderCancelReject.h" />
+    <ClInclude Include="fix41\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix41\OrderCancelRequest.h" />
+    <ClInclude Include="fix41\OrderStatusRequest.h" />
+    <ClInclude Include="fix41\Quote.h" />
+    <ClInclude Include="fix41\QuoteRequest.h" />
+    <ClInclude Include="fix41\Reject.h" />
+    <ClInclude Include="fix41\ResendRequest.h" />
+    <ClInclude Include="fix41\SequenceReset.h" />
+    <ClInclude Include="fix41\SettlementInstructions.h" />
+    <ClInclude Include="fix41\TestRequest.h" />
+    <ClInclude Include="fix42\Advertisement.h" />
+    <ClInclude Include="fix42\Allocation.h" />
+    <ClInclude Include="fix42\BidRequest.h" />
+    <ClInclude Include="fix42\BidResponse.h" />
+    <ClInclude Include="fix42\BusinessMessageReject.h" />
+    <ClInclude Include="fix42\DontKnowTrade.h" />
+    <ClInclude Include="fix42\Email.h" />
+    <ClInclude Include="fix42\ExecutionReport.h" />
+    <ClInclude Include="fix42\Heartbeat.h" />
+    <ClInclude Include="fix42\ListCancelRequest.h" />
+    <ClInclude Include="fix42\ListExecute.h" />
+    <ClInclude Include="fix42\ListStatus.h" />
+    <ClInclude Include="fix42\ListStatusRequest.h" />
+    <ClInclude Include="fix42\ListStrikePrice.h" />
+    <ClInclude Include="fix42\Logon.h" />
+    <ClInclude Include="fix42\Logout.h" />
+    <ClInclude Include="fix42\MarketDataIncrementalRefresh.h" />
+    <ClInclude Include="fix42\MarketDataRequest.h" />
+    <ClInclude Include="fix42\MarketDataRequestReject.h" />
+    <ClInclude Include="fix42\MarketDataSnapshotFullRefresh.h" />
+    <ClInclude Include="fix42\MassQuote.h" />
+    <ClInclude Include="fix42\Message.h" />
+    <ClInclude Include="fix42\MessageCracker.h" />
+    <ClInclude Include="fix42\NewOrderList.h" />
+    <ClInclude Include="fix42\NewOrderSingle.h" />
+    <ClInclude Include="fix42\News.h" />
+    <ClInclude Include="fix42\OrderCancelReject.h" />
+    <ClInclude Include="fix42\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix42\OrderCancelRequest.h" />
+    <ClInclude Include="fix42\OrderStatusRequest.h" />
+    <ClInclude Include="fix42\Quote.h" />
+    <ClInclude Include="fix42\QuoteAcknowledgement.h" />
+    <ClInclude Include="fix42\QuoteCancel.h" />
+    <ClInclude Include="fix42\QuoteRequest.h" />
+    <ClInclude Include="fix42\QuoteStatusRequest.h" />
+    <ClInclude Include="fix42\Reject.h" />
+    <ClInclude Include="fix42\ResendRequest.h" />
+    <ClInclude Include="fix42\SecurityDefinition.h" />
+    <ClInclude Include="fix42\SecurityDefinitionRequest.h" />
+    <ClInclude Include="fix42\SecurityStatus.h" />
+    <ClInclude Include="fix42\SecurityStatusRequest.h" />
+    <ClInclude Include="fix42\SequenceReset.h" />
+    <ClInclude Include="fix42\SettlementInstructions.h" />
+    <ClInclude Include="fix42\TestRequest.h" />
+    <ClInclude Include="fix42\TradingSessionStatus.h" />
+    <ClInclude Include="fix42\TradingSessionStatusRequest.h" />
+    <ClInclude Include="fix43\Advertisement.h" />
+    <ClInclude Include="fix43\Allocation.h" />
+    <ClInclude Include="fix43\AllocationAck.h" />
+    <ClInclude Include="fix43\BidRequest.h" />
+    <ClInclude Include="fix43\BidResponse.h" />
+    <ClInclude Include="fix43\BusinessMessageReject.h" />
+    <ClInclude Include="fix43\CrossOrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix43\CrossOrderCancelRequest.h" />
+    <ClInclude Include="fix43\DerivativeSecurityList.h" />
+    <ClInclude Include="fix43\DerivativeSecurityListRequest.h" />
+    <ClInclude Include="fix43\DontKnowTrade.h" />
+    <ClInclude Include="fix43\Email.h" />
+    <ClInclude Include="fix43\ExecutionReport.h" />
+    <ClInclude Include="fix43\Heartbeat.h" />
+    <ClInclude Include="fix43\IOI.h" />
+    <ClInclude Include="fix43\ListCancelRequest.h" />
+    <ClInclude Include="fix43\ListExecute.h" />
+    <ClInclude Include="fix43\ListStatus.h" />
+    <ClInclude Include="fix43\ListStatusRequest.h" />
+    <ClInclude Include="fix43\ListStrikePrice.h" />
+    <ClInclude Include="fix43\Logon.h" />
+    <ClInclude Include="fix43\Logout.h" />
+    <ClInclude Include="fix43\MarketDataIncrementalRefresh.h" />
+    <ClInclude Include="fix43\MarketDataRequest.h" />
+    <ClInclude Include="fix43\MarketDataRequestReject.h" />
+    <ClInclude Include="fix43\MarketDataSnapshotFullRefresh.h" />
+    <ClInclude Include="fix43\MassQuote.h" />
+    <ClInclude Include="fix43\MassQuoteAcknowledgement.h" />
+    <ClInclude Include="fix43\Message.h" />
+    <ClInclude Include="fix43\MessageCracker.h" />
+    <ClInclude Include="fix43\MultilegOrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix43\NewOrderCross.h" />
+    <ClInclude Include="fix43\NewOrderList.h" />
+    <ClInclude Include="fix43\NewOrderMultileg.h" />
+    <ClInclude Include="fix43\NewOrderSingle.h" />
+    <ClInclude Include="fix43\News.h" />
+    <ClInclude Include="fix43\OrderCancelReject.h" />
+    <ClInclude Include="fix43\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix43\OrderCancelRequest.h" />
+    <ClInclude Include="fix43\OrderMassCancelReport.h" />
+    <ClInclude Include="fix43\OrderMassCancelRequest.h" />
+    <ClInclude Include="fix43\OrderMassStatusRequest.h" />
+    <ClInclude Include="fix43\OrderStatusRequest.h" />
+    <ClInclude Include="fix43\Quote.h" />
+    <ClInclude Include="fix43\QuoteCancel.h" />
+    <ClInclude Include="fix43\QuoteRequest.h" />
+    <ClInclude Include="fix43\QuoteRequestReject.h" />
+    <ClInclude Include="fix43\QuoteStatusReport.h" />
+    <ClInclude Include="fix43\QuoteStatusRequest.h" />
+    <ClInclude Include="fix43\RegistrationInstructions.h" />
+    <ClInclude Include="fix43\RegistrationInstructionsResponse.h" />
+    <ClInclude Include="fix43\Reject.h" />
+    <ClInclude Include="fix43\ResendRequest.h" />
+    <ClInclude Include="fix43\RFQRequest.h" />
+    <ClInclude Include="fix43\SecurityDefinition.h" />
+    <ClInclude Include="fix43\SecurityDefinitionRequest.h" />
+    <ClInclude Include="fix43\SecurityList.h" />
+    <ClInclude Include="fix43\SecurityListRequest.h" />
+    <ClInclude Include="fix43\SecurityStatus.h" />
+    <ClInclude Include="fix43\SecurityStatusRequest.h" />
+    <ClInclude Include="fix43\SecurityTypeRequest.h" />
+    <ClInclude Include="fix43\SecurityTypes.h" />
+    <ClInclude Include="fix43\SequenceReset.h" />
+    <ClInclude Include="fix43\SettlementInstructions.h" />
+    <ClInclude Include="fix43\TestRequest.h" />
+    <ClInclude Include="fix43\TradeCaptureReport.h" />
+    <ClInclude Include="fix43\TradeCaptureReportRequest.h" />
+    <ClInclude Include="fix43\TradingSessionStatus.h" />
+    <ClInclude Include="fix43\TradingSessionStatusRequest.h" />
+    <ClInclude Include="fix44\Advertisement.h" />
+    <ClInclude Include="fix44\AllocationInstruction.h" />
+    <ClInclude Include="fix44\AllocationInstructionAck.h" />
+    <ClInclude Include="fix44\AllocationReport.h" />
+    <ClInclude Include="fix44\AllocationReportAck.h" />
+    <ClInclude Include="fix44\AssignmentReport.h" />
+    <ClInclude Include="fix44\BidRequest.h" />
+    <ClInclude Include="fix44\BidResponse.h" />
+    <ClInclude Include="fix44\BusinessMessageReject.h" />
+    <ClInclude Include="fix44\CollateralAssignment.h" />
+    <ClInclude Include="fix44\CollateralInquiry.h" />
+    <ClInclude Include="fix44\CollateralInquiryAck.h" />
+    <ClInclude Include="fix44\CollateralReport.h" />
+    <ClInclude Include="fix44\CollateralRequest.h" />
+    <ClInclude Include="fix44\CollateralResponse.h" />
+    <ClInclude Include="fix44\Confirmation.h" />
+    <ClInclude Include="fix44\ConfirmationAck.h" />
+    <ClInclude Include="fix44\ConfirmationRequest.h" />
+    <ClInclude Include="fix44\CrossOrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix44\CrossOrderCancelRequest.h" />
+    <ClInclude Include="fix44\DerivativeSecurityList.h" />
+    <ClInclude Include="fix44\DerivativeSecurityListRequest.h" />
+    <ClInclude Include="fix44\DontKnowTrade.h" />
+    <ClInclude Include="fix44\Email.h" />
+    <ClInclude Include="fix44\ExecutionReport.h" />
+    <ClInclude Include="fix44\Heartbeat.h" />
+    <ClInclude Include="fix44\IOI.h" />
+    <ClInclude Include="fix44\ListCancelRequest.h" />
+    <ClInclude Include="fix44\ListExecute.h" />
+    <ClInclude Include="fix44\ListStatus.h" />
+    <ClInclude Include="fix44\ListStatusRequest.h" />
+    <ClInclude Include="fix44\ListStrikePrice.h" />
+    <ClInclude Include="fix44\Logon.h" />
+    <ClInclude Include="fix44\Logout.h" />
+    <ClInclude Include="fix44\MarketDataIncrementalRefresh.h" />
+    <ClInclude Include="fix44\MarketDataRequest.h" />
+    <ClInclude Include="fix44\MarketDataRequestReject.h" />
+    <ClInclude Include="fix44\MarketDataSnapshotFullRefresh.h" />
+    <ClInclude Include="fix44\MassQuote.h" />
+    <ClInclude Include="fix44\MassQuoteAcknowledgement.h" />
+    <ClInclude Include="fix44\Message.h" />
+    <ClInclude Include="fix44\MessageCracker.h" />
+    <ClInclude Include="fix44\MultilegOrderCancelReplace.h" />
+    <ClInclude Include="fix44\NetworkCounterpartySystemStatusRequest.h" />
+    <ClInclude Include="fix44\NetworkCounterpartySystemStatusResponse.h" />
+    <ClInclude Include="fix44\NewOrderCross.h" />
+    <ClInclude Include="fix44\NewOrderList.h" />
+    <ClInclude Include="fix44\NewOrderMultileg.h" />
+    <ClInclude Include="fix44\NewOrderSingle.h" />
+    <ClInclude Include="fix44\News.h" />
+    <ClInclude Include="fix44\OrderCancelReject.h" />
+    <ClInclude Include="fix44\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix44\OrderCancelRequest.h" />
+    <ClInclude Include="fix44\OrderMassCancelReport.h" />
+    <ClInclude Include="fix44\OrderMassCancelRequest.h" />
+    <ClInclude Include="fix44\OrderMassStatusRequest.h" />
+    <ClInclude Include="fix44\OrderStatusRequest.h" />
+    <ClInclude Include="fix44\PositionMaintenanceReport.h" />
+    <ClInclude Include="fix44\PositionMaintenanceRequest.h" />
+    <ClInclude Include="fix44\PositionReport.h" />
+    <ClInclude Include="fix44\Quote.h" />
+    <ClInclude Include="fix44\QuoteCancel.h" />
+    <ClInclude Include="fix44\QuoteRequest.h" />
+    <ClInclude Include="fix44\QuoteRequestReject.h" />
+    <ClInclude Include="fix44\QuoteResponse.h" />
+    <ClInclude Include="fix44\QuoteStatusReport.h" />
+    <ClInclude Include="fix44\QuoteStatusRequest.h" />
+    <ClInclude Include="fix44\RegistrationInstructions.h" />
+    <ClInclude Include="fix44\RegistrationInstructionsResponse.h" />
+    <ClInclude Include="fix44\Reject.h" />
+    <ClInclude Include="fix44\RequestForPositions.h" />
+    <ClInclude Include="fix44\RequestForPositionsAck.h" />
+    <ClInclude Include="fix44\ResendRequest.h" />
+    <ClInclude Include="fix44\RFQRequest.h" />
+    <ClInclude Include="fix44\SecurityDefinition.h" />
+    <ClInclude Include="fix44\SecurityDefinitionRequest.h" />
+    <ClInclude Include="fix44\SecurityList.h" />
+    <ClInclude Include="fix44\SecurityListRequest.h" />
+    <ClInclude Include="fix44\SecurityStatus.h" />
+    <ClInclude Include="fix44\SecurityStatusRequest.h" />
+    <ClInclude Include="fix44\SecurityTypeRequest.h" />
+    <ClInclude Include="fix44\SecurityTypes.h" />
+    <ClInclude Include="fix44\SequenceReset.h" />
+    <ClInclude Include="fix44\SettlementInstructionRequest.h" />
+    <ClInclude Include="fix44\SettlementInstructions.h" />
+    <ClInclude Include="fix44\TestRequest.h" />
+    <ClInclude Include="fix44\TradeCaptureReport.h" />
+    <ClInclude Include="fix44\TradeCaptureReportAck.h" />
+    <ClInclude Include="fix44\TradeCaptureReportRequest.h" />
+    <ClInclude Include="fix44\TradeCaptureReportRequestAck.h" />
+    <ClInclude Include="fix44\TradingSessionStatus.h" />
+    <ClInclude Include="fix44\TradingSessionStatusRequest.h" />
+    <ClInclude Include="fix44\UserRequest.h" />
+    <ClInclude Include="fix44\UserResponse.h" />
+    <ClInclude Include="fix50sp1\AdjustedPositionReport.h" />
+    <ClInclude Include="fix50sp1\Advertisement.h" />
+    <ClInclude Include="fix50sp1\AllocationInstruction.h" />
+    <ClInclude Include="fix50sp1\AllocationInstructionAck.h" />
+    <ClInclude Include="fix50sp1\AllocationInstructionAlert.h" />
+    <ClInclude Include="fix50sp1\AllocationReport.h" />
+    <ClInclude Include="fix50sp1\AllocationReportAck.h" />
+    <ClInclude Include="fix50sp1\ApplicationMessageReport.h" />
+    <ClInclude Include="fix50sp1\ApplicationMessageRequest.h" />
+    <ClInclude Include="fix50sp1\ApplicationMessageRequestAck.h" />
+    <ClInclude Include="fix50sp1\AssignmentReport.h" />
+    <ClInclude Include="fix50sp1\BidRequest.h" />
+    <ClInclude Include="fix50sp1\BidResponse.h" />
+    <ClInclude Include="fix50sp1\BusinessMessageReject.h" />
+    <ClInclude Include="fix50sp1\CollateralAssignment.h" />
+    <ClInclude Include="fix50sp1\CollateralInquiry.h" />
+    <ClInclude Include="fix50sp1\CollateralInquiryAck.h" />
+    <ClInclude Include="fix50sp1\CollateralReport.h" />
+    <ClInclude Include="fix50sp1\CollateralRequest.h" />
+    <ClInclude Include="fix50sp1\CollateralResponse.h" />
+    <ClInclude Include="fix50sp1\Confirmation.h" />
+    <ClInclude Include="fix50sp1\ConfirmationAck.h" />
+    <ClInclude Include="fix50sp1\ConfirmationRequest.h" />
+    <ClInclude Include="fix50sp1\ContraryIntentionReport.h" />
+    <ClInclude Include="fix50sp1\CrossOrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix50sp1\CrossOrderCancelRequest.h" />
+    <ClInclude Include="fix50sp1\DerivativeSecurityList.h" />
+    <ClInclude Include="fix50sp1\DerivativeSecurityListRequest.h" />
+    <ClInclude Include="fix50sp1\DerivativeSecurityListUpdateReport.h" />
+    <ClInclude Include="fix50sp1\DontKnowTrade.h" />
+    <ClInclude Include="fix50sp1\Email.h" />
+    <ClInclude Include="fix50sp1\ExecutionAcknowledgement.h" />
+    <ClInclude Include="fix50sp1\ExecutionReport.h" />
+    <ClInclude Include="fix50sp1\IOI.h" />
+    <ClInclude Include="fix50sp1\ListCancelRequest.h" />
+    <ClInclude Include="fix50sp1\ListExecute.h" />
+    <ClInclude Include="fix50sp1\ListStatus.h" />
+    <ClInclude Include="fix50sp1\ListStatusRequest.h" />
+    <ClInclude Include="fix50sp1\ListStrikePrice.h" />
+    <ClInclude Include="fix50sp1\MarketDataIncrementalRefresh.h" />
+    <ClInclude Include="fix50sp1\MarketDataRequest.h" />
+    <ClInclude Include="fix50sp1\MarketDataRequestReject.h" />
+    <ClInclude Include="fix50sp1\MarketDataSnapshotFullRefresh.h" />
+    <ClInclude Include="fix50sp1\MarketDefinition.h" />
+    <ClInclude Include="fix50sp1\MarketDefinitionRequest.h" />
+    <ClInclude Include="fix50sp1\MarketDefinitionUpdateReport.h" />
+    <ClInclude Include="fix50sp1\MassQuote.h" />
+    <ClInclude Include="fix50sp1\MassQuoteAcknowledgement.h" />
+    <ClInclude Include="fix50sp1\Message.h" />
+    <ClInclude Include="fix50sp1\MessageCracker.h" />
+    <ClInclude Include="fix50sp1\MultilegOrderCancelReplace.h" />
+    <ClInclude Include="fix50sp1\NetworkCounterpartySystemStatusRequest.h" />
+    <ClInclude Include="fix50sp1\NetworkCounterpartySystemStatusResponse.h" />
+    <ClInclude Include="fix50sp1\NewOrderCross.h" />
+    <ClInclude Include="fix50sp1\NewOrderList.h" />
+    <ClInclude Include="fix50sp1\NewOrderMultileg.h" />
+    <ClInclude Include="fix50sp1\NewOrderSingle.h" />
+    <ClInclude Include="fix50sp1\News.h" />
+    <ClInclude Include="fix50sp1\OrderCancelReject.h" />
+    <ClInclude Include="fix50sp1\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix50sp1\OrderCancelRequest.h" />
+    <ClInclude Include="fix50sp1\OrderMassActionReport.h" />
+    <ClInclude Include="fix50sp1\OrderMassActionRequest.h" />
+    <ClInclude Include="fix50sp1\OrderMassCancelReport.h" />
+    <ClInclude Include="fix50sp1\OrderMassCancelRequest.h" />
+    <ClInclude Include="fix50sp1\OrderMassStatusRequest.h" />
+    <ClInclude Include="fix50sp1\OrderStatusRequest.h" />
+    <ClInclude Include="fix50sp1\PositionMaintenanceReport.h" />
+    <ClInclude Include="fix50sp1\PositionMaintenanceRequest.h" />
+    <ClInclude Include="fix50sp1\PositionReport.h" />
+    <ClInclude Include="fix50sp1\Quote.h" />
+    <ClInclude Include="fix50sp1\QuoteCancel.h" />
+    <ClInclude Include="fix50sp1\QuoteRequest.h" />
+    <ClInclude Include="fix50sp1\QuoteRequestReject.h" />
+    <ClInclude Include="fix50sp1\QuoteResponse.h" />
+    <ClInclude Include="fix50sp1\QuoteStatusReport.h" />
+    <ClInclude Include="fix50sp1\QuoteStatusRequest.h" />
+    <ClInclude Include="fix50sp1\RegistrationInstructions.h" />
+    <ClInclude Include="fix50sp1\RegistrationInstructionsResponse.h" />
+    <ClInclude Include="fix50sp1\RequestForPositions.h" />
+    <ClInclude Include="fix50sp1\RequestForPositionsAck.h" />
+    <ClInclude Include="fix50sp1\RFQRequest.h" />
+    <ClInclude Include="fix50sp1\SecurityDefinition.h" />
+    <ClInclude Include="fix50sp1\SecurityDefinitionRequest.h" />
+    <ClInclude Include="fix50sp1\SecurityDefinitionUpdateReport.h" />
+    <ClInclude Include="fix50sp1\SecurityList.h" />
+    <ClInclude Include="fix50sp1\SecurityListRequest.h" />
+    <ClInclude Include="fix50sp1\SecurityListUpdateReport.h" />
+    <ClInclude Include="fix50sp1\SecurityStatus.h" />
+    <ClInclude Include="fix50sp1\SecurityStatusRequest.h" />
+    <ClInclude Include="fix50sp1\SecurityTypeRequest.h" />
+    <ClInclude Include="fix50sp1\SecurityTypes.h" />
+    <ClInclude Include="fix50sp1\SettlementInstructionRequest.h" />
+    <ClInclude Include="fix50sp1\SettlementInstructions.h" />
+    <ClInclude Include="fix50sp1\SettlementObligationReport.h" />
+    <ClInclude Include="fix50sp1\TradeCaptureReport.h" />
+    <ClInclude Include="fix50sp1\TradeCaptureReportAck.h" />
+    <ClInclude Include="fix50sp1\TradeCaptureReportRequest.h" />
+    <ClInclude Include="fix50sp1\TradeCaptureReportRequestAck.h" />
+    <ClInclude Include="fix50sp1\TradingSessionList.h" />
+    <ClInclude Include="fix50sp1\TradingSessionListRequest.h" />
+    <ClInclude Include="fix50sp1\TradingSessionListUpdateReport.h" />
+    <ClInclude Include="fix50sp1\TradingSessionStatus.h" />
+    <ClInclude Include="fix50sp1\TradingSessionStatusRequest.h" />
+    <ClInclude Include="fix50sp1\UserNotification.h" />
+    <ClInclude Include="fix50sp1\UserRequest.h" />
+    <ClInclude Include="fix50sp1\UserResponse.h" />
+    <ClInclude Include="fix50sp2\AdjustedPositionReport.h" />
+    <ClInclude Include="fix50sp2\Advertisement.h" />
+    <ClInclude Include="fix50sp2\AllocationInstruction.h" />
+    <ClInclude Include="fix50sp2\AllocationInstructionAck.h" />
+    <ClInclude Include="fix50sp2\AllocationInstructionAlert.h" />
+    <ClInclude Include="fix50sp2\AllocationReport.h" />
+    <ClInclude Include="fix50sp2\AllocationReportAck.h" />
+    <ClInclude Include="fix50sp2\ApplicationMessageReport.h" />
+    <ClInclude Include="fix50sp2\ApplicationMessageRequest.h" />
+    <ClInclude Include="fix50sp2\ApplicationMessageRequestAck.h" />
+    <ClInclude Include="fix50sp2\AssignmentReport.h" />
+    <ClInclude Include="fix50sp2\BidRequest.h" />
+    <ClInclude Include="fix50sp2\BidResponse.h" />
+    <ClInclude Include="fix50sp2\BusinessMessageReject.h" />
+    <ClInclude Include="fix50sp2\CollateralAssignment.h" />
+    <ClInclude Include="fix50sp2\CollateralInquiry.h" />
+    <ClInclude Include="fix50sp2\CollateralInquiryAck.h" />
+    <ClInclude Include="fix50sp2\CollateralReport.h" />
+    <ClInclude Include="fix50sp2\CollateralRequest.h" />
+    <ClInclude Include="fix50sp2\CollateralResponse.h" />
+    <ClInclude Include="fix50sp2\Confirmation.h" />
+    <ClInclude Include="fix50sp2\ConfirmationAck.h" />
+    <ClInclude Include="fix50sp2\ConfirmationRequest.h" />
+    <ClInclude Include="fix50sp2\ContraryIntentionReport.h" />
+    <ClInclude Include="fix50sp2\CrossOrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix50sp2\CrossOrderCancelRequest.h" />
+    <ClInclude Include="fix50sp2\DerivativeSecurityList.h" />
+    <ClInclude Include="fix50sp2\DerivativeSecurityListRequest.h" />
+    <ClInclude Include="fix50sp2\DerivativeSecurityListUpdateReport.h" />
+    <ClInclude Include="fix50sp2\DontKnowTrade.h" />
+    <ClInclude Include="fix50sp2\Email.h" />
+    <ClInclude Include="fix50sp2\ExecutionAcknowledgement.h" />
+    <ClInclude Include="fix50sp2\ExecutionReport.h" />
+    <ClInclude Include="fix50sp2\IOI.h" />
+    <ClInclude Include="fix50sp2\ListCancelRequest.h" />
+    <ClInclude Include="fix50sp2\ListExecute.h" />
+    <ClInclude Include="fix50sp2\ListStatus.h" />
+    <ClInclude Include="fix50sp2\ListStatusRequest.h" />
+    <ClInclude Include="fix50sp2\ListStrikePrice.h" />
+    <ClInclude Include="fix50sp2\MarketDataIncrementalRefresh.h" />
+    <ClInclude Include="fix50sp2\MarketDataRequest.h" />
+    <ClInclude Include="fix50sp2\MarketDataRequestReject.h" />
+    <ClInclude Include="fix50sp2\MarketDataSnapshotFullRefresh.h" />
+    <ClInclude Include="fix50sp2\MarketDefinition.h" />
+    <ClInclude Include="fix50sp2\MarketDefinitionRequest.h" />
+    <ClInclude Include="fix50sp2\MarketDefinitionUpdateReport.h" />
+    <ClInclude Include="fix50sp2\MassQuote.h" />
+    <ClInclude Include="fix50sp2\MassQuoteAcknowledgement.h" />
+    <ClInclude Include="fix50sp2\Message.h" />
+    <ClInclude Include="fix50sp2\MessageCracker.h" />
+    <ClInclude Include="fix50sp2\MultilegOrderCancelReplace.h" />
+    <ClInclude Include="fix50sp2\NetworkCounterpartySystemStatusRequest.h" />
+    <ClInclude Include="fix50sp2\NetworkCounterpartySystemStatusResponse.h" />
+    <ClInclude Include="fix50sp2\NewOrderCross.h" />
+    <ClInclude Include="fix50sp2\NewOrderList.h" />
+    <ClInclude Include="fix50sp2\NewOrderMultileg.h" />
+    <ClInclude Include="fix50sp2\NewOrderSingle.h" />
+    <ClInclude Include="fix50sp2\News.h" />
+    <ClInclude Include="fix50sp2\OrderCancelReject.h" />
+    <ClInclude Include="fix50sp2\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix50sp2\OrderCancelRequest.h" />
+    <ClInclude Include="fix50sp2\OrderMassActionReport.h" />
+    <ClInclude Include="fix50sp2\OrderMassActionRequest.h" />
+    <ClInclude Include="fix50sp2\OrderMassCancelReport.h" />
+    <ClInclude Include="fix50sp2\OrderMassCancelRequest.h" />
+    <ClInclude Include="fix50sp2\OrderMassStatusRequest.h" />
+    <ClInclude Include="fix50sp2\OrderStatusRequest.h" />
+    <ClInclude Include="fix50sp2\PositionMaintenanceReport.h" />
+    <ClInclude Include="fix50sp2\PositionMaintenanceRequest.h" />
+    <ClInclude Include="fix50sp2\PositionReport.h" />
+    <ClInclude Include="fix50sp2\Quote.h" />
+    <ClInclude Include="fix50sp2\QuoteCancel.h" />
+    <ClInclude Include="fix50sp2\QuoteRequest.h" />
+    <ClInclude Include="fix50sp2\QuoteRequestReject.h" />
+    <ClInclude Include="fix50sp2\QuoteResponse.h" />
+    <ClInclude Include="fix50sp2\QuoteStatusReport.h" />
+    <ClInclude Include="fix50sp2\QuoteStatusRequest.h" />
+    <ClInclude Include="fix50sp2\RegistrationInstructions.h" />
+    <ClInclude Include="fix50sp2\RegistrationInstructionsResponse.h" />
+    <ClInclude Include="fix50sp2\RequestForPositions.h" />
+    <ClInclude Include="fix50sp2\RequestForPositionsAck.h" />
+    <ClInclude Include="fix50sp2\RFQRequest.h" />
+    <ClInclude Include="fix50sp2\SecurityDefinition.h" />
+    <ClInclude Include="fix50sp2\SecurityDefinitionRequest.h" />
+    <ClInclude Include="fix50sp2\SecurityDefinitionUpdateReport.h" />
+    <ClInclude Include="fix50sp2\SecurityList.h" />
+    <ClInclude Include="fix50sp2\SecurityListRequest.h" />
+    <ClInclude Include="fix50sp2\SecurityListUpdateReport.h" />
+    <ClInclude Include="fix50sp2\SecurityStatus.h" />
+    <ClInclude Include="fix50sp2\SecurityStatusRequest.h" />
+    <ClInclude Include="fix50sp2\SecurityTypeRequest.h" />
+    <ClInclude Include="fix50sp2\SecurityTypes.h" />
+    <ClInclude Include="fix50sp2\SettlementInstructionRequest.h" />
+    <ClInclude Include="fix50sp2\SettlementInstructions.h" />
+    <ClInclude Include="fix50sp2\SettlementObligationReport.h" />
+    <ClInclude Include="fix50sp2\StreamAssignmentReport.h" />
+    <ClInclude Include="fix50sp2\StreamAssignmentReportACK.h" />
+    <ClInclude Include="fix50sp2\StreamAssignmentRequest.h" />
+    <ClInclude Include="fix50sp2\TradeCaptureReport.h" />
+    <ClInclude Include="fix50sp2\TradeCaptureReportAck.h" />
+    <ClInclude Include="fix50sp2\TradeCaptureReportRequest.h" />
+    <ClInclude Include="fix50sp2\TradeCaptureReportRequestAck.h" />
+    <ClInclude Include="fix50sp2\TradingSessionList.h" />
+    <ClInclude Include="fix50sp2\TradingSessionListRequest.h" />
+    <ClInclude Include="fix50sp2\TradingSessionListUpdateReport.h" />
+    <ClInclude Include="fix50sp2\TradingSessionStatus.h" />
+    <ClInclude Include="fix50sp2\TradingSessionStatusRequest.h" />
+    <ClInclude Include="fix50sp2\UserNotification.h" />
+    <ClInclude Include="fix50sp2\UserRequest.h" />
+    <ClInclude Include="fix50sp2\UserResponse.h" />
+    <ClInclude Include="fix50\AdjustedPositionReport.h" />
+    <ClInclude Include="fix50\Advertisement.h" />
+    <ClInclude Include="fix50\AllocationInstruction.h" />
+    <ClInclude Include="fix50\AllocationInstructionAck.h" />
+    <ClInclude Include="fix50\AllocationInstructionAlert.h" />
+    <ClInclude Include="fix50\AllocationReport.h" />
+    <ClInclude Include="fix50\AllocationReportAck.h" />
+    <ClInclude Include="fix50\AssignmentReport.h" />
+    <ClInclude Include="fix50\BidRequest.h" />
+    <ClInclude Include="fix50\BidResponse.h" />
+    <ClInclude Include="fix50\BusinessMessageReject.h" />
+    <ClInclude Include="fix50\CollateralAssignment.h" />
+    <ClInclude Include="fix50\CollateralInquiry.h" />
+    <ClInclude Include="fix50\CollateralInquiryAck.h" />
+    <ClInclude Include="fix50\CollateralReport.h" />
+    <ClInclude Include="fix50\CollateralRequest.h" />
+    <ClInclude Include="fix50\CollateralResponse.h" />
+    <ClInclude Include="fix50\Confirmation.h" />
+    <ClInclude Include="fix50\ConfirmationAck.h" />
+    <ClInclude Include="fix50\ConfirmationRequest.h" />
+    <ClInclude Include="fix50\ContraryIntentionReport.h" />
+    <ClInclude Include="fix50\CrossOrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix50\CrossOrderCancelRequest.h" />
+    <ClInclude Include="fix50\DerivativeSecurityList.h" />
+    <ClInclude Include="fix50\DerivativeSecurityListRequest.h" />
+    <ClInclude Include="fix50\DontKnowTrade.h" />
+    <ClInclude Include="fix50\Email.h" />
+    <ClInclude Include="fix50\ExecutionAcknowledgement.h" />
+    <ClInclude Include="fix50\ExecutionReport.h" />
+    <ClInclude Include="fix50\IOI.h" />
+    <ClInclude Include="fix50\ListCancelRequest.h" />
+    <ClInclude Include="fix50\ListExecute.h" />
+    <ClInclude Include="fix50\ListStatus.h" />
+    <ClInclude Include="fix50\ListStatusRequest.h" />
+    <ClInclude Include="fix50\ListStrikePrice.h" />
+    <ClInclude Include="fix50\MarketDataIncrementalRefresh.h" />
+    <ClInclude Include="fix50\MarketDataRequest.h" />
+    <ClInclude Include="fix50\MarketDataRequestReject.h" />
+    <ClInclude Include="fix50\MarketDataSnapshotFullRefresh.h" />
+    <ClInclude Include="fix50\MassQuote.h" />
+    <ClInclude Include="fix50\MassQuoteAcknowledgement.h" />
+    <ClInclude Include="fix50\Message.h" />
+    <ClInclude Include="fix50\MessageCracker.h" />
+    <ClInclude Include="fix50\MultilegOrderCancelReplace.h" />
+    <ClInclude Include="fix50\NetworkCounterpartySystemStatusRequest.h" />
+    <ClInclude Include="fix50\NetworkCounterpartySystemStatusResponse.h" />
+    <ClInclude Include="fix50\NewOrderCross.h" />
+    <ClInclude Include="fix50\NewOrderList.h" />
+    <ClInclude Include="fix50\NewOrderMultileg.h" />
+    <ClInclude Include="fix50\NewOrderSingle.h" />
+    <ClInclude Include="fix50\News.h" />
+    <ClInclude Include="fix50\OrderCancelReject.h" />
+    <ClInclude Include="fix50\OrderCancelReplaceRequest.h" />
+    <ClInclude Include="fix50\OrderCancelRequest.h" />
+    <ClInclude Include="fix50\OrderMassCancelReport.h" />
+    <ClInclude Include="fix50\OrderMassCancelRequest.h" />
+    <ClInclude Include="fix50\OrderMassStatusRequest.h" />
+    <ClInclude Include="fix50\OrderStatusRequest.h" />
+    <ClInclude Include="fix50\PositionMaintenanceReport.h" />
+    <ClInclude Include="fix50\PositionMaintenanceRequest.h" />
+    <ClInclude Include="fix50\PositionReport.h" />
+    <ClInclude Include="fix50\Quote.h" />
+    <ClInclude Include="fix50\QuoteCancel.h" />
+    <ClInclude Include="fix50\QuoteRequest.h" />
+    <ClInclude Include="fix50\QuoteRequestReject.h" />
+    <ClInclude Include="fix50\QuoteResponse.h" />
+    <ClInclude Include="fix50\QuoteStatusReport.h" />
+    <ClInclude Include="fix50\QuoteStatusRequest.h" />
+    <ClInclude Include="fix50\RegistrationInstructions.h" />
+    <ClInclude Include="fix50\RegistrationInstructionsResponse.h" />
+    <ClInclude Include="fix50\RequestForPositions.h" />
+    <ClInclude Include="fix50\RequestForPositionsAck.h" />
+    <ClInclude Include="fix50\RFQRequest.h" />
+    <ClInclude Include="fix50\SecurityDefinition.h" />
+    <ClInclude Include="fix50\SecurityDefinitionRequest.h" />
+    <ClInclude Include="fix50\SecurityDefinitionUpdateReport.h" />
+    <ClInclude Include="fix50\SecurityList.h" />
+    <ClInclude Include="fix50\SecurityListRequest.h" />
+    <ClInclude Include="fix50\SecurityListUpdateReport.h" />
+    <ClInclude Include="fix50\SecurityStatus.h" />
+    <ClInclude Include="fix50\SecurityStatusRequest.h" />
+    <ClInclude Include="fix50\SecurityTypeRequest.h" />
+    <ClInclude Include="fix50\SecurityTypes.h" />
+    <ClInclude Include="fix50\SettlementInstructionRequest.h" />
+    <ClInclude Include="fix50\SettlementInstructions.h" />
+    <ClInclude Include="fix50\TradeCaptureReport.h" />
+    <ClInclude Include="fix50\TradeCaptureReportAck.h" />
+    <ClInclude Include="fix50\TradeCaptureReportRequest.h" />
+    <ClInclude Include="fix50\TradeCaptureReportRequestAck.h" />
+    <ClInclude Include="fix50\TradingSessionList.h" />
+    <ClInclude Include="fix50\TradingSessionListRequest.h" />
+    <ClInclude Include="fix50\TradingSessionStatus.h" />
+    <ClInclude Include="fix50\TradingSessionStatusRequest.h" />
+    <ClInclude Include="fix50\UserRequest.h" />
+    <ClInclude Include="fix50\UserResponse.h" />
+    <ClInclude Include="FixFieldNumbers.h" />
+    <ClInclude Include="FixFields.h" />
+    <ClInclude Include="fixt11\Heartbeat.h" />
+    <ClInclude Include="fixt11\Logon.h" />
+    <ClInclude Include="fixt11\Logout.h" />
+    <ClInclude Include="fixt11\Message.h" />
+    <ClInclude Include="fixt11\MessageCracker.h" />
+    <ClInclude Include="fixt11\Reject.h" />
+    <ClInclude Include="fixt11\ResendRequest.h" />
+    <ClInclude Include="fixt11\SequenceReset.h" />
+    <ClInclude Include="fixt11\TestRequest.h" />
+    <ClInclude Include="FixValues.h" />
+    <ClInclude Include="FlexLexer.h" />
+    <ClInclude Include="Group.h" />
+    <ClInclude Include="HttpConnection.h" />
+    <ClInclude Include="HttpMessage.h" />
+    <ClInclude Include="HttpParser.h" />
+    <ClInclude Include="HttpServer.h" />
+    <ClInclude Include="Initiator.h" />
+    <ClInclude Include="Log.h" />
+    <ClInclude Include="Message.h" />
+    <ClInclude Include="MessageCracker.h" />
+    <ClInclude Include="MessageSorters.h" />
+    <ClInclude Include="MessageStore.h" />
+    <ClInclude Include="Mutex.h" />
+    <ClInclude Include="MySQLConnection.h" />
+    <ClInclude Include="MySQLLog.h" />
+    <ClInclude Include="MySQLStore.h" />
+    <ClInclude Include="NullStore.h" />
+    <ClInclude Include="OdbcConnection.h" />
+    <ClInclude Include="OdbcLog.h" />
+    <ClInclude Include="OdbcStore.h" />
+    <ClInclude Include="Parser.h" />
+    <ClInclude Include="PostgreSQLConnection.h" />
+    <ClInclude Include="PostgreSQLLog.h" />
+    <ClInclude Include="PostgreSQLStore.h" />
+    <ClInclude Include="pugiconfig.hpp" />
+    <ClInclude Include="pugixml.hpp" />
+    <ClInclude Include="PUGIXML_DOMDocument.h" />
+    <ClInclude Include="Queue.h" />
+    <ClInclude Include="Responder.h" />
+    <ClInclude Include="Session.h" />
+    <ClInclude Include="SessionFactory.h" />
+    <ClInclude Include="SessionID.h" />
+    <ClInclude Include="SessionSettings.h" />
+    <ClInclude Include="SessionState.h" />
+    <ClInclude Include="Settings.h" />
+    <ClInclude Include="SharedArray.h" />
+    <ClInclude Include="SocketAcceptor.h" />
+    <ClInclude Include="SocketConnection.h" />
+    <ClInclude Include="SocketConnector.h" />
+    <ClInclude Include="SocketInitiator.h" />
+    <ClInclude Include="SocketMonitor.h" />
+    <ClInclude Include="SocketServer.h" />
+    <ClInclude Include="strptime.h" />
+    <ClInclude Include="ThreadedSocketAcceptor.h" />
+    <ClInclude Include="ThreadedSocketConnection.h" />
+    <ClInclude Include="ThreadedSocketInitiator.h" />
+    <ClInclude Include="TimeRange.h" />
+    <ClInclude Include="Utility.h" />
+    <ClInclude Include="Values.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="Acceptor.cpp" />
+    <ClCompile Include="DataDictionary.cpp" />
+    <ClCompile Include="DataDictionaryProvider.cpp" />
+    <ClCompile Include="Dictionary.cpp" />
+    <ClCompile Include="FieldConvertors.cpp" />
+    <ClCompile Include="FieldMap.cpp" />
+    <ClCompile Include="FieldTypes.cpp" />
+    <ClCompile Include="FileLog.cpp" />
+    <ClCompile Include="FileStore.cpp" />
+    <ClCompile Include="Group.cpp" />
+    <ClCompile Include="HttpConnection.cpp" />
+    <ClCompile Include="HttpMessage.cpp" />
+    <ClCompile Include="HttpParser.cpp" />
+    <ClCompile Include="HttpServer.cpp" />
+    <ClCompile Include="Initiator.cpp" />
+    <ClCompile Include="Log.cpp" />
+    <ClCompile Include="Message.cpp" />
+    <ClCompile Include="MessageSorters.cpp" />
+    <ClCompile Include="MessageStore.cpp" />
+    <ClCompile Include="MySQLLog.cpp" />
+    <ClCompile Include="MySQLStore.cpp" />
+    <ClCompile Include="NullStore.cpp" />
+    <ClCompile Include="OdbcLog.cpp" />
+    <ClCompile Include="OdbcStore.cpp" />
+    <ClCompile Include="Parser.cpp" />
+    <ClCompile Include="PostgreSQLLog.cpp" />
+    <ClCompile Include="PostgreSQLStore.cpp" />
+    <ClCompile Include="pugixml.cpp" />
+    <ClCompile Include="PUGIXML_DOMDocument.cpp" />
+    <ClCompile Include="Session.cpp" />
+    <ClCompile Include="SessionFactory.cpp" />
+    <ClCompile Include="SessionSettings.cpp" />
+    <ClCompile Include="Settings.cpp" />
+    <ClCompile Include="SocketAcceptor.cpp" />
+    <ClCompile Include="SocketConnection.cpp" />
+    <ClCompile Include="SocketConnector.cpp" />
+    <ClCompile Include="SocketInitiator.cpp" />
+    <ClCompile Include="SocketMonitor.cpp" />
+    <ClCompile Include="SocketServer.cpp" />
+    <ClCompile Include="strptime.c" />
+    <ClCompile Include="ThreadedSocketAcceptor.cpp" />
+    <ClCompile Include="ThreadedSocketConnection.cpp" />
+    <ClCompile Include="ThreadedSocketInitiator.cpp" />
+    <ClCompile Include="TimeRange.cpp" />
+    <ClCompile Include="Utility.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>quickfix</ProjectName>
+    <ProjectGuid>{D5D558EA-BBAC-4862-A946-D3881BACE3B7}</ProjectGuid>
+    <RootNamespace>quickfix_vc12</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)lib\debug\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)lib\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">quickfix</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">quickfix</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Debug/quickfix.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Lib>
+    <PostBuildEvent>
+      <Command>echo test\ &gt; EXCLUDE
+echo stdafx.h &gt;&gt; EXCLUDE
+echo release\ &gt;&gt; EXCLUDE
+echo debug\ &gt;&gt; EXCLUDE
+xcopy *.h /S/Y/E/I /EXCLUDE:EXCLUDE ..\..\include\quickfix
+del /F EXCLUDE
+</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Release/quickfix.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Lib>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Lib>
+    <PostBuildEvent>
+      <Command>echo test\ &gt; EXCLUDE
+echo stdafx.h &gt;&gt; EXCLUDE
+echo release\ &gt;&gt; EXCLUDE
+echo debug\ &gt;&gt; EXCLUDE
+xcopy *.h /S/Y/E/I /EXCLUDE:EXCLUDE ..\..\include\quickfix
+del /F EXCLUDE
+</Command>
+    </PostBuildEvent>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test_acceptance_vs17.vcxproj
+++ b/src/test_acceptance_vs17.vcxproj
@@ -1,0 +1,144 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>test_acceptance</ProjectName>
+    <ProjectGuid>{63CC102A-A3CD-43CC-9535-A91E67256360}</ProjectGuid>
+    <RootNamespace>test_acceptance</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)test\release\at\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)test\debug\at\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">at</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">at</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/at.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>$(SolutionDir)/src;$(SolutionDir)/src/c++;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Release/at.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/at.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/at.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir)/src;$(SolutionDir)/src/c++;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Debug/at.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/at.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="at.cpp" />
+    <ClCompile Include="getopt.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="at_application.h" />
+    <ClInclude Include="getopt-repl.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="C++\quickfix_vs17.vcxproj">
+      <Project>{d5d558ea-bbac-4862-a946-d3881bace3b7}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test_performance_vs17.vcxproj
+++ b/src/test_performance_vs17.vcxproj
@@ -1,0 +1,146 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>test_performance</ProjectName>
+    <ProjectGuid>{4E6CE474-47A1-4AC8-8161-9CD214664EBB}</ProjectGuid>
+    <RootNamespace>test_performance</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)test\debug\pt\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)test\release\pt\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">pt</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">pt</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/pt.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir)/src;$(SolutionDir)/src/c++;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Debug/pt.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/pt.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/pt.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <FavorSizeOrSpeed>Neither</FavorSizeOrSpeed>
+      <AdditionalIncludeDirectories>$(SolutionDir)/src;$(SolutionDir)/src/c++;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Release/pt.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/pt.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="getopt.c" />
+    <ClCompile Include="pt.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="getopt-repl.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="C++\quickfix_vs17.vcxproj">
+      <Project>{d5d558ea-bbac-4862-a946-d3881bace3b7}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/src/test_unit_vs17.vcxproj
+++ b/src/test_unit_vs17.vcxproj
@@ -1,0 +1,182 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>test_unit</ProjectName>
+    <ProjectGuid>{CD58A1FF-0F7A-4490-B9B4-944326C48A5A}</ProjectGuid>
+    <RootNamespace>ut_vc12</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)test\release\ut\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)test\debug\ut\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">ut</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">ut</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/ut.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalOptions>"  /I /src/socket"  "  /I /src/socket"  "  /I /src/socket"  "  /I /src/socket"  %(AdditionalOptions)</AdditionalOptions>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src\C++;$(SolutionDir)\src\C++\test;$(SolutionDir)\UnitTest++\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Release/ut.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;UnitTest++_vs17.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/ut.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/ut.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <AdditionalOptions>"  /I /src/socket"  "  /I /src/socket"  "  /I /src/socket"  "  /I /src/socket"  %(AdditionalOptions)</AdditionalOptions>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)\src\C++;$(SolutionDIr)\src\C++\test;$(SolutionDir)\UnitTest++\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>.\Debug/ut.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+      <ShowIncludes>false</ShowIncludes>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>quickfix.lib;UnitTest++_vs17.lib;ws2_32.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/ut.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="C++\test\DataDictionaryTestCase.cpp" />
+    <ClCompile Include="C++\test\DictionaryTestCase.cpp" />
+    <ClCompile Include="C++\test\FieldBaseTestCase.cpp" />
+    <ClCompile Include="C++\test\FieldConvertorsTestCase.cpp" />
+    <ClCompile Include="C++\test\FileLogTestCase.cpp" />
+    <ClCompile Include="C++\test\FileStoreFactoryTestCase.cpp" />
+    <ClCompile Include="C++\test\FileStoreTestCase.cpp" />
+    <ClCompile Include="C++\test\FileUtilitiesTestCase.cpp" />
+    <ClCompile Include="C++\test\GroupTestCase.cpp" />
+    <ClCompile Include="C++\test\SessionFactoryTestCase.cpp" />
+    <ClCompile Include="getopt.c" />
+    <ClCompile Include="C++\test\HttpMessageTestCase.cpp" />
+    <ClCompile Include="C++\test\HttpParserTestCase.cpp" />
+    <ClCompile Include="C++\test\MemoryStoreTestCase.cpp" />
+    <ClCompile Include="C++\test\MessageSortersTestCase.cpp" />
+    <ClCompile Include="C++\test\MessagesTestCase.cpp" />
+    <ClCompile Include="C++\test\MySQLStoreTestCase.cpp" />
+    <ClCompile Include="C++\test\NullStoreTestCase.cpp" />
+    <ClCompile Include="C++\test\OdbcStoreTestCase.cpp" />
+    <ClCompile Include="C++\test\ParserTestCase.cpp" />
+    <ClCompile Include="C++\test\PostgreSQLStoreTestCase.cpp" />
+    <ClCompile Include="C++\test\SessionIDTestCase.cpp" />
+    <ClCompile Include="C++\test\SessionSettingsTestCase.cpp" />
+    <ClCompile Include="C++\test\SessionTestCase.cpp" />
+    <ClCompile Include="C++\test\SettingsTestCase.cpp" />
+    <ClCompile Include="C++\test\SocketAcceptorTestCase.cpp" />
+    <ClCompile Include="C++\test\SocketConnectorTestCase.cpp" />
+    <ClCompile Include="C++\test\SocketServerTestCase.cpp" />
+    <ClCompile Include="C++\test\StringUtilitiesTestCase.cpp" />
+    <ClCompile Include="C++\test\TestHelper.cpp" />
+    <ClCompile Include="C++\test\TimeRangeTestCase.cpp" />
+    <ClCompile Include="ut.cpp" />
+    <ClCompile Include="C++\test\UtcTimeOnlyTestCase.cpp" />
+    <ClCompile Include="C++\test\UtcTimeStampTestCase.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="C++\test\MessageStoreTestCase.h" />
+    <ClInclude Include="C++\test\TestHelper.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="C++\quickfix_vs17.vcxproj">
+      <Project>{d5d558ea-bbac-4862-a946-d3881bace3b7}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/test/atrun/test_acceptance_runner_vs17.vcxproj
+++ b/test/atrun/test_acceptance_runner_vs17.vcxproj
@@ -1,0 +1,142 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectName>test_acceptance_runner</ProjectName>
+    <ProjectGuid>{A58C8BD5-3602-4886-80A0-CD4FFED42144}</ProjectGuid>
+    <RootNamespace>atrun</RootNamespace>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseOfMfc>false</UseOfMfc>
+    <CharacterSet>MultiByte</CharacterSet>
+    <PlatformToolset>v141</PlatformToolset>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.21006.1</_ProjectFileVersion>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)test\debug\at\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">debug\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkIncremental>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)test\release\at\</OutDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">release\vs17\</IntDir>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkIncremental>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">atrun</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">atrun</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Debug/atrun.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <Optimization>Disabled</Optimization>
+      <AdditionalIncludeDirectories>..\..;..\..\..;$(SolutionDir)\UnitTest++\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Debug/atrun.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Debug/</AssemblerListingLocation>
+      <ObjectFileName>.\Debug/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Debug/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>odbc32.lib;odbccp32.lib;UnitTest++_vs17.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)$(TargetFileName)</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib\debug;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <ProgramDatabaseFile>.\Debug/atrun.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Midl>
+      <TypeLibraryName>.\Release/atrun.tlb</TypeLibraryName>
+    </Midl>
+    <ClCompile>
+      <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
+      <AdditionalIncludeDirectories>..\..;..\..\..;$(SolutionDir)\UnitTest++\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <StringPooling>true</StringPooling>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <RuntimeTypeInfo>true</RuntimeTypeInfo>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <PrecompiledHeaderOutputFile>.\Release/atrun.pch</PrecompiledHeaderOutputFile>
+      <AssemblerListingLocation>.\Release/</AssemblerListingLocation>
+      <ObjectFileName>.\Release/</ObjectFileName>
+      <ProgramDataBaseFileName>.\Release/</ProgramDataBaseFileName>
+      <WarningLevel>Level3</WarningLevel>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <CompileAs>Default</CompileAs>
+    </ClCompile>
+    <ResourceCompile>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <Culture>0x0409</Culture>
+    </ResourceCompile>
+    <Link>
+      <AdditionalOptions>/MACHINE:I386 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalDependencies>odbc32.lib;odbccp32.lib;UnitTest++_vs17.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)atrun.exe</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <AdditionalLibraryDirectories>$(SolutionDir)lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <ProgramDatabaseFile>.\Release/atrun.pdb</ProgramDatabaseFile>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\getopt.c" />
+    <ClCompile Include="main.cpp" />
+    <ClCompile Include="Process.cpp" />
+    <ClCompile Include="test\ProcessTestCase.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="Process.h" />
+    <ClInclude Include="test\ProcessTestCase.h" />
+    <ClInclude Include="TestSuite.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
I encountered two issues while building on VS 2017

1.) The example files were referencing src\C++\quickfix_vs12.vcxproj
2.) FieldConvertors.cpp was missing from quickfix_vs15.vcxproj

Let me know if you accept this pull request with a new "vs17" build as is or if you prefer to keep only the vs15 files and make those two changes only in those.
