### PR TITLE
Fix python build

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(${quickfix_python_lib_name} SHARED  ${quickfix_python_SOURCES})
 
 target_include_directories(${quickfix_python_lib_name} PRIVATE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src/C++)
 
-target_link_libraries(${quickfix_python_lib_name} ${PROJECT_NAME})
+target_link_libraries(${quickfix_python_lib_name} ${PROJECT_NAME} ${PYTHON_LIBRARY})
 
 set_target_properties(${quickfix_python_lib_name} PROPERTIES VERSION ${quickfix_python_VERSION} SOVERSION ${quickfix_python_VERSION_MAJOR} PREFIX "")
 


### PR DESCRIPTION
The linux build (with python support) happens to work without specifying `${PYTHON_LIBRARY}`, but the macOS build needs it.