### PR TITLE
Fix conditional inclusion of headers and namespace for shared_ptr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ AC_TRY_COMPILE(
 	[#include <tr1/memory>],
 	[std::tr1::shared_ptr<int> ptr;],
 	AC_MSG_RESULT(yes)
-	AC_DEFINE(HAVE_STD_TR1_SHARED_PTR, 1,
+	AC_DEFINE(HAVE_SHARED_PTR_IN_TR1_NAMESPACE, 1,
 	The system supports std::tr1::shared_ptr),
 	AC_MSG_RESULT(no))
 

--- a/configure.ac
+++ b/configure.ac
@@ -234,7 +234,7 @@ AC_TRY_COMPILE(
 	[#include <tr1/memory>],
 	[std::tr1::shared_ptr<int> ptr;],
 	AC_MSG_RESULT(yes)
-	AC_DEFINE(HAVE_SHARED_PTR_IN_TR1_NAMESPACE, 1,
+	AC_DEFINE(HAVE_STD_TR1_SHARED_PTR_FROM_TR1_MEMORY_HEADER, 1,
 	The system supports std::tr1::shared_ptr),
 	AC_MSG_RESULT(no))
 

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -111,6 +111,9 @@ typedef int ssize_t;
 #if defined(HAVE_STD_SHARED_PTR)
   namespace ptr = std;
 #elif defined(HAVE_STD_TR1_SHARED_PTR)
+  #include <memory>
+  namespace ptr = std::tr1;
+#elif defined(HAVE_STD_TR1_SHARED_PTR_FROM_TR1_MEMORY_HEADER)
   #include <tr1/memory>
   namespace ptr = std::tr1;
 #elif defined(HAVE_BOOST_SHARED_PTR)


### PR DESCRIPTION
I wasn't being able to compile the project on CentOS 7.5 with `cmake` because of a missing condition in the *src/C++/Utility.h* file.

This PR fixes two things:

- A wrong `HAVE_STD_TR1_SHARED_PTR` condition where it was including `<tr1/memory>` instead of just `<memory>`
- Adds the missing `HAVE_STD_TR1_SHARED_PTR_FROM_TR1_MEMORY_HEADER` condition to include `<tr1/memory>` and use the namespace `ptr = std::tr1`

---------------

The solution is based on the content of the file *cmake/FindSharedPtr.cmake*:

This is the condition to set the `HAVE_STD_TR1_SHARED_PTR` variable:

```
check_cxx_source_compiles("#include <memory>
                           int main() {
                             std::shared_ptr<int> int_ptr;
                             return 0;
                           }"
                          HAVE_SHARED_PTR_IN_STD_NAMESPACE)
```

And this is the one to set `HAVE_STD_TR1_SHARED_PTR_FROM_TR1_MEMORY_HEADER`:

```
check_cxx_source_compiles("#include <tr1/memory>
                           int main() {
                             std::tr1::shared_ptr<int> int_ptr;
                             return 0;
                           }"
                          HAVE_SHARED_PTR_IN_TR1_NAMESPACE_FROM_TR1_MEMORY_HEADER)
```
