### PR TITLE
Using `poll` instead of `select` for sockets

### DIFF
--- a/src/C++/HttpConnection.cpp
+++ b/src/C++/HttpConnection.cpp
@@ -29,6 +29,8 @@
 #include "Session.h"
 #include "Utility.h"
 
+#include <poll.h>
+
 using namespace HTML;
 
 namespace FIX
@@ -36,8 +38,6 @@ namespace FIX
 HttpConnection::HttpConnection( int s )
 : m_socket( s )
 {
-  FD_ZERO( &m_fds );
-  FD_SET( m_socket, &m_fds );
 }
 
 bool HttpConnection::send( const std::string& msg )
@@ -46,7 +46,7 @@ bool HttpConnection::send( const std::string& msg )
 }
 
 void HttpConnection::disconnect( int error )
-{ 
+{
   if( error > 0 )
     send( HttpMessage::createResponse(error) );
 
@@ -55,13 +55,13 @@ void HttpConnection::disconnect( int error )
 
 bool HttpConnection::read()
 {
-  struct timeval timeout = { 2, 0 };
-  fd_set readset = m_fds;
+  int timeout = 2000; // 2000ms = 2 seconds
+  struct pollfd pfd = { m_socket, POLLIN | POLLPRI, 0 };
 
   try
   {
-    // Wait for input (1 second timeout)
-    int result = select( 1 + m_socket, &readset, 0, 0, &timeout );
+    // Wait for input (2 second timeout)
+    int result = poll( &pfd, 1, timeout );
 
     if( result > 0 ) // Something to read
     {
@@ -97,8 +97,8 @@ throw( SocketRecvFailed )
   {
     return m_parser.readHttpMessage( msg );
   }
-  catch ( MessageParseError& ) 
-  { 
+  catch ( MessageParseError& )
+  {
     disconnect( 400 );
   }
   return true;
@@ -114,7 +114,7 @@ void HttpConnection::processStream()
     HttpMessage request( msg );
     processRequest( request );
   }
-  catch( InvalidMessage& ) 
+  catch( InvalidMessage& )
   {
     disconnect( 400 );
     return;

--- a/src/C++/HttpConnection.h
+++ b/src/C++/HttpConnection.h
@@ -71,7 +71,6 @@ private:
   char m_buffer[BUFSIZ];
 
   HttpParser m_parser;
-  fd_set m_fds;
 };
 }
 

--- a/src/C++/SocketConnection.cpp
+++ b/src/C++/SocketConnection.cpp
@@ -30,6 +30,8 @@
 #include "Session.h"
 #include "Utility.h"
 
+#include <poll.h>
+
 namespace FIX
 {
 SocketConnection::SocketConnection( int s, Sessions sessions,
@@ -37,8 +39,6 @@ SocketConnection::SocketConnection( int s, Sessions sessions,
 : m_socket( s ), m_sendLength( 0 ),
   m_sessions(sessions), m_pSession( 0 ), m_pMonitor( pMonitor )
 {
-  FD_ZERO( &m_fds );
-  FD_SET( m_socket, &m_fds );
 }
 
 SocketConnection::SocketConnection( SocketInitiator& i,
@@ -46,10 +46,8 @@ SocketConnection::SocketConnection( SocketInitiator& i,
                                     SocketMonitor* pMonitor )
 : m_socket( s ), m_sendLength( 0 ),
   m_pSession( i.getSession( sessionID, *this ) ),
-  m_pMonitor( pMonitor ) 
+  m_pMonitor( pMonitor )
 {
-  FD_ZERO( &m_fds );
-  FD_SET( m_socket, &m_fds );
   m_sessions.insert( sessionID );
 }
 
@@ -75,11 +73,9 @@ bool SocketConnection::processQueue()
 
   if( !m_sendQueue.size() ) return true;
 
-  struct timeval timeout = { 0, 0 };
-  fd_set writeset = m_fds;
-  if( select( 1 + m_socket, 0, &writeset, 0, &timeout ) <= 0 )
-    return false;
-    
+  struct pollfd pfd = { m_socket, POLLOUT, 0 };
+  if ( poll( &pfd, 1, 0 ) <= 0 ) { return false; }
+
   const std::string& msg = m_sendQueue.front();
 
   ssize_t result = socket_send
@@ -127,12 +123,12 @@ bool SocketConnection::read( SocketAcceptor& a, SocketServer& s )
   {
     if ( !m_pSession )
     {
-      struct timeval timeout = { 1, 0 };
-      fd_set readset = m_fds;
+      int timeout = 1000; // 1000ms = 1 second
+      struct pollfd pfd = { m_socket, POLLIN | POLLPRI, 0 };
 
       while( !readMessage( msg ) )
       {
-        int result = select( 1 + m_socket, &readset, 0, 0, &timeout );
+        int result = poll( &pfd, 1, timeout );
         if( result > 0 )
           readFromSocket();
         else if( result == 0 )

--- a/src/C++/SocketConnection.h
+++ b/src/C++/SocketConnection.h
@@ -96,7 +96,6 @@ private:
   Session* m_pSession;
   SocketMonitor* m_pMonitor;
   Mutex m_mutex;
-  fd_set m_fds;
 };
 }
 

--- a/src/C++/SocketMonitor.cpp
+++ b/src/C++/SocketMonitor.cpp
@@ -44,11 +44,7 @@ SocketMonitor::SocketMonitor( int timeout )
   socket_setnonblock( m_interrupt );
   m_readSockets.insert( m_interrupt );
 
-  m_timeval.tv_sec = 0;
-  m_timeval.tv_usec = 0;
-#ifndef SELECT_DECREMENTS_TIME
   m_ticks = clock();
-#endif
 }
 
 SocketMonitor::~SocketMonitor()
@@ -101,7 +97,7 @@ bool SocketMonitor::drop( int s )
   Sockets::iterator j = m_writeSockets.find( s );
   Sockets::iterator k = m_connectSockets.find( s );
 
-  if ( i != m_readSockets.end() || 
+  if ( i != m_readSockets.end() ||
        j != m_writeSockets.end() ||
        k != m_connectSockets.end() )
   {
@@ -115,38 +111,29 @@ bool SocketMonitor::drop( int s )
   return false;
 }
 
-inline timeval* SocketMonitor::getTimeval( bool poll, double timeout )
+inline int SocketMonitor::getTimeval( bool poll, double timeout )
 {
   if ( poll )
   {
-    m_timeval.tv_sec = 0;
-    m_timeval.tv_usec = 0;
-    return &m_timeval;
+    return 0;
   }
 
   timeout = m_timeout;
 
   if ( !timeout )
     return 0;
-#ifdef SELECT_MODIFIES_TIMEVAL
-  if ( !m_timeval.tv_sec && !m_timeval.tv_usec && timeout )
-    m_timeval.tv_sec = timeout;
-  return &m_timeval;
-#else
+
   double elapsed = ( double ) ( clock() - m_ticks ) / ( double ) CLOCKS_PER_SEC;
   if ( elapsed >= timeout || elapsed == 0.0 )
   {
-    m_ticks = clock();
-    m_timeval.tv_sec = 0;
-    m_timeval.tv_usec = (long)(timeout * 1000000);
+      m_ticks = clock();
+      return ( timeout * 1000 );
   }
   else
   {
-    m_timeval.tv_sec = 0;
-    m_timeval.tv_usec = (long)( ( timeout - elapsed ) * 1000000 );
+      return ( ( timeout - elapsed ) * 1000 );
   }
-  return &m_timeval;
-#endif
+  return ( timeout * 1000 );
 }
 
 bool SocketMonitor::sleepIfEmpty( bool poll )
@@ -154,7 +141,7 @@ bool SocketMonitor::sleepIfEmpty( bool poll )
   if( poll )
     return false;
 
-  if ( m_readSockets.empty() && 
+  if ( m_readSockets.empty() &&
        m_writeSockets.empty() &&
        m_connectSockets.empty() )
   {
@@ -178,7 +165,7 @@ void SocketMonitor::unsignal( int s )
   m_writeSockets.erase( s );
 }
 
-void SocketMonitor::block( Strategy& strategy, bool poll, double timeout )
+void SocketMonitor::block( Strategy& strategy, bool should_poll, double timeout )
 {
   while ( m_dropped.size() )
   {
@@ -188,24 +175,22 @@ void SocketMonitor::block( Strategy& strategy, bool poll, double timeout )
       return ;
   }
 
-  fd_set readSet;
-  FD_ZERO( &readSet );
-  buildSet( m_readSockets, readSet );
-  fd_set writeSet;
-  FD_ZERO( &writeSet );
-  buildSet( m_connectSockets, writeSet );
-  buildSet( m_writeSockets, writeSet );
-  fd_set exceptSet;
-  FD_ZERO( &exceptSet );
-  buildSet( m_connectSockets, exceptSet );
+  int pfds_size = m_readSockets.size() +
+                  m_connectSockets.size() +
+                  m_writeSockets.size();
+  struct pollfd pfds[ pfds_size ];
+  buildSet( m_readSockets, pfds, POLLPRI | POLLIN );
+  buildSet( m_connectSockets, pfds + m_readSockets.size(), POLLOUT | POLLERR );
+  buildSet( m_writeSockets, pfds + m_readSockets.size() + m_connectSockets.size(),
+            POLLOUT );
 
-  if ( sleepIfEmpty(poll) )
+  if ( sleepIfEmpty(should_poll) )
   {
     strategy.onTimeout( *this );
     return;
   }
 
-  int result = select( FD_SETSIZE, &readSet, &writeSet, &exceptSet, getTimeval(poll, timeout) );
+  int result = poll( pfds, pfds_size, getTimeval( should_poll, timeout ) );
 
   if ( result == 0 )
   {
@@ -214,9 +199,7 @@ void SocketMonitor::block( Strategy& strategy, bool poll, double timeout )
   }
   else if ( result > 0 )
   {
-    processExceptSet( strategy, exceptSet );
-    processWriteSet( strategy, writeSet );
-    processReadSet( strategy, readSet );
+    processPollList( strategy, pfds, pfds_size );
   }
   else
   {
@@ -224,112 +207,71 @@ void SocketMonitor::block( Strategy& strategy, bool poll, double timeout )
   }
 }
 
-void SocketMonitor::processReadSet( Strategy& strategy, fd_set& readSet )
+void SocketMonitor::processRead( Strategy& strategy, int socket_fd )
 {
-#ifdef _MSC_VER
-  for ( unsigned i = 0; i < readSet.fd_count; ++i )
+  int s = socket_fd;
+  if( s == m_interrupt )
   {
-    int s = readSet.fd_array[ i ];
-    if( s == m_interrupt )
-    {
-      int socket = 0;
-      socket_recv( s, (char*)&socket, sizeof(socket) );
-      addWrite( socket );
-    }
-    else
-    {
-      strategy.onEvent( *this, s );
-    }
+    int socket = 0;
+    recv( s, (char*)&socket, sizeof(socket), 0 );
+    addWrite( socket );
   }
-#else
-    Sockets::iterator i;
-    Sockets sockets = m_readSockets;
-    for ( i = sockets.begin(); i != sockets.end(); ++i )
-    {
-      int s = *i;
-      if ( !FD_ISSET( *i, &readSet ) )
-        continue;
-      if( s == m_interrupt )
-      {
-        int socket = 0;
-        socket_recv( s, (char*)&socket, sizeof(socket) );
-        addWrite( socket );
-      }
-      else
-      {
-        strategy.onEvent( *this, s );
-      }
-    }
-#endif
+  else
+  {
+    strategy.onEvent( *this, s );
+  }
 }
 
-void SocketMonitor::processWriteSet( Strategy& strategy, fd_set& writeSet )
+void SocketMonitor::processWrite( Strategy& strategy, int socket_fd )
 {
-#ifdef _MSC_VER
-  for ( unsigned i = 0; i < writeSet.fd_count; ++i )
+  int s = socket_fd;
+  if( m_connectSockets.find(s) != m_connectSockets.end() )
   {
-    int s = writeSet.fd_array[ i ];
-    if( m_connectSockets.find(s) != m_connectSockets.end() )
-    {
-      m_connectSockets.erase( s );
-      m_readSockets.insert( s );
-      strategy.onConnect( *this, s );
-    }
-    else
-    {
-      strategy.onWrite( *this, s );
-    }
-  }
-#else
-  Sockets::iterator i;
-  Sockets sockets = m_connectSockets;
-  for( i = sockets.begin(); i != sockets.end(); ++i )
-  {
-    int s = *i;
-    if ( !FD_ISSET( *i, &writeSet ) )
-      continue;
     m_connectSockets.erase( s );
     m_readSockets.insert( s );
     strategy.onConnect( *this, s );
   }
-
-  sockets = m_writeSockets;
-  for( i = sockets.begin(); i != sockets.end(); ++i )
+  else
   {
-    int s = *i;
-    if ( !FD_ISSET( *i, &writeSet ) )
-      continue;
     strategy.onWrite( *this, s );
   }
-#endif
 }
 
-void SocketMonitor::processExceptSet( Strategy& strategy, fd_set& exceptSet )
+void SocketMonitor::processError( Strategy& strategy, int socket_fd )
 {
-#ifdef _MSC_VER
-  for ( unsigned i = 0; i < exceptSet.fd_count; ++i )
-  {
-    int s = exceptSet.fd_array[ i ];
-    strategy.onError( *this, s );
-  }
-#else
-    Sockets::iterator i;
-    Sockets sockets = m_connectSockets;
-    for ( i = sockets.begin(); i != sockets.end(); ++i )
-    {
-      int s = *i;
-      if ( !FD_ISSET( *i, &exceptSet ) )
-        continue;
-      strategy.onError( *this, s );
-    }
-#endif
+  strategy.onError( *this, socket_fd );
 }
 
-void SocketMonitor::buildSet( const Sockets& sockets, fd_set& watchSet )
+void SocketMonitor::processPollList( Strategy& strategy, struct pollfd *pfds, unsigned pfds_size )
+{
+  for ( unsigned i = 0; i < pfds_size; ++i )
+  {
+    if ( ( pfds[i].revents & POLLIN ) || ( pfds[i].revents & POLLPRI ) )
+    {
+      processRead( strategy, pfds[i].fd );
+    }
+
+    if ( ( pfds[i].revents & POLLOUT ) )
+    {
+      processWrite( strategy, pfds[i].fd );
+    }
+    if ( ( pfds[i].revents & POLLERR ) )
+    {
+      processError( strategy, pfds[i].fd );
+    }
+  }
+}
+
+void SocketMonitor::buildSet( const Sockets& sockets, struct pollfd *pfds, short events )
 {
   Sockets::const_iterator iter;
+  unsigned int i = 0;
   for ( iter = sockets.begin(); iter != sockets.end(); ++iter ) {
-    FD_SET( *iter, &watchSet );
+    pfds[i].fd = *iter;
+    pfds[i].events = events;
+    pfds[i].revents = 0;
+    i += 1;
   }
 }
+
 }

--- a/src/C++/SocketMonitor.h
+++ b/src/C++/SocketMonitor.h
@@ -40,6 +40,7 @@ typedef int socklen_t;
 #include <set>
 #include <queue>
 #include <time.h>
+#include <poll.h>
 
 namespace FIX
 {
@@ -70,19 +71,18 @@ private:
   void setsockopt();
   bool bind();
   bool listen();
-  void buildSet( const Sockets&, fd_set& );
-  inline timeval* getTimeval( bool poll, double timeout );
+  void buildSet( const Sockets&, struct pollfd *pfds, short events );
+  inline int getTimeval( bool poll, double timeout );
   inline bool sleepIfEmpty( bool poll );
 
-  void processReadSet( Strategy&, fd_set& );
-  void processWriteSet( Strategy&, fd_set& );
-  void processExceptSet( Strategy&, fd_set& );
+  void processRead( Strategy&, int socket_fd );
+  void processWrite( Strategy&, int socket_fd );
+  void processError( Strategy&, int socket_fd );
+  void processPollList( Strategy& strategy, struct pollfd *pfds,
+                        unsigned pfds_size );
 
   int m_timeout;
-  timeval m_timeval;
-#ifndef SELECT_DECREMENTS_TIME
   clock_t m_ticks;
-#endif
 
   int m_signal;
   int m_interrupt;

--- a/src/C++/ThreadedSocketConnection.cpp
+++ b/src/C++/ThreadedSocketConnection.cpp
@@ -29,6 +29,8 @@
 #include "Session.h"
 #include "Utility.h"
 
+#include <poll.h>
+
 namespace FIX
 {
 ThreadedSocketConnection::ThreadedSocketConnection
@@ -37,13 +39,11 @@ ThreadedSocketConnection::ThreadedSocketConnection
   m_sessions( sessions ), m_pSession( 0 ),
   m_disconnect( false )
 {
-  FD_ZERO( &m_fds );
-  FD_SET( m_socket, &m_fds );
 }
 
 ThreadedSocketConnection::ThreadedSocketConnection
 ( const SessionID& sessionID, int s,
-  const std::string& address, short port, 
+  const std::string& address, short port,
   Log* pLog,
   const std::string& sourceAddress, short sourcePort )
   : m_socket( s ), m_address( address ), m_port( port ),
@@ -52,8 +52,6 @@ ThreadedSocketConnection::ThreadedSocketConnection
     m_pSession( Session::lookupSession( sessionID ) ),
     m_disconnect( false )
 {
-  FD_ZERO( &m_fds );
-  FD_SET( m_socket, &m_fds );
   if ( m_pSession ) m_pSession->setResponder( this );
 }
 
@@ -89,20 +87,20 @@ bool ThreadedSocketConnection::connect()
 }
 
 void ThreadedSocketConnection::disconnect()
-{  
+{
   m_disconnect = true;
   socket_close( m_socket );
 }
 
 bool ThreadedSocketConnection::read()
 {
-  struct timeval timeout = { 1, 0 };
-  fd_set readset = m_fds;
+  int timeout = 1000; // 1000ms = 1 second
+  struct pollfd pfd = { m_socket, POLLIN | POLLPRI, 0 };
 
   try
   {
     // Wait for input (1 second timeout)
-    int result = select( 1 + m_socket, &readset, 0, 0, &timeout );
+    int result = poll( &pfd, 1, timeout );
 
     if( result > 0 ) // Something to read
     {
@@ -181,7 +179,7 @@ void ThreadedSocketConnection::processStream()
 bool ThreadedSocketConnection::setSession( const std::string& msg )
 {
   m_pSession = Session::lookupSession( msg, true );
-  if ( !m_pSession ) 
+  if ( !m_pSession )
   {
     if( m_pLog )
     {
@@ -203,7 +201,7 @@ bool ThreadedSocketConnection::setSession( const std::string& msg )
     process_sleep( 1 );
   }
 
-  if ( !m_pSession ) 
+  if ( !m_pSession )
     return false;
   if ( m_sessions.find(m_pSession->getSessionID()) == m_sessions.end() )
     return false;

--- a/src/C++/ThreadedSocketConnection.h
+++ b/src/C++/ThreadedSocketConnection.h
@@ -78,7 +78,6 @@ private:
   Sessions m_sessions;
   Session* m_pSession;
   bool m_disconnect;
-  fd_set m_fds;
 };
 }
 

--- a/src/C++/TimeRange.cpp
+++ b/src/C++/TimeRange.cpp
@@ -58,6 +58,25 @@ namespace FIX
     { m_endTime = m_startTime; }
   }
 
+  int TimeRange::getRangeStartDate( const DateTime& time,
+                                    int startDay,
+                                    const DateTime& startTime )
+  {
+    if (time.getWeekDay() > startDay)
+    {
+      return time.getJulianDate() - time.getWeekDay() + startDay;
+    }
+    else if (time.getWeekDay() < startDay)
+    {
+      return time.getJulianDate() -time.getWeekDay() + startDay - 7;
+    }
+    else
+    {
+      if (UtcTimeOnly(time) >= UtcTimeOnly(startTime)) return time.getJulianDate();
+      else return time.getJulianDate() - 7;
+    }
+  }
+
   bool TimeRange::isInRange( const DateTime& start,
                              const DateTime& end,
                              const DateTime& time )
@@ -225,9 +244,11 @@ namespace FIX
       // session start and end day are the same day, which is between these times
       else
       {
+        int time1RangeStartDate = getRangeStartDate(time1, startDay, startTime);
+        int time2RangeStartDate = getRangeStartDate(time2, startDay, startTime);
         bool time1_past_reset = time1.getWeekDay() > startDay || (time1.getWeekDay() == startDay && UtcTimeOnly(time1) >= UtcTimeOnly(startTime));
         bool time2_past_reset = time2.getWeekDay() > startDay || (time2.getWeekDay() == startDay && UtcTimeOnly(time2) >= UtcTimeOnly(startTime));
-        return time1_past_reset == time2_past_reset;
+        return time1RangeStartDate == time2RangeStartDate;
       }
 
     }

--- a/src/C++/TimeRange.cpp
+++ b/src/C++/TimeRange.cpp
@@ -168,6 +168,68 @@ namespace FIX
 
     int absoluteDay1 = time1.getJulianDate() - time1.getWeekDay();
     int absoluteDay2 = time2.getJulianDate() - time2.getWeekDay();
-    return absoluteDay1 == absoluteDay2;
+
+    if (startDay != endDay)
+    {
+      return absoluteDay1 == absoluteDay2;
+    }
+    else
+    {
+      int day1 = time1.getJulianDate();
+      int day2 = time2.getJulianDate();
+
+      // session start and end day are the same day, which is also both of these time's day
+      if (time1.getJulianDate() == time2.getJulianDate() && startDay == time1.getWeekDay())
+      {
+        auto time1_utcTimeOnly = UtcTimeOnly(time1);
+        auto time2_utcTimeOnly = UtcTimeOnly(time2);
+        auto startTime_utcTimeOnly = UtcTimeOnly(startTime);
+        auto endTime_utcTimeOnly = UtcTimeOnly(endTime);
+        bool bothBeforeEndOfRange = time1_utcTimeOnly <= endTime_utcTimeOnly && time2_utcTimeOnly <= endTime_utcTimeOnly;
+        bool bothAfterStartOfRange = time1_utcTimeOnly >= startTime_utcTimeOnly && time2_utcTimeOnly >= startTime_utcTimeOnly;
+        return bothBeforeEndOfRange || bothAfterStartOfRange;
+      }
+
+      // session start and end day are the same day, which is neither of these time's day
+      else if (day1 == day2 && startDay != time1.getWeekDay())
+      {
+        return true;
+      }
+
+      // session start and end day are 7 days apart, so times greater than 7 days apart means different range
+      else if (abs(day1-day2) > 7)
+      {
+        return false;
+      }
+
+      else if (abs(day1-day2) == 7)
+      {
+        if (time1.getWeekDay() != startDay)
+          return false;
+
+        // a week apart on start days
+        DateTime earlierTime, laterTime;
+        if (day2 > day1)
+        {
+          earlierTime = time1;
+          laterTime = time2;
+        }
+        else
+        {
+          earlierTime = time2;
+          laterTime = time1;
+        }
+        return UtcTimeOnly(earlierTime) >= UtcTimeOnly(startTime) && UtcTimeOnly(laterTime) <= UtcTimeOnly(endTime);
+      }
+
+      // session start and end day are the same day, which is between these times
+      else
+      {
+        bool time1_past_reset = time1.getWeekDay() > startDay || (time1.getWeekDay() == startDay && UtcTimeOnly(time1) >= UtcTimeOnly(startTime));
+        bool time2_past_reset = time2.getWeekDay() > startDay || (time2.getWeekDay() == startDay && UtcTimeOnly(time2) >= UtcTimeOnly(startTime));
+        return time1_past_reset == time2_past_reset;
+      }
+
+    }
   }
 }

--- a/src/C++/TimeRange.h
+++ b/src/C++/TimeRange.h
@@ -153,6 +153,10 @@ public:
   }
 
 private:
+  static int getRangeStartDate( const DateTime& time,
+                                int startDay,
+                                const DateTime& startTime );
+
   static bool isInRange( const DateTime& start,
                          const DateTime& end,
                          const DateTime& time );

--- a/src/C++/test/TimeRangeTestCase.cpp
+++ b/src/C++/test/TimeRangeTestCase.cpp
@@ -274,6 +274,20 @@ TEST(isInSameRangeWithDay)
   endDay = -1;
   CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
 
+  startDay = 5;
+  endDay = 5;
+  startTime = UtcTimeOnly(22, 28, 20);
+  endTime = UtcTimeOnly(22, 28, 5);
+  time1 = UtcTimeStamp(22, 28, 2, 16, 1, 2020); // session
+  time2 = UtcTimeStamp(22, 30, 47, 16, 1, 2020); // date
+  CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+
+  startTime = UtcTimeOnly(22, 24, 0);
+  endTime = UtcTimeOnly(22, 15, 30);
+  time1 = UtcTimeStamp(18, 15, 15, 15, 1, 2020); // session
+  time2 = UtcTimeStamp(22, 26, 20, 16, 1, 2020); // date
+  CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+
   // Session days are the same
   startDay = 1;
   endDay = 1;
@@ -306,6 +320,23 @@ TEST(isInSameRangeWithDay)
   time2 = UtcTimeStamp(9, 1, 0, 11, 12, 2006);
   CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
   time2 = UtcTimeStamp(8, 1, 0, 3, 12, 2006);
+  CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+
+  // Re-creating weekend cert reset
+  startDay = 2;
+  endDay = 2;
+  startTime = UtcTimeOnly(17, 0, 0);
+  endTime = UtcTimeOnly(16, 02, 30);
+  time1 = UtcTimeStamp(23, 4, 3, 17, 1, 2020); // 20200117-23:04:03.008 -> H M S, D M Y
+  time2 = UtcTimeStamp(6, 0, 0, 19, 1, 2020); // 20200119-06:00:00
+  CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+
+  startDay = 4;
+  endDay = 4;
+  startTime = UtcTimeOnly(17, 0, 0);
+  endTime = UtcTimeOnly(16, 02, 30);
+  time1 = UtcTimeStamp(23, 4, 3, 17, 1, 2020); // 20200117-23:04:03.008 -> H M S, D M Y
+  time2 = UtcTimeStamp(6, 0, 0, 20, 1, 2020); // 20200120-06:00:00
   CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
 }
 

--- a/src/C++/test/TimeRangeTestCase.cpp
+++ b/src/C++/test/TimeRangeTestCase.cpp
@@ -286,6 +286,27 @@ TEST(isInSameRangeWithDay)
   CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
   time2 = UtcTimeStamp(9, 1, 0, 4, 12, 2006);
   CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+
+  time1 = UtcTimeStamp(10, 1, 0, 3, 12, 2006);
+  time2 = UtcTimeStamp(9, 1, 0, 10, 12, 2006);
+  CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+  time2 = UtcTimeStamp(8, 1, 0, 10, 12, 2006);
+  CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+  time2 = UtcTimeStamp(8, 1, 0, 5, 12, 2006);
+  CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+
+  // Session days are the same, and not today
+  startDay = 2;
+  endDay = 2;
+  startTime = UtcTimeOnly(9, 1, 0);
+  endTime = UtcTimeOnly(8, 59, 0);
+  time1 = UtcTimeStamp(9, 1, 0, 3, 12, 2006); // day before swap
+  time2 = UtcTimeStamp(9, 1, 0, 5, 12, 2006);
+  CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+  time2 = UtcTimeStamp(9, 1, 0, 11, 12, 2006);
+  CHECK( !TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
+  time2 = UtcTimeStamp(8, 1, 0, 3, 12, 2006);
+  CHECK( TimeRange::isInSameRange(startTime, endTime, startDay, endDay, time1, time2) );
 }
 
 }


### PR DESCRIPTION
Switching to `poll` instead of `select` for polling sockets, in order to get around the size limit of `FD_SET` (1024).

Code adapted from: https://github.com/s10i/quickfix
