### PR TITLE
Avoid unnecessary copy of Dictionary

### DIFF
--- a/src/C++/FileLog.cpp
+++ b/src/C++/FileLog.cpp
@@ -38,7 +38,7 @@ Log* FileLogFactory::create()
     std::string path;
     std::string backupPath;
 
-    Dictionary settings = m_settings.get();
+    const Dictionary& settings = m_settings.get();
     path = settings.getString( FILE_LOG_PATH );
     backupPath = path;
     if( settings.has( FILE_LOG_BACKUP_PATH ) )
@@ -62,7 +62,7 @@ Log* FileLogFactory::create( const SessionID& s )
 
   std::string path;
   std::string backupPath;
-  Dictionary settings = m_settings.get( s );
+  const Dictionary& settings = m_settings.get( s );
   path = settings.getString( FILE_LOG_PATH );
   backupPath = path;
   if( settings.has( FILE_LOG_BACKUP_PATH ) )

--- a/src/C++/FileStore.cpp
+++ b/src/C++/FileStore.cpp
@@ -179,7 +179,7 @@ MessageStore* FileStoreFactory::create( const SessionID& s )
   if ( m_path.size() ) return new FileStore( m_path, s );
 
   std::string path;
-  Dictionary settings = m_settings.get( s );
+  const Dictionary& settings = m_settings.get( s );
   path = settings.getString( FILE_STORE_PATH );
   return new FileStore( path, s );
 }


### PR DESCRIPTION
Use const reference instead of copying the object.