### PR TITLE
Fix typo

### DIFF
--- a/src/C++/FieldTypes.h
+++ b/src/C++/FieldTypes.h
@@ -157,9 +157,14 @@ struct DateTime
   }
 
   /// Return the microsecond portion of the time
-  inline int getMicroecond() const
+  inline int getMicrosecond() const
   {
     return (getNanosecond() / PRECISION_FACTOR[6]);
+  }
+
+  // deprecated method: use getMicrosecond instead
+  inline int getMicroecond() const {
+    return getMicrosecond();
   }
 
   /// Return the nanosecond portion of the time


### PR DESCRIPTION
Rename method: `getMicroecond` -> `getMicrosecond`

The former is maintained as a deprecated method to not break any application using it.