### PR TITLE
Correction of repeated group.

### DIFF
--- a/src/python/quickfix50sp2.py
+++ b/src/python/quickfix50sp2.py
@@ -1029,6 +1029,24 @@ class OrderCancelReject(Message):
 		Message.__init__(self)
 		self.getHeader().setField( fix.MsgType("9") )
 
+	class NoPartyIDs(fix.Group):
+		def __init__(self):
+			order = fix.IntArray(5)
+			order[0] = 448
+			order[1] = 447
+			order[2] = 452
+			order[3] = 802
+			order[4] = 0
+			fix.Group.__init__(self, 453, 448, order)
+
+		class NoPartySubIDs(fix.Group):
+			def __init__(self):
+				order = fix.IntArray(3)
+				order[0] = 523
+				order[1] = 803
+				order[2] = 0
+				fix.Group.__init__(self, 802, 523, order)
+
 class News(Message):
 	def __init__(self):
 		Message.__init__(self)


### PR DESCRIPTION
This correction, fix the follow exception ( issue #199 ):

**Exception:**
```
Traceback (most recent call last):
  File "/home/christian/dev/<dev-code.py>", line 226, in fromApp
    msg = self.orderCancelReject(message)
  File "/home/christian/dev/<dev-code.py>", line 1677, in orderCancelReject
    group = quickfix50sp2.OrderCancelReject.NoPartyIDs()
AttributeError: type object 'OrderCancelReject' has no attribute 'NoPartyIDs'
```

**The group has a _"Parties"_ block:**
http://btobits.com/fixopaedia/fixdic50-sp2-ep/message_Order_Cancel_Reject_9_.html


