### PR TITLE
`removeField` generates invalid message in some cases

### DIFF
--- a/src/C++/FieldMap.cpp
+++ b/src/C++/FieldMap.cpp
@@ -248,6 +248,9 @@ int FieldMap::calculateLength( int beginStringField,
   Groups::const_iterator j;
   for ( j = m_groups.begin(); j != m_groups.end(); ++j )
   {
+    if(findTag(j->first) == m_fields.end()) {
+      continue;
+    }
     std::vector < FieldMap* > ::const_iterator k;
     for ( k = j->second.begin(); k != j->second.end(); ++k )
       result += ( *k ) ->calculateLength();
@@ -268,6 +271,9 @@ int FieldMap::calculateTotal( int checkSumField ) const
   Groups::const_iterator j;
   for ( j = m_groups.begin(); j != m_groups.end(); ++j )
   {
+    if(findTag(j->first) == m_fields.end()) {
+      continue;
+    }
     std::vector < FieldMap* > ::const_iterator k;
     for ( k = j->second.begin(); k != j->second.end(); ++k )
       result += ( *k ) ->calculateTotal();


### PR DESCRIPTION
When removing a field that has the count of repeated group members, the
message will have wrong values for bodylength and checksum.

This happens because there is an inconsistency between calculateString
and calculateLength/calculateChecksum API. calculateString ignores the
repeating group which does not have the counter field while the latter
includes them.

Sample code to demonstrate the problem

https://gist.github.com/balkierode/43759bee0fbbbe5af9f1a964dde93075