### PR TITLE
run_executor_python.sh: default python version

### DIFF
--- a/bin/run_executor_python.sh
+++ b/bin/run_executor_python.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-export PYTHONPATH=../lib/python
+DEFAULTPYTHONVERSION="$(python -c 'import sys; print(sys.version_info.major);')"
+export PYTHONPATH="../lib/python${DEFAULTPYTHONVERSION}"
 
 python ../examples/executor/python/executor.py cfg/executor.cfg


### PR DESCRIPTION
point to correct quickfix python lib by getting version from python in path
in case that is specified by a venv or as provided by the operating system.