### PR TITLE
Doc update - PersistMessages is Y by default

### DIFF
--- a/doc/html/configuration.html
+++ b/doc/html/configuration.html
@@ -848,9 +848,9 @@ AppDataDictionary.FIX.4.4=FIX44.xml
           to resend a message. Useful for market data streams.</td>
 
           <td>Y<br>
-          Y</td>
+          N</td>
 
-          <td>N</td>
+          <td>Y</td>
         </tr>
 
         <tr align="center" valign="middle">


### PR DESCRIPTION
Fix the default value of PersistMessages in doc. It's [set to Y by default](https://github.com/quickfix/quickfix/blob/b7c346f81a772ada7dd0bb0ea7b6a0962c8cec69/src/C%2B%2B/Session.cpp#L62), but the doc says it's N. 

Also Valid values in current version is Y<br>Y, which should be Y<br>N.