### PR TITLE
Improved compatibility with Windows x64

### DIFF
--- a/src/C++/HttpConnection.cpp
+++ b/src/C++/HttpConnection.cpp
@@ -33,7 +33,7 @@ using namespace HTML;
 
 namespace FIX
 {
-HttpConnection::HttpConnection( int s )
+HttpConnection::HttpConnection(socket_handle s )
 : m_socket( s )
 {
   FD_ZERO( &m_fds );

--- a/src/C++/HttpConnection.h
+++ b/src/C++/HttpConnection.h
@@ -37,9 +37,9 @@ class HttpMessage;
 class HttpConnection
 {
 public:
-  HttpConnection( int s );
+  HttpConnection(socket_handle s );
 
-  int getSocket() const { return m_socket; }
+  socket_handle getSocket() const { return m_socket; }
   bool read();
 
 private:
@@ -67,7 +67,7 @@ private:
   bool send( const std::string& );
   void disconnect( int error = 0 );
 
-  int m_socket;
+  socket_handle m_socket;
   char m_buffer[BUFSIZ];
 
   HttpParser m_parser;

--- a/src/C++/HttpServer.cpp
+++ b/src/C++/HttpServer.cpp
@@ -132,7 +132,7 @@ void HttpServer::onStop()
 {
 }
 
-void HttpServer::onConnect( SocketServer& server, int a, int s )
+void HttpServer::onConnect( SocketServer& server, socket_handle a, socket_handle s )
 {
   if ( !socket_isValid( s ) ) return;
   HttpConnection connection( s );
@@ -140,16 +140,16 @@ void HttpServer::onConnect( SocketServer& server, int a, int s )
   m_pServer->getMonitor().drop( s );
 }
 
-void HttpServer::onWrite( SocketServer& server, int s ) 
+void HttpServer::onWrite( SocketServer& server, socket_handle s )
 {
 }
 
-bool HttpServer::onData( SocketServer& server, int s )
+bool HttpServer::onData( SocketServer& server, socket_handle s )
 {
   return true;
 }
 
-void HttpServer::onDisconnect( SocketServer&, int s ) 
+void HttpServer::onDisconnect( SocketServer&, socket_handle s )
 {
 }
 

--- a/src/C++/HttpServer.h
+++ b/src/C++/HttpServer.h
@@ -53,10 +53,10 @@ private:
   bool onPoll();
   void onStop();
 
-  void onConnect( SocketServer&, int, int );
-  void onWrite( SocketServer&, int );
-  bool onData( SocketServer&, int );
-  void onDisconnect( SocketServer&, int );
+  void onConnect( SocketServer&, socket_handle, socket_handle);
+  void onWrite( SocketServer&, socket_handle);
+  bool onData( SocketServer&, socket_handle);
+  void onDisconnect( SocketServer&, socket_handle);
   void onError( SocketServer& );
   void onTimeout( SocketServer& );
 

--- a/src/C++/SSLSocketAcceptor.cpp
+++ b/src/C++/SSLSocketAcceptor.cpp
@@ -317,7 +317,7 @@ void SSLSocketAcceptor::onStop()
 {
 }
 
-void SSLSocketAcceptor::onConnect( SocketServer& server, int a, int s )
+void SSLSocketAcceptor::onConnect( SocketServer& server, socket_handle a, socket_handle s )
 {
   if ( !socket_isValid( s ) ) return;
   SocketConnections::iterator i = m_connections.find( s );
@@ -355,7 +355,7 @@ void SSLSocketAcceptor::onConnect( SocketServer& server, int a, int s )
     getLog()->onEvent( stream.str() );
 }
 
-void SSLSocketAcceptor::onWrite( SocketServer& server, int s )
+void SSLSocketAcceptor::onWrite( SocketServer& server, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return ;
@@ -364,7 +364,7 @@ void SSLSocketAcceptor::onWrite( SocketServer& server, int s )
     pSocketConnection->unsignal();
 }
 
-bool SSLSocketAcceptor::onData( SocketServer& server, int s )
+bool SSLSocketAcceptor::onData( SocketServer& server, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return false;
@@ -372,7 +372,7 @@ bool SSLSocketAcceptor::onData( SocketServer& server, int s )
   return pSocketConnection->read( *this, server );
 }
 
-void SSLSocketAcceptor::onDisconnect( SocketServer&, int s )
+void SSLSocketAcceptor::onDisconnect( SocketServer&, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return ;

--- a/src/C++/SSLSocketAcceptor.cpp
+++ b/src/C++/SSLSocketAcceptor.cpp
@@ -327,7 +327,7 @@ void SSLSocketAcceptor::onConnect( SocketServer& server, socket_handle a, socket
 
   SSL *ssl = SSL_new(m_ctx);
   SSL_clear(ssl);
-  BIO *sBio = BIO_new_socket(s, BIO_CLOSE);
+  BIO *sBio = BIO_new_socket(s, BIO_CLOSE); //Unfortunately OpenSSL assumes socket is int
   SSL_set_bio(ssl, sBio, sBio);
   // TODO - check this
   SSL_set_app_data(ssl, m_revocationStore);

--- a/src/C++/SSLSocketAcceptor.h
+++ b/src/C++/SSLSocketAcceptor.h
@@ -152,7 +152,7 @@ private:
 
   typedef std::set < SessionID > Sessions;
   typedef std::map < int, Sessions > PortToSessions;
-  typedef std::map < int, SSLSocketConnection* > SocketConnections;
+  typedef std::map < socket_handle, SSLSocketConnection* > SocketConnections;
 
   void onConfigure( const SessionSettings& ) throw ( ConfigError );
   void onInitialize( const SessionSettings& ) throw ( RuntimeError );
@@ -161,10 +161,10 @@ private:
   bool onPoll( double timeout );
   void onStop();
 
-  void onConnect( SocketServer&, int, int );
-  void onWrite( SocketServer&, int );
-  bool onData( SocketServer&, int );
-  void onDisconnect( SocketServer&, int );
+  void onConnect( SocketServer&, socket_handle, socket_handle);
+  void onWrite( SocketServer&, socket_handle);
+  bool onData( SocketServer&, socket_handle);
+  void onDisconnect( SocketServer&, socket_handle);
   void onError( SocketServer& );
   void onTimeout( SocketServer& );
 

--- a/src/C++/SSLSocketConnection.cpp
+++ b/src/C++/SSLSocketConnection.cpp
@@ -129,7 +129,7 @@
 
 namespace FIX
 {
-SSLSocketConnection::SSLSocketConnection(int s, SSL *ssl, Sessions sessions,
+SSLSocketConnection::SSLSocketConnection(socket_handle s, SSL *ssl, Sessions sessions,
                                     SocketMonitor* pMonitor )
 : m_socket( s ), m_ssl(ssl), m_sendLength( 0 ),
   m_sessions(sessions), m_pSession( 0 ), m_pMonitor( pMonitor )
@@ -139,7 +139,7 @@ SSLSocketConnection::SSLSocketConnection(int s, SSL *ssl, Sessions sessions,
 }
 
 SSLSocketConnection::SSLSocketConnection(SSLSocketInitiator &i,
-                                    const SessionID& sessionID, int s, SSL * ssl,
+                                    const SessionID& sessionID, socket_handle s, SSL * ssl,
                                     SocketMonitor* pMonitor )
 : m_socket( s ), m_ssl(ssl), m_sendLength( 0 ),
   m_pSession( i.getSession( sessionID, *this ) ),

--- a/src/C++/SSLSocketConnection.h
+++ b/src/C++/SSLSocketConnection.h
@@ -146,11 +146,11 @@ class SSLSocketConnection : Responder
 public:
   typedef std::set<SessionID> Sessions;
 
-  SSLSocketConnection( int s, SSL *ssl, Sessions sessions, SocketMonitor* pMonitor );
-  SSLSocketConnection( SSLSocketInitiator&, const SessionID&, int, SSL *, SocketMonitor* );
+  SSLSocketConnection( socket_handle s, SSL *ssl, Sessions sessions, SocketMonitor* pMonitor );
+  SSLSocketConnection( SSLSocketInitiator&, const SessionID&, socket_handle, SSL *, SocketMonitor* );
   virtual ~SSLSocketConnection();
 
-  int getSocket() const { return m_socket; }
+  socket_handle getSocket() const { return m_socket; }
   Session* getSession() const { return m_pSession; }
 
   bool read( SocketConnector& s );
@@ -186,7 +186,7 @@ private:
   bool send( const std::string& );
   void disconnect();
 
-  int m_socket;
+  socket_handle m_socket;
   SSL *m_ssl;
   char m_buffer[BUFSIZ];
 

--- a/src/C++/SSLSocketInitiator.h
+++ b/src/C++/SSLSocketInitiator.h
@@ -153,7 +153,7 @@ public:
   static int passwordHandleCB(char *buf, int bufsize, int verify, void *job);
 
 private:
-  typedef std::map < int, SSLSocketConnection* > SocketConnections;
+  typedef std::map < socket_handle, SSLSocketConnection* > SocketConnections;
   typedef std::map < SessionID, int > SessionToHostNum;
 
   void onConfigure( const SessionSettings& ) throw ( ConfigError );
@@ -164,10 +164,10 @@ private:
   void onStop();
 
   void doConnect( const SessionID&, const Dictionary& d );
-  void onConnect( SocketConnector&, int );
-  void onWrite( SocketConnector&, int );
-  bool onData( SocketConnector&, int );
-  void onDisconnect( SocketConnector&, int );
+  void onConnect( SocketConnector&, socket_handle);
+  void onWrite( SocketConnector&, socket_handle);
+  bool onData( SocketConnector&, socket_handle);
+  void onDisconnect( SocketConnector&, socket_handle);
   void onError( SocketConnector& );
   void onTimeout( SocketConnector& );
 

--- a/src/C++/SSLSocketInitiator.h
+++ b/src/C++/SSLSocketInitiator.h
@@ -170,7 +170,7 @@ private:
   void onDisconnect( SocketConnector&, socket_handle);
   void onError( SocketConnector& );
   void onTimeout( SocketConnector& );
-
+  bool handshakeSSL(SSL* ssl);
   void getHost( const SessionID&, const Dictionary&, std::string&, short&, std::string&, short& );
 
   SessionToHostNum m_sessionToHostNum;

--- a/src/C++/SocketAcceptor.cpp
+++ b/src/C++/SocketAcceptor.cpp
@@ -163,7 +163,7 @@ void SocketAcceptor::onStop()
 {
 }
 
-void SocketAcceptor::onConnect( SocketServer& server, int a, int s )
+void SocketAcceptor::onConnect( SocketServer& server, socket_handle a, socket_handle s )
 {
   if ( !socket_isValid( s ) ) return;
   SocketConnections::iterator i = m_connections.find( s );
@@ -179,7 +179,7 @@ void SocketAcceptor::onConnect( SocketServer& server, int a, int s )
     getLog()->onEvent( stream.str() );
 }
 
-void SocketAcceptor::onWrite( SocketServer& server, int s )
+void SocketAcceptor::onWrite( SocketServer& server, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return ;
@@ -188,7 +188,7 @@ void SocketAcceptor::onWrite( SocketServer& server, int s )
     pSocketConnection->unsignal();
 }
 
-bool SocketAcceptor::onData( SocketServer& server, int s )
+bool SocketAcceptor::onData( SocketServer& server, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return false;
@@ -196,7 +196,7 @@ bool SocketAcceptor::onData( SocketServer& server, int s )
   return pSocketConnection->read( *this, server );
 }
 
-void SocketAcceptor::onDisconnect( SocketServer&, int s )
+void SocketAcceptor::onDisconnect( SocketServer&, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return ;

--- a/src/C++/SocketAcceptor.h
+++ b/src/C++/SocketAcceptor.h
@@ -49,7 +49,7 @@ private:
 
   typedef std::set < SessionID > Sessions;
   typedef std::map < int, Sessions > PortToSessions;
-  typedef std::map < int, SocketConnection* > SocketConnections;
+  typedef std::map < socket_handle, SocketConnection* > SocketConnections;
 
   void onConfigure( const SessionSettings& ) throw ( ConfigError );
   void onInitialize( const SessionSettings& ) throw ( RuntimeError );
@@ -58,10 +58,10 @@ private:
   bool onPoll( double timeout );
   void onStop();
 
-  void onConnect( SocketServer&, int, int );
-  void onWrite( SocketServer&, int );
-  bool onData( SocketServer&, int );
-  void onDisconnect( SocketServer&, int );
+  void onConnect( SocketServer&, socket_handle, socket_handle );
+  void onWrite( SocketServer&, socket_handle );
+  bool onData( SocketServer&, socket_handle );
+  void onDisconnect( SocketServer&, socket_handle );
   void onError( SocketServer& );
   void onTimeout( SocketServer& );
 

--- a/src/C++/SocketConnection.cpp
+++ b/src/C++/SocketConnection.cpp
@@ -32,7 +32,7 @@
 
 namespace FIX
 {
-SocketConnection::SocketConnection( int s, Sessions sessions,
+SocketConnection::SocketConnection(socket_handle s, Sessions sessions,
                                     SocketMonitor* pMonitor )
 : m_socket( s ), m_sendLength( 0 ),
   m_sessions(sessions), m_pSession( 0 ), m_pMonitor( pMonitor )
@@ -42,7 +42,7 @@ SocketConnection::SocketConnection( int s, Sessions sessions,
 }
 
 SocketConnection::SocketConnection( SocketInitiator& i,
-                                    const SessionID& sessionID, int s,
+                                    const SessionID& sessionID, socket_handle s,
                                     SocketMonitor* pMonitor )
 : m_socket( s ), m_sendLength( 0 ),
   m_pSession( i.getSession( sessionID, *this ) ),

--- a/src/C++/SocketConnection.h
+++ b/src/C++/SocketConnection.h
@@ -48,11 +48,11 @@ class SocketConnection : Responder
 public:
   typedef std::set<SessionID> Sessions;
 
-  SocketConnection( int s, Sessions sessions, SocketMonitor* pMonitor );
-  SocketConnection( SocketInitiator&, const SessionID&, int, SocketMonitor* );
+  SocketConnection( socket_handle s, Sessions sessions, SocketMonitor* pMonitor );
+  SocketConnection( SocketInitiator&, const SessionID&, socket_handle, SocketMonitor* );
   virtual ~SocketConnection();
 
-  int getSocket() const { return m_socket; }
+  socket_handle getSocket() const { return m_socket; }
   Session* getSession() const { return m_pSession; }
 
   bool read( SocketConnector& s );
@@ -86,7 +86,7 @@ private:
   bool send( const std::string& );
   void disconnect();
 
-  int m_socket;
+  socket_handle m_socket;
   char m_buffer[BUFSIZ];
 
   Parser m_parser;

--- a/src/C++/SocketConnector.cpp
+++ b/src/C++/SocketConnector.cpp
@@ -44,23 +44,23 @@ public:
 : m_connector( connector ), m_strategy( strategy ) {}
 
 private:
-  void onConnect( SocketMonitor&, int socket )
+  void onConnect( SocketMonitor&, socket_handle socket )
   {    
     m_strategy.onConnect( m_connector, socket );
   }
 
-  void onWrite( SocketMonitor&, int socket )
+  void onWrite( SocketMonitor&, socket_handle socket )
   {
     m_strategy.onWrite( m_connector, socket );
   }
 
-  void onEvent( SocketMonitor&, int socket )
+  void onEvent( SocketMonitor&, socket_handle socket )
   {
     if( !m_strategy.onData( m_connector, socket ) )
       m_strategy.onDisconnect( m_connector, socket );
   }
 
-  void onError( SocketMonitor&, int socket )
+  void onError( SocketMonitor&, socket_handle socket )
   {
     m_strategy.onDisconnect( m_connector, socket );
   }
@@ -82,13 +82,13 @@ private:
 SocketConnector::SocketConnector( int timeout )
 : m_monitor( timeout ) {}
 
-int SocketConnector::connect( const std::string& address, int port, bool noDelay,
+socket_handle SocketConnector::connect( const std::string& address, int port, bool noDelay,
                               int sendBufSize, int rcvBufSize,
                               const std::string& sourceAddress, int sourcePort)
 {
-  int socket = socket_createConnector();
+  socket_handle socket = socket_createConnector();
 
-  if ( socket != -1 )
+  if ( socket != INVALID_SOCKET_HANDLE )
   {
     if( noDelay )
       socket_setsockopt( socket, TCP_NODELAY );
@@ -104,10 +104,10 @@ int SocketConnector::connect( const std::string& address, int port, bool noDelay
   return socket;
 }
 
-int SocketConnector::connect( const std::string& address, int port, bool noDelay, 
+socket_handle SocketConnector::connect( const std::string& address, int port, bool noDelay,
                               int sendBufSize, int rcvBufSize, Strategy& strategy )
 {
-  int socket = connect( address, port, noDelay, sendBufSize, rcvBufSize, "", 0);
+  socket_handle socket = connect( address, port, noDelay, sendBufSize, rcvBufSize, "", 0);
   return socket;
 }
 

--- a/src/C++/SocketConnector.h
+++ b/src/C++/SocketConnector.h
@@ -39,10 +39,10 @@ public:
 
   SocketConnector( int timeout = 0 );
 
-  int connect( const std::string& address, int port, bool noDelay,
+  socket_handle connect( const std::string& address, int port, bool noDelay,
                  int sendBufSize, int rcvBufSize,
                  const std::string& sourceAddress = "", int sourcePort = 0);
-  int connect( const std::string& address, int port, bool noDelay, 
+  socket_handle connect( const std::string& address, int port, bool noDelay,
                int sendBufSize, int rcvBufSize, Strategy& );
   void block( Strategy& strategy, bool poll = 0, double timeout = 0.0 );
   SocketMonitor& getMonitor() { return m_monitor; }
@@ -55,10 +55,10 @@ public:
   {
   public:
     virtual ~Strategy() {}
-    virtual void onConnect( SocketConnector&, int socket ) = 0;
-    virtual void onWrite( SocketConnector&, int socket ) = 0;
-    virtual bool onData( SocketConnector&, int socket ) = 0;
-    virtual void onDisconnect( SocketConnector&, int socket ) = 0;
+    virtual void onConnect( SocketConnector&, socket_handle socket ) = 0;
+    virtual void onWrite( SocketConnector&, socket_handle socket ) = 0;
+    virtual bool onData( SocketConnector&, socket_handle socket ) = 0;
+    virtual void onDisconnect( SocketConnector&, socket_handle socket ) = 0;
     virtual void onError( SocketConnector& ) = 0;
     virtual void onTimeout( SocketConnector& ) {};
   };

--- a/src/C++/SocketInitiator.cpp
+++ b/src/C++/SocketInitiator.cpp
@@ -145,7 +145,7 @@ void SocketInitiator::doConnect( const SessionID& s, const Dictionary& d )
     getHost( s, d, address, port, sourceAddress, sourcePort );
 
     log->onEvent( "Connecting to " + address + " on port " + IntConvertor::convert((unsigned short)port) + " (Source " + sourceAddress + ":" + IntConvertor::convert((unsigned short)sourcePort) + ")");
-    int result = m_connector.connect( address, port, m_noDelay, m_sendBufSize, m_rcvBufSize, sourceAddress, sourcePort );
+    socket_handle result = m_connector.connect( address, port, m_noDelay, m_sendBufSize, m_rcvBufSize, sourceAddress, sourcePort );
     setPending( s );
 
     m_pendingConnections[ result ] 
@@ -154,7 +154,7 @@ void SocketInitiator::doConnect( const SessionID& s, const Dictionary& d )
   catch ( std::exception& ) {}
 }
 
-void SocketInitiator::onConnect( SocketConnector&, int s )
+void SocketInitiator::onConnect( SocketConnector&, socket_handle s )
 {
   SocketConnections::iterator i = m_pendingConnections.find( s );
   if( i == m_pendingConnections.end() ) return;
@@ -166,7 +166,7 @@ void SocketInitiator::onConnect( SocketConnector&, int s )
   pSocketConnection->onTimeout();
 }
 
-void SocketInitiator::onWrite( SocketConnector& connector, int s )
+void SocketInitiator::onWrite( SocketConnector& connector, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return ;
@@ -175,7 +175,7 @@ void SocketInitiator::onWrite( SocketConnector& connector, int s )
     pSocketConnection->unsignal();
 }
 
-bool SocketInitiator::onData( SocketConnector& connector, int s )
+bool SocketInitiator::onData( SocketConnector& connector, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   if ( i == m_connections.end() ) return false;
@@ -183,7 +183,7 @@ bool SocketInitiator::onData( SocketConnector& connector, int s )
   return pSocketConnection->read( connector );
 }
 
-void SocketInitiator::onDisconnect( SocketConnector&, int s )
+void SocketInitiator::onDisconnect( SocketConnector&, socket_handle s )
 {
   SocketConnections::iterator i = m_connections.find( s );
   SocketConnections::iterator j = m_pendingConnections.find( s );

--- a/src/C++/SocketInitiator.h
+++ b/src/C++/SocketInitiator.h
@@ -44,7 +44,7 @@ public:
   virtual ~SocketInitiator();
 
 private:
-  typedef std::map < int, SocketConnection* > SocketConnections;
+  typedef std::map < socket_handle, SocketConnection* > SocketConnections;
   typedef std::map < SessionID, int > SessionToHostNum;
 
   void onConfigure( const SessionSettings& ) throw ( ConfigError );
@@ -55,10 +55,10 @@ private:
   void onStop();
 
   void doConnect( const SessionID&, const Dictionary& d );
-  void onConnect( SocketConnector&, int );
-  void onWrite( SocketConnector&, int );
-  bool onData( SocketConnector&, int );
-  void onDisconnect( SocketConnector&, int );
+  void onConnect( SocketConnector&, socket_handle);
+  void onWrite( SocketConnector&, socket_handle);
+  bool onData( SocketConnector&, socket_handle);
+  void onDisconnect( SocketConnector&, socket_handle);
   void onError( SocketConnector& );
   void onTimeout( SocketConnector& );
 

--- a/src/C++/SocketMonitor.cpp
+++ b/src/C++/SocketMonitor.cpp
@@ -37,7 +37,7 @@ SocketMonitor::SocketMonitor( int timeout )
 {
   socket_init();
 
-  std::pair<int, int> sockets = socket_createpair();
+  std::pair<socket_handle, socket_handle> sockets = socket_createpair();
   m_signal = sockets.first;
   m_interrupt = sockets.second;
   socket_setnonblock( m_signal );
@@ -62,7 +62,7 @@ SocketMonitor::~SocketMonitor()
   socket_term();
 }
 
-bool SocketMonitor::addConnect( int s )
+bool SocketMonitor::addConnect(socket_handle s )
 {
   socket_setnonblock( s );
   Sockets::iterator i = m_connectSockets.find( s );
@@ -72,7 +72,7 @@ bool SocketMonitor::addConnect( int s )
   return true;
 }
 
-bool SocketMonitor::addRead( int s )
+bool SocketMonitor::addRead(socket_handle s )
 {
   socket_setnonblock( s );
   Sockets::iterator i = m_readSockets.find( s );
@@ -82,7 +82,7 @@ bool SocketMonitor::addRead( int s )
   return true;
 }
 
-bool SocketMonitor::addWrite( int s )
+bool SocketMonitor::addWrite(socket_handle s )
 {
   if( m_readSockets.find(s) == m_readSockets.end() )
     return false;
@@ -95,7 +95,7 @@ bool SocketMonitor::addWrite( int s )
   return true;
 }
 
-bool SocketMonitor::drop( int s )
+bool SocketMonitor::drop(socket_handle s )
 {
   Sockets::iterator i = m_readSockets.find( s );
   Sockets::iterator j = m_writeSockets.find( s );
@@ -165,12 +165,12 @@ bool SocketMonitor::sleepIfEmpty( bool poll )
     return false;
 }
 
-void SocketMonitor::signal( int socket )
+void SocketMonitor::signal(socket_handle socket )
 {
   socket_send( m_signal, (char*)&socket, sizeof(socket) );
 }
 
-void SocketMonitor::unsignal( int s )
+void SocketMonitor::unsignal(socket_handle s )
 {
   Sockets::iterator i = m_writeSockets.find( s );
   if( i == m_writeSockets.end() ) return;
@@ -229,10 +229,10 @@ void SocketMonitor::processReadSet( Strategy& strategy, fd_set& readSet )
 #ifdef _MSC_VER
   for ( unsigned i = 0; i < readSet.fd_count; ++i )
   {
-    int s = readSet.fd_array[ i ];
+    socket_handle s = readSet.fd_array[ i ];
     if( s == m_interrupt )
     {
-      int socket = 0;
+      socket_handle socket = 0;
       socket_recv( s, (char*)&socket, sizeof(socket) );
       addWrite( socket );
     }
@@ -246,12 +246,12 @@ void SocketMonitor::processReadSet( Strategy& strategy, fd_set& readSet )
     Sockets sockets = m_readSockets;
     for ( i = sockets.begin(); i != sockets.end(); ++i )
     {
-      int s = *i;
+      socket_handle s = *i;
       if ( !FD_ISSET( *i, &readSet ) )
         continue;
       if( s == m_interrupt )
       {
-        int socket = 0;
+        socket_handle socket = 0;
         socket_recv( s, (char*)&socket, sizeof(socket) );
         addWrite( socket );
       }
@@ -268,7 +268,7 @@ void SocketMonitor::processWriteSet( Strategy& strategy, fd_set& writeSet )
 #ifdef _MSC_VER
   for ( unsigned i = 0; i < writeSet.fd_count; ++i )
   {
-    int s = writeSet.fd_array[ i ];
+    socket_handle s = writeSet.fd_array[ i ];
     if( m_connectSockets.find(s) != m_connectSockets.end() )
     {
       m_connectSockets.erase( s );
@@ -285,7 +285,7 @@ void SocketMonitor::processWriteSet( Strategy& strategy, fd_set& writeSet )
   Sockets sockets = m_connectSockets;
   for( i = sockets.begin(); i != sockets.end(); ++i )
   {
-    int s = *i;
+    socket_handle s = *i;
     if ( !FD_ISSET( *i, &writeSet ) )
       continue;
     m_connectSockets.erase( s );
@@ -296,7 +296,7 @@ void SocketMonitor::processWriteSet( Strategy& strategy, fd_set& writeSet )
   sockets = m_writeSockets;
   for( i = sockets.begin(); i != sockets.end(); ++i )
   {
-    int s = *i;
+    socket_handle s = *i;
     if ( !FD_ISSET( *i, &writeSet ) )
       continue;
     strategy.onWrite( *this, s );
@@ -309,7 +309,7 @@ void SocketMonitor::processExceptSet( Strategy& strategy, fd_set& exceptSet )
 #ifdef _MSC_VER
   for ( unsigned i = 0; i < exceptSet.fd_count; ++i )
   {
-    int s = exceptSet.fd_array[ i ];
+    socket_handle s = exceptSet.fd_array[ i ];
     strategy.onError( *this, s );
   }
 #else
@@ -317,7 +317,7 @@ void SocketMonitor::processExceptSet( Strategy& strategy, fd_set& exceptSet )
     Sockets sockets = m_connectSockets;
     for ( i = sockets.begin(); i != sockets.end(); ++i )
     {
-      int s = *i;
+      socket_handle s = *i;
       if ( !FD_ISSET( *i, &exceptSet ) )
         continue;
       strategy.onError( *this, s );

--- a/src/C++/SocketMonitor.h
+++ b/src/C++/SocketMonitor.h
@@ -41,6 +41,8 @@ typedef int socklen_t;
 #include <queue>
 #include <time.h>
 
+#include "Utility.h"
+
 namespace FIX
 {
 /// Monitors events on a collection of sockets.
@@ -52,20 +54,20 @@ public:
   SocketMonitor( int timeout = 0 );
   virtual ~SocketMonitor();
 
-  bool addConnect( int socket );
-  bool addRead( int socket );
-  bool addWrite( int socket );
-  bool drop( int socket );
-  void signal( int socket );
-  void unsignal( int socket );
+  bool addConnect(socket_handle socket );
+  bool addRead(socket_handle socket );
+  bool addWrite(socket_handle socket );
+  bool drop(socket_handle socket );
+  void signal(socket_handle socket );
+  void unsignal(socket_handle socket );
   void block( Strategy& strategy, bool poll = 0, double timeout = 0.0 );
 
   size_t numSockets() 
   { return m_readSockets.size() - 1; }
 
 private:
-  typedef std::set < int > Sockets;
-  typedef std::queue < int > Queue;
+  typedef std::set < socket_handle > Sockets;
+  typedef std::queue < socket_handle > Queue;
 
   void setsockopt();
   bool bind();
@@ -84,8 +86,8 @@ private:
   clock_t m_ticks;
 #endif
 
-  int m_signal;
-  int m_interrupt;
+  socket_handle m_signal;
+  socket_handle m_interrupt;
   Sockets m_connectSockets;
   Sockets m_readSockets;
   Sockets m_writeSockets;
@@ -97,10 +99,10 @@ public:
   public:
     virtual ~Strategy()
     {}
-    virtual void onConnect( SocketMonitor&, int socket ) = 0;
-    virtual void onEvent( SocketMonitor&, int socket ) = 0;
-    virtual void onWrite( SocketMonitor&, int socket ) = 0;
-    virtual void onError( SocketMonitor&, int socket ) = 0;
+    virtual void onConnect( SocketMonitor&, socket_handle socket ) = 0;
+    virtual void onEvent( SocketMonitor&, socket_handle socket ) = 0;
+    virtual void onWrite( SocketMonitor&, socket_handle socket ) = 0;
+    virtual void onError( SocketMonitor&, socket_handle socket ) = 0;
     virtual void onError( SocketMonitor& ) = 0;
     virtual void onTimeout( SocketMonitor& )
   {}}

--- a/src/C++/SocketServer.cpp
+++ b/src/C++/SocketServer.cpp
@@ -40,16 +40,16 @@ namespace FIX
 class ServerWrapper : public SocketMonitor::Strategy
 {
 public:
-  ServerWrapper( std::set<int> sockets, SocketServer& server,
+  ServerWrapper( std::set<socket_handle> sockets, SocketServer& server,
                  SocketServer::Strategy& strategy )
 : m_sockets( sockets ), m_server( server ), m_strategy( strategy ) {}
 
 private:
-  void onConnect( SocketMonitor&, int socket )
+  void onConnect( SocketMonitor&, socket_handle socket )
   {
   }
 
-  void onEvent( SocketMonitor& monitor, int socket )
+  void onEvent( SocketMonitor& monitor, socket_handle socket )
   {
     if( m_sockets.find(socket) != m_sockets.end() )
     {
@@ -62,12 +62,12 @@ private:
     }
   }
 
-  void onWrite( SocketMonitor&, int socket )
+  void onWrite( SocketMonitor&, socket_handle socket )
   {
     m_strategy.onWrite( m_server, socket );
   }
 
-  void onError( SocketMonitor& monitor, int socket )
+  void onError( SocketMonitor& monitor, socket_handle socket )
   {
     m_strategy.onDisconnect( m_server, socket );
     monitor.drop( socket );
@@ -83,7 +83,7 @@ private:
     m_strategy.onTimeout( m_server );
   };
 
-  typedef std::set<int>
+  typedef std::set<socket_handle>
     Sockets;
 
   Sockets m_sockets;
@@ -94,15 +94,15 @@ private:
 SocketServer::SocketServer( int timeout )
 : m_monitor( timeout ) {}
 
-int SocketServer::add( int port, bool reuse, bool noDelay, 
+socket_handle SocketServer::add( int port, bool reuse, bool noDelay,
                        int sendBufSize, int rcvBufSize )
   throw( SocketException& )
 {
   if( m_portToInfo.find(port) != m_portToInfo.end() )
     return m_portToInfo[port].m_socket;
 
-  int socket = socket_createAcceptor( port, reuse );
-  if( socket < 0 )
+  socket_handle socket = socket_createAcceptor( port, reuse );
+  if( socket == INVALID_SOCKET_HANDLE)
     throw SocketException();
   if( noDelay )
     socket_setsockopt( socket, TCP_NODELAY );
@@ -118,18 +118,18 @@ int SocketServer::add( int port, bool reuse, bool noDelay,
   return socket;
 }
 
-int SocketServer::accept( int socket )
+socket_handle SocketServer::accept(socket_handle socket )
 {
   SocketInfo info = m_socketToInfo[socket];
 
-  int result = socket_accept( socket );
+  socket_handle result = socket_accept( socket );
   if( info.m_noDelay )
     socket_setsockopt( result, TCP_NODELAY );
   if( info.m_sendBufSize )
     socket_setsockopt( result, SO_SNDBUF, info.m_sendBufSize );
   if( info.m_rcvBufSize )
     socket_setsockopt( result, SO_RCVBUF, info.m_rcvBufSize );
-  if ( result >= 0 )
+  if ( result != INVALID_SOCKET_HANDLE)
     m_monitor.addConnect( result );
   return result;
 }
@@ -139,7 +139,7 @@ void SocketServer::close()
   SocketToInfo::iterator i = m_socketToInfo.begin();
   for( ; i != m_socketToInfo.end(); ++i )
   {
-    int s = i->first;
+    socket_handle s = i->first;
     socket_close( s );
     socket_invalidate( s );
   }
@@ -147,7 +147,7 @@ void SocketServer::close()
 
 bool SocketServer::block( Strategy& strategy, bool poll, double timeout )
 {
-  std::set<int> sockets;
+  std::set<socket_handle> sockets;
   SocketToInfo::iterator i = m_socketToInfo.begin();
   for( ; i != m_socketToInfo.end(); ++i )
   {
@@ -161,16 +161,16 @@ bool SocketServer::block( Strategy& strategy, bool poll, double timeout )
   return true;
 }
 
-int SocketServer::socketToPort( int socket )
+int SocketServer::socketToPort(socket_handle socket )
 {
   SocketToInfo::iterator find = m_socketToInfo.find( socket );
   if( find == m_socketToInfo.end() ) return 0;
   return find->second.m_port;
 }
  
-int SocketServer::portToSocket( int port )
+socket_handle SocketServer::portToSocket( int port )
 {
-  SocketToInfo::iterator find = m_portToInfo.find( port );
+  PortToInfo::iterator find = m_portToInfo.find( port );
   if( find == m_portToInfo.end() ) return 0;
   return find->second.m_socket;
 }

--- a/src/C++/SocketServer.h
+++ b/src/C++/SocketServer.h
@@ -38,14 +38,14 @@ namespace FIX
 struct SocketInfo
 {
   SocketInfo()
-  : m_socket( -1 ), m_port( 0 ), m_noDelay( false ),
+  : m_socket( INVALID_SOCKET_HANDLE ), m_port( 0 ), m_noDelay( false ),
     m_sendBufSize( 0 ), m_rcvBufSize( 0 ) {}
   
-  SocketInfo( int socket, short port, bool noDelay, int sendBufSize, int rcvBufSize )
+  SocketInfo(socket_handle socket, short port, bool noDelay, int sendBufSize, int rcvBufSize )
   : m_socket( socket ), m_port( port ), m_noDelay( noDelay ), 
     m_sendBufSize( sendBufSize ), m_rcvBufSize( rcvBufSize ) {}
 
-  int m_socket;
+  socket_handle m_socket;
   short m_port;
   bool m_noDelay;
   int m_sendBufSize;
@@ -60,20 +60,20 @@ public:
 
   SocketServer( int timeout = 0 );
 
-  int add( int port, bool reuse = false, bool noDelay = false, 
+  socket_handle add( int port, bool reuse = false, bool noDelay = false,
            int sendBufSize = 0, int rcvBufSize = 0 ) throw( SocketException& );
-  int accept( int socket );
+  socket_handle accept(socket_handle socket );
   void close();
   bool block( Strategy& strategy, bool poll = 0, double timeout = 0.0 );
 
   size_t numConnections() { return m_monitor.numSockets() - 1; }
   SocketMonitor& getMonitor() { return m_monitor; }
 
-  int socketToPort( int socket );
-  int portToSocket( int port );
+  int socketToPort(socket_handle socket );
+  socket_handle portToSocket( int port );
 
 private:
-  typedef std::map<int, SocketInfo>
+  typedef std::map<socket_handle, SocketInfo>
     SocketToInfo;
   typedef std::map<int, SocketInfo>
     PortToInfo;
@@ -87,10 +87,10 @@ public:
   {
   public:
     virtual ~Strategy() {}
-    virtual void onConnect( SocketServer&, int acceptSocket, int socket ) = 0;
-    virtual void onWrite( SocketServer&, int socket ) = 0;
-    virtual bool onData( SocketServer&, int socket ) = 0;
-    virtual void onDisconnect( SocketServer&, int socket ) = 0;
+    virtual void onConnect( SocketServer&, socket_handle acceptSocket, socket_handle socket ) = 0;
+    virtual void onWrite( SocketServer&, socket_handle socket ) = 0;
+    virtual bool onData( SocketServer&, socket_handle socket ) = 0;
+    virtual void onDisconnect( SocketServer&, socket_handle socket ) = 0;
     virtual void onError( SocketServer& ) = 0;
     virtual void onTimeout( SocketServer& ) {};
   };

--- a/src/C++/ThreadedSSLSocketAcceptor.cpp
+++ b/src/C++/ThreadedSSLSocketAcceptor.cpp
@@ -346,7 +346,7 @@ THREAD_PROC ThreadedSSLSocketAcceptor::socketAcceptorThread(void *p)
   AcceptorThreadInfo *info = reinterpret_cast< AcceptorThreadInfo * >(p);
 
   ThreadedSSLSocketAcceptor *pAcceptor = info->m_pAcceptor;
-  int s = info->m_socket;
+  socket_handle s = info->m_socket;
   int port = info->m_port;
   delete info;
 
@@ -373,7 +373,7 @@ THREAD_PROC ThreadedSSLSocketAcceptor::socketAcceptorThread(void *p)
     ThreadedSSLSocketConnection *pConnection = new ThreadedSSLSocketConnection(
         socket, ssl, sessions, pAcceptor->getLog());
     SSL_clear(ssl);
-    BIO *sBio = BIO_new_socket(socket, BIO_CLOSE);
+    BIO *sBio = BIO_new_socket(socket, BIO_CLOSE); //unfortunately OpenSSL uses int as socket handle
     SSL_set_bio(ssl, sBio, sBio);
     // TODO - check this
     SSL_set_app_data(ssl, pAcceptor->revocationStore());

--- a/src/C++/ThreadedSSLSocketAcceptor.cpp
+++ b/src/C++/ThreadedSSLSocketAcceptor.cpp
@@ -252,8 +252,8 @@ void ThreadedSSLSocketAcceptor::onInitialize(const SessionSettings &s) throw(
                                ? settings.getInt(SOCKET_RECEIVE_BUFFER_SIZE)
                                : 0;
 
-    int socket = socket_createAcceptor(port, reuseAddress);
-    if (socket < 0)
+    socket_handle socket = socket_createAcceptor(port, reuseAddress);
+    if (socket == INVALID_SOCKET_HANDLE)
     {
       SocketException e;
       socket_close(socket);
@@ -357,8 +357,8 @@ THREAD_PROC ThreadedSSLSocketAcceptor::socketAcceptorThread(void *p)
   socket_getsockopt(s, SO_SNDBUF, sendBufSize);
   socket_getsockopt(s, SO_RCVBUF, rcvBufSize);
 
-  int socket = 0;
-  while ((!pAcceptor->isStopped() && (socket = socket_accept(s)) >= 0))
+  socket_handle socket = 0;
+  while ((!pAcceptor->isStopped() && (socket = socket_accept(s)) != INVALID_SOCKET_HANDLE))
   {
     if (noDelay)
       socket_setsockopt(socket, TCP_NODELAY);
@@ -418,7 +418,7 @@ THREAD_PROC ThreadedSSLSocketAcceptor::socketConnectionThread(void *p)
   ThreadedSSLSocketConnection *pConnection = info->m_pConnection;
   delete info;
 
-  int socket = pConnection->getSocket();
+  socket_handle socket = pConnection->getSocket();
 
   if (acceptSSLConnection(pConnection->getSocket(), pConnection->sslObject(), pAcceptor->getLog(), pAcceptor->m_verify) != 0)
   {

--- a/src/C++/ThreadedSSLSocketAcceptor.h
+++ b/src/C++/ThreadedSSLSocketAcceptor.h
@@ -151,14 +151,14 @@ public:
 private:
   struct AcceptorThreadInfo
   {
-    AcceptorThreadInfo(ThreadedSSLSocketAcceptor *pAcceptor, int socket,
+    AcceptorThreadInfo(ThreadedSSLSocketAcceptor *pAcceptor, socket_handle socket,
                        int port)
         : m_pAcceptor(pAcceptor), m_socket(socket), m_port(port)
     {
     }
 
     ThreadedSSLSocketAcceptor *m_pAcceptor;
-    int m_socket;
+    socket_handle m_socket;
     int m_port;
   };
 
@@ -176,11 +176,11 @@ private:
 
   bool readSettings(const SessionSettings &);
 
-  typedef std::set< int > Sockets;
+  typedef std::set< socket_handle > Sockets;
   typedef std::set< SessionID > Sessions;
   typedef std::map< int, Sessions > PortToSessions;
-  typedef std::map< int, int > SocketToPort;
-  typedef std::pair< int, SSL * > SocketKey;
+  typedef std::map< socket_handle, int > SocketToPort;
+  typedef std::pair< socket_handle, SSL * > SocketKey;
   typedef std::map< SocketKey, thread_id > SocketToThread;
 
   void onConfigure(const SessionSettings &) throw(ConfigError);

--- a/src/C++/ThreadedSSLSocketConnection.cpp
+++ b/src/C++/ThreadedSSLSocketConnection.cpp
@@ -128,7 +128,7 @@
 
 namespace FIX
 {
-ThreadedSSLSocketConnection::ThreadedSSLSocketConnection(int s, SSL *ssl,
+ThreadedSSLSocketConnection::ThreadedSSLSocketConnection(socket_handle s, SSL *ssl,
                                                          Sessions sessions,
                                                          Log *pLog)
     : m_socket(s), m_ssl(ssl), m_pLog(pLog), m_sessions(sessions),
@@ -139,7 +139,7 @@ ThreadedSSLSocketConnection::ThreadedSSLSocketConnection(int s, SSL *ssl,
 }
 
 ThreadedSSLSocketConnection::ThreadedSSLSocketConnection(
-    const SessionID &sessionID, int s, SSL *ssl, const std::string &address,
+    const SessionID &sessionID, socket_handle s, SSL *ssl, const std::string &address,
     short port, Log *pLog)
     : m_socket(s), m_ssl(ssl), m_address(address), m_port(port), m_pLog(pLog),
       m_pSession(Session::lookupSession(sessionID)), m_disconnect(false)

--- a/src/C++/ThreadedSSLSocketConnection.h
+++ b/src/C++/ThreadedSSLSocketConnection.h
@@ -145,28 +145,28 @@ class ThreadedSSLSocketConnection : Responder
 public:
   typedef std::set< SessionID > Sessions;
 
-  ThreadedSSLSocketConnection(int s, SSL *ssl, Sessions sessions, Log *pLog);
-  ThreadedSSLSocketConnection(const SessionID &, int s, SSL *ssl,
+  ThreadedSSLSocketConnection(socket_handle s, SSL *ssl, Sessions sessions, Log *pLog);
+  ThreadedSSLSocketConnection(const SessionID &, socket_handle s, SSL *ssl,
                               const std::string &address, short port,
                               Log *pLog);
   virtual ~ThreadedSSLSocketConnection();
 
   Session *getSession() const { return m_pSession; }
-  int getSocket() const { return m_socket; }
+  socket_handle getSocket() const { return m_socket; }
   bool connect();
   void disconnect();
   bool read();
   SSL *sslObject() { return m_ssl; }
 
 private:
-  typedef std::pair< int, SSL * > SocketKey;
+  typedef std::pair< socket_handle, SSL * > SocketKey;
 
   bool readMessage(std::string &msg) throw(SocketRecvFailed);
   void processStream();
   bool send(const std::string &);
   bool setSession(const std::string &msg);
 
-  int m_socket;
+  socket_handle m_socket;
   SSL *m_ssl;
   char m_buffer[BUFSIZ];
 

--- a/src/C++/ThreadedSSLSocketInitiator.cpp
+++ b/src/C++/ThreadedSSLSocketInitiator.cpp
@@ -297,7 +297,7 @@ void ThreadedSSLSocketInitiator::doConnect(const SessionID &s,
     short port = 0;
     getHost(s, d, address, port);
 
-    int socket = socket_createConnector();
+    socket_handle socket = socket_createConnector();
     if (m_noDelay)
       socket_setsockopt(socket, TCP_NODELAY);
     if (m_sendBufSize)
@@ -316,7 +316,7 @@ void ThreadedSSLSocketInitiator::doConnect(const SessionID &s,
       return;
     }
     SSL_clear(ssl);
-    BIO *sbio = BIO_new_socket(socket, BIO_CLOSE);
+    BIO *sbio = BIO_new_socket(socket, BIO_CLOSE); //unfortunately OpenSSL uses int for socket handles
     SSL_set_bio(ssl, sbio, sbio);
 
     ThreadedSSLSocketConnection *pConnection = new ThreadedSSLSocketConnection(
@@ -375,7 +375,7 @@ THREAD_PROC ThreadedSSLSocketInitiator::socketThread(void *p)
   ThreadedSSLSocketConnection *pConnection = pair->second;
   FIX::SessionID sessionID = pConnection->getSession()->getSessionID();
   FIX::Session *pSession = FIX::Session::lookupSession(sessionID);
-  int socket = pConnection->getSocket();
+  socket_handle socket = pConnection->getSocket();
   delete pair;
 
   pInitiator->lock();

--- a/src/C++/ThreadedSSLSocketInitiator.h
+++ b/src/C++/ThreadedSSLSocketInitiator.h
@@ -157,7 +157,7 @@ public:
   static int passwordHandleCB(char *buf, int bufsize, int verify, void *job);
 
 private:
-  typedef std::pair< int, SSL * > SocketKey;
+  typedef std::pair< socket_handle, SSL * > SocketKey;
   typedef std::map< SocketKey, thread_id > SocketToThread;
   typedef std::map< SessionID, int > SessionToHostNum;
   typedef std::pair< ThreadedSSLSocketInitiator *,

--- a/src/C++/ThreadedSocketAcceptor.h
+++ b/src/C++/ThreadedSocketAcceptor.h
@@ -48,11 +48,11 @@ public:
 private:
   struct AcceptorThreadInfo
   {
-    AcceptorThreadInfo( ThreadedSocketAcceptor* pAcceptor, int socket, int port )
+    AcceptorThreadInfo( ThreadedSocketAcceptor* pAcceptor, socket_handle socket, int port )
     : m_pAcceptor( pAcceptor ), m_socket( socket ), m_port( port ) {}
 
     ThreadedSocketAcceptor* m_pAcceptor;
-    int m_socket;
+    socket_handle m_socket;
     int m_port;
   };
 
@@ -68,11 +68,11 @@ private:
 
   bool readSettings( const SessionSettings& );
 
-  typedef std::set < int >  Sockets;
+  typedef std::set < socket_handle >  Sockets;
   typedef std::set < SessionID > Sessions;
   typedef std::map < int, Sessions > PortToSessions;
-  typedef std::map < int, int > SocketToPort;
-  typedef std::map < int, thread_id > SocketToThread;
+  typedef std::map < socket_handle, int > SocketToPort;
+  typedef std::map < socket_handle, thread_id > SocketToThread;
 
   void onConfigure( const SessionSettings& ) throw ( ConfigError );
   void onInitialize( const SessionSettings& ) throw ( RuntimeError );
@@ -81,8 +81,8 @@ private:
   bool onPoll( double timeout );
   void onStop();
 
-  void addThread( int s, thread_id t );
-  void removeThread( int s );
+  void addThread(socket_handle s, thread_id t );
+  void removeThread(socket_handle s );
   static THREAD_PROC socketAcceptorThread( void* p );
   static THREAD_PROC socketConnectionThread( void* p );
 

--- a/src/C++/ThreadedSocketConnection.cpp
+++ b/src/C++/ThreadedSocketConnection.cpp
@@ -32,7 +32,7 @@
 namespace FIX
 {
 ThreadedSocketConnection::ThreadedSocketConnection
-( int s, Sessions sessions, Log* pLog )
+(socket_handle s, Sessions sessions, Log* pLog )
 : m_socket( s ), m_pLog( pLog ),
   m_sessions( sessions ), m_pSession( 0 ),
   m_disconnect( false )
@@ -42,7 +42,7 @@ ThreadedSocketConnection::ThreadedSocketConnection
 }
 
 ThreadedSocketConnection::ThreadedSocketConnection
-( const SessionID& sessionID, int s,
+( const SessionID& sessionID, socket_handle s,
   const std::string& address, short port, 
   Log* pLog,
   const std::string& sourceAddress, short sourcePort )

--- a/src/C++/ThreadedSocketConnection.h
+++ b/src/C++/ThreadedSocketConnection.h
@@ -46,15 +46,15 @@ class ThreadedSocketConnection : Responder
 public:
   typedef std::set<SessionID> Sessions;
 
-  ThreadedSocketConnection( int s, Sessions sessions, Log* pLog );
-  ThreadedSocketConnection( const SessionID&, int s, 
+  ThreadedSocketConnection( socket_handle s, Sessions sessions, Log* pLog );
+  ThreadedSocketConnection( const SessionID&, socket_handle s,
                             const std::string& address, short port, 
                             Log* pLog,
                             const std::string& sourceAddress = "", short sourcePort = 0);
   virtual ~ThreadedSocketConnection() ;
 
   Session* getSession() const { return m_pSession; }
-  int getSocket() const { return m_socket; }
+  socket_handle getSocket() const { return m_socket; }
   bool connect();
   void disconnect();
   bool read();
@@ -65,7 +65,7 @@ private:
   bool send( const std::string& );
   bool setSession( const std::string& msg );
 
-  int m_socket;
+  socket_handle m_socket;
   char m_buffer[BUFSIZ];
 
   std::string m_address;

--- a/src/C++/ThreadedSocketInitiator.cpp
+++ b/src/C++/ThreadedSocketInitiator.cpp
@@ -145,7 +145,7 @@ void ThreadedSocketInitiator::doConnect( const SessionID& s, const Dictionary& d
     short sourcePort = 0;
     getHost( s, d, address, port, sourceAddress, sourcePort );
 
-    int socket = socket_createConnector();
+    socket_handle socket = socket_createConnector();
     if( m_noDelay )
       socket_setsockopt( socket, TCP_NODELAY );
     if( m_sendBufSize )
@@ -180,14 +180,14 @@ void ThreadedSocketInitiator::doConnect( const SessionID& s, const Dictionary& d
   catch ( std::exception& ) {}
 }
 
-void ThreadedSocketInitiator::addThread( int s, thread_id t )
+void ThreadedSocketInitiator::addThread(socket_handle s, thread_id t )
 {
   Locker l(m_mutex);
 
   m_threads[ s ] = t;
 }
 
-void ThreadedSocketInitiator::removeThread( int s )
+void ThreadedSocketInitiator::removeThread(socket_handle s )
 {
   Locker l(m_mutex);
   SocketToThread::iterator i = m_threads.find( s );
@@ -207,7 +207,7 @@ THREAD_PROC ThreadedSocketInitiator::socketThread( void* p )
   ThreadedSocketConnection* pConnection = pair->second;
   FIX::SessionID sessionID = pConnection->getSession()->getSessionID();
   FIX::Session* pSession = FIX::Session::lookupSession( sessionID );
-  int socket = pConnection->getSocket();
+  socket_handle socket = pConnection->getSocket();
   delete pair;
 
   pInitiator->lock();

--- a/src/C++/ThreadedSocketInitiator.h
+++ b/src/C++/ThreadedSocketInitiator.h
@@ -48,7 +48,7 @@ public:
   virtual ~ThreadedSocketInitiator();
 
 private:
-  typedef std::map < int, thread_id > SocketToThread;
+  typedef std::map < socket_handle, thread_id > SocketToThread;
   typedef std::map < SessionID, int > SessionToHostNum;
   typedef std::pair < ThreadedSocketInitiator*, ThreadedSocketConnection* > ThreadPair;
 
@@ -61,8 +61,8 @@ private:
 
   void doConnect( const SessionID& s, const Dictionary& d );
 
-  void addThread( int s, thread_id t );
-  void removeThread( int s );
+  void addThread(socket_handle s, thread_id t );
+  void removeThread(socket_handle s );
   void lock() { Locker l(m_mutex); }
   static THREAD_PROC socketThread( void* p );
 

--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -100,7 +100,7 @@ void socket_term()
 #endif
 }
 
-int socket_bind( int socket, const char* hostname, int port )
+int socket_bind(socket_handle socket, const char* hostname, int port )
 {
   sockaddr_in address;
   socklen_t socklen;
@@ -117,10 +117,10 @@ int socket_bind( int socket, const char* hostname, int port )
                      socklen );
 }
 
-int socket_createAcceptor(int port, bool reuse)
+socket_handle socket_createAcceptor(int port, bool reuse)
 {
-  int socket = ::socket( PF_INET, SOCK_STREAM, 0 );
-  if ( socket < 0 ) return -1;
+    socket_handle socket = ::socket( PF_INET, SOCK_STREAM, 0 );
+  if ( socket == INVALID_SOCKET_HANDLE) return INVALID_SOCKET_HANDLE;
 
   sockaddr_in address;
   socklen_t socklen;
@@ -134,18 +134,19 @@ int socket_createAcceptor(int port, bool reuse)
 
   int result = bind( socket, reinterpret_cast < sockaddr* > ( &address ),
                      socklen );
-  if ( result < 0 ) return -1;
+  
+  if ( result == BIND_SOCKET_ERROR) return INVALID_SOCKET_HANDLE;
   result = listen( socket, SOMAXCONN );
-  if ( result < 0 ) return -1;
+  if ( result == LISTEN_SOCKET_ERROR) return INVALID_SOCKET_HANDLE;
   return socket;
 }
 
-int socket_createConnector()
+socket_handle socket_createConnector()
 {
   return ::socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );
 }
 
-int socket_connect( int socket, const char* address, int port )
+int socket_connect(socket_handle socket, const char* address, int port )
 {
   const char* hostname = socket_hostname( address );
   if( hostname == 0 ) return -1;
@@ -161,23 +162,23 @@ int socket_connect( int socket, const char* address, int port )
   return result;
 }
 
-int socket_accept( int s )
+socket_handle socket_accept(socket_handle s )
 {
-  if ( !socket_isValid( s ) ) return -1;
+  if ( !socket_isValid( s ) ) return INVALID_SOCKET_HANDLE;
   return accept( s, 0, 0 );
 }
 
-ssize_t socket_recv( int s, char* buf, size_t length )
+ssize_t socket_recv(socket_handle s, char* buf, size_t length )
 {
   return recv( s, buf, length, 0 );
 }
 
-ssize_t socket_send( int s, const char* msg, size_t length )
+ssize_t socket_send(socket_handle s, const char* msg, size_t length )
 {
   return send( s, msg, length, 0 );
 }
 
-void socket_close( int s )
+void socket_close(socket_handle s )
 {
   shutdown( s, 2 );
 #ifdef _MSC_VER
@@ -187,7 +188,7 @@ void socket_close( int s )
 #endif
 }
 
-bool socket_fionread( int s, int& bytes )
+bool socket_fionread(socket_handle s, int& bytes )
 {
   bytes = 0;
 #if defined(_MSC_VER)
@@ -199,13 +200,13 @@ bool socket_fionread( int s, int& bytes )
 #endif
 }
 
-bool socket_disconnected( int s )
+bool socket_disconnected(socket_handle s )
 {
   char byte;
   return ::recv (s, &byte, sizeof (byte), MSG_PEEK) <= 0;
 }
 
-int socket_setsockopt( int s, int opt )
+int socket_setsockopt(socket_handle s, int opt )
 {
 #ifdef _MSC_VER
   BOOL optval = TRUE;
@@ -215,7 +216,7 @@ int socket_setsockopt( int s, int opt )
   return socket_setsockopt( s, opt, optval );
 }
 
-int socket_setsockopt( int s, int opt, int optval )
+int socket_setsockopt(socket_handle s, int opt, int optval )
 {
   int level = SOL_SOCKET;
   if( opt == TCP_NODELAY )
@@ -230,7 +231,7 @@ int socket_setsockopt( int s, int opt, int optval )
 #endif
 }
 
-int socket_getsockopt( int s, int opt, int& optval )
+int socket_getsockopt(socket_handle s, int opt, int& optval )
 {
   int level = SOL_SOCKET;
   if( opt == TCP_NODELAY )
@@ -265,7 +266,7 @@ int socket_setfcntlflag( int s, int arg )
 }
 #endif
 
-void socket_setnonblock( int socket )
+void socket_setnonblock(socket_handle socket )
 {
 #ifdef _MSC_VER
   u_long opt = 1;
@@ -274,10 +275,10 @@ void socket_setnonblock( int socket )
   socket_setfcntlflag( socket, O_NONBLOCK );
 #endif
 }
-bool socket_isValid( int socket )
+bool socket_isValid(socket_handle socket )
 {
 #ifdef _MSC_VER
-  return socket != INVALID_SOCKET;
+  return socket != INVALID_SOCKET_HANDLE;
 #else
   return socket >= 0;
 #endif
@@ -292,16 +293,12 @@ bool socket_isBad( int s )
 }
 #endif
 
-void socket_invalidate( int& socket )
+void socket_invalidate(socket_handle& socket )
 {
-#ifdef _MSC_VER
-  socket = INVALID_SOCKET;
-#else
-  socket = -1;
-#endif
+  socket = INVALID_SOCKET_HANDLE;
 }
 
-short socket_hostport( int socket )
+short socket_hostport(socket_handle socket )
 {
   struct sockaddr_in addr;
   socklen_t len = sizeof(addr);
@@ -311,7 +308,7 @@ short socket_hostport( int socket )
   return ntohs( addr.sin_port );
 }
 
-const char* socket_hostname( int socket )
+const char* socket_hostname(socket_handle socket )
 {
   struct sockaddr_in addr;
   socklen_t len = sizeof(addr);
@@ -350,7 +347,7 @@ const char* socket_hostname( const char* name )
   return inet_ntoa( **paddr );
 }
 
-const char* socket_peername( int socket )
+const char* socket_peername(socket_handle socket )
 {
   struct sockaddr_in addr;
   socklen_t len = sizeof(addr);
@@ -363,21 +360,21 @@ const char* socket_peername( int socket )
     return "UNKNOWN";
 }
 
-std::pair<int, int> socket_createpair()
+std::pair<socket_handle, socket_handle> socket_createpair()
 {
 #ifdef _MSC_VER
-  int acceptor = socket_createAcceptor(0, true);
+  socket_handle acceptor = socket_createAcceptor(0, true);
   const char* host = socket_hostname( acceptor );
   short port = socket_hostport( acceptor );
-  int client = socket_createConnector();
+  socket_handle client = socket_createConnector();
   socket_connect( client, "localhost", port );
-  int server = socket_accept( acceptor );
+  socket_handle server = socket_accept( acceptor );
   socket_close(acceptor);
-  return std::pair<int, int>( client, server );
+  return std::make_pair( client, server );
 #else
-  int pair[2];
+  socket_handle pair[2];
   socketpair( AF_UNIX, SOCK_STREAM, 0, pair );
-  return std::pair<int, int>( pair[0], pair[1] );
+  return std::make_pair( pair[0], pair[1] );
 #endif
 }
 

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -70,6 +70,9 @@ typedef int socklen_t;
 typedef int ssize_t;
 typedef SOCKET socket_handle;
 #define INVALID_SOCKET_HANDLE INVALID_SOCKET
+#define BIND_SOCKET_ERROR SOCKET_ERROR
+#define LISTEN_SOCKET_ERROR SOCKET_ERROR
+#define SET_SOCK_OPT_ERROR SOCKET_ERROR
 /////////////////////////////////////////////
 #else
 /////////////////////////////////////////////
@@ -94,6 +97,9 @@ typedef SOCKET socket_handle;
 #include <stdlib.h>
 typedef int socket_handle;
 #define INVALID_SOCKET_HANDLE -1
+#define BIND_SOCKET_ERROR -1
+#define LISTEN_SOCKET_ERROR -1
+#define SET_SOCK_OPT_ERROR -1
 /////////////////////////////////////////////
 #endif
 

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -68,6 +68,8 @@
 #include <time.h>
 typedef int socklen_t;
 typedef int ssize_t;
+typedef SOCKET socket_handle;
+#define INVALID_SOCKET_HANDLE INVALID_SOCKET
 /////////////////////////////////////////////
 #else
 /////////////////////////////////////////////
@@ -90,6 +92,8 @@ typedef int ssize_t;
 #include <errno.h>
 #include <time.h>
 #include <stdlib.h>
+typedef int socket_handle;
+#define INVALID_SOCKET_HANDLE -1
 /////////////////////////////////////////////
 #endif
 
@@ -140,35 +144,35 @@ std::string string_strip( const std::string& value );
 
 void socket_init();
 void socket_term();
-int socket_bind( int socket, const char* hostname, int port );
-int socket_createAcceptor( int port, bool reuse = false );
-int socket_createConnector();
-int socket_connect( int s, const char* address, int port );
-int socket_accept( int s );
-ssize_t socket_recv( int s, char* buf, size_t length );
-ssize_t socket_send( int s, const char* msg, size_t length );
-void socket_close( int s );
-bool socket_fionread( int s, int& bytes );
-bool socket_disconnected( int s );
-int socket_setsockopt( int s, int opt );
-int socket_setsockopt( int s, int opt, int optval );
-int socket_getsockopt( int s, int opt, int& optval );
+int socket_bind(socket_handle socket, const char* hostname, int port );
+socket_handle socket_createAcceptor( int port, bool reuse = false );
+socket_handle socket_createConnector();
+int socket_connect(socket_handle s, const char* address, int port );
+socket_handle socket_accept(socket_handle s );
+ssize_t socket_recv(socket_handle s, char* buf, size_t length );
+ssize_t socket_send(socket_handle s, const char* msg, size_t length );
+void socket_close(socket_handle s );
+bool socket_fionread(socket_handle s, int& bytes );
+bool socket_disconnected(socket_handle s );
+int socket_setsockopt(socket_handle s, int opt );
+int socket_setsockopt(socket_handle s, int opt, int optval );
+int socket_getsockopt(socket_handle s, int opt, int& optval );
 #ifndef _MSC_VER
 int socket_fcntl( int s, int opt, int arg );
 int socket_getfcntlflag( int s, int arg );
 int socket_setfcntlflag( int s, int arg );
 #endif
-void socket_setnonblock( int s );
-bool socket_isValid( int socket );
+void socket_setnonblock(socket_handle s );
+bool socket_isValid(socket_handle socket );
 #ifndef _MSC_VER
 bool socket_isBad( int s );
 #endif
-void socket_invalidate( int& socket );
-short socket_hostport( int socket );
-const char* socket_hostname( int socket );
+void socket_invalidate(socket_handle& socket );
+short socket_hostport(socket_handle socket );
+const char* socket_hostname(socket_handle socket );
 const char* socket_hostname( const char* name );
-const char* socket_peername( int socket );
-std::pair<int, int> socket_createpair();
+const char* socket_peername(socket_handle socket );
+std::pair<socket_handle, socket_handle> socket_createpair();
 
 tm time_gmtime( const time_t* t );
 tm time_localtime( const time_t* t );

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -367,7 +367,7 @@ void ssl_term()
 #endif
 }
 
-void ssl_socket_close(int socket, SSL *ssl)
+void ssl_socket_close(socket_handle socket, SSL *ssl)
 {
 
   if (ssl == 0)
@@ -982,7 +982,7 @@ char *strCat(const char *a, ...)
   return res;
 }
 
-int setSocketNonBlocking(int pSocket)
+int setSocketNonBlocking(socket_handle pSocket)
 /********************************************************************************
 * switch socket to non-blocking mode
 * Returns: 0 in the case of success, -1 in the case of error
@@ -1519,7 +1519,7 @@ int doAccept(SSL *ssl, int &result)
   return rc;
 }
 
-int acceptSSLConnection(int socket, SSL *ssl, Log *log, int verify)
+int acceptSSLConnection(socket_handle socket, SSL *ssl, Log *log, int verify)
 {
   int rc;
   int result = -1;
@@ -1635,7 +1635,7 @@ int acceptSSLConnection(int socket, SSL *ssl, Log *log, int verify)
               std::string(
                   "SSL handshake interrupted by system, system error ") +
               IntConvertor::convert(lastSocketError) + " socket " +
-              IntConvertor::convert(socket));
+              std::to_string(socket));
 
 #else
         if (errno == EINTR)

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -404,7 +404,7 @@ static void locking_callback(int mode, int type, const char *file, int line)
 static unsigned long thread_id_func()
 {
 #ifdef _MSC_VER
-  return (unsigned)GetCurrentThread();
+  return (unsigned)GetCurrentThreadId();
 #else
   return (unsigned long)pthread_self();
 #endif

--- a/src/C++/UtilitySSL.h
+++ b/src/C++/UtilitySSL.h
@@ -210,7 +210,7 @@ EVP_PKEY *readPrivateKey(FILE *fp, EVP_PKEY **key,
 char *strCat(const char *a, ...);
 }
 
-int setSocketNonBlocking(int pSocket);
+int setSocketNonBlocking(socket_handle pSocket);
 
 // define certificate algorithm type
 #define SSL_ALGO_UNKNOWN 0
@@ -244,7 +244,7 @@ void ssl_init();
 
 void ssl_term();
 
-void ssl_socket_close(int socket, SSL *ssl);
+void ssl_socket_close(socket_handle socket, SSL *ssl);
 
 const char *socket_error(char *tempbuf, int buflen);
 
@@ -269,7 +269,7 @@ bool loadCAInfo(SSL_CTX *ctx, bool server, const SessionSettings &settings,
 X509_STORE *loadCRLInfo(SSL_CTX *ctx, const SessionSettings &settings, Log *log,
                         std::string &errStr);
 
-int acceptSSLConnection(int socket, SSL * ssl, Log * log, int verify);
+int acceptSSLConnection(socket_handle socket, SSL * ssl, Log * log, int verify);
 }
 
 #endif

--- a/src/C++/test/SocketAcceptorTestCase.cpp
+++ b/src/C++/test/SocketAcceptorTestCase.cpp
@@ -79,7 +79,7 @@ struct receivePartialMessageFixture
   TestApplication application;
   MemoryStoreFactory factory;
   SocketAcceptor* object;
-  int s;
+  socket_handle s;
 };
 
 TEST_FIXTURE(receivePartialMessageFixture, receivePartialMessage)

--- a/src/C++/test/SocketConnectorTestCase.cpp
+++ b/src/C++/test/SocketConnectorTestCase.cpp
@@ -41,7 +41,7 @@ TEST(accept)
 {
   SocketConnector object;
   SocketServer server( 0 );
-  int socket = server.add( TestSettings::port, true, true );
+  socket_handle socket = server.add( TestSettings::port, true, true );
   CHECK( object.connect( "127.0.0.1", TestSettings::port, false, 1024, 1024 ) );
   CHECK( server.accept(socket) );
 }

--- a/src/C++/test/SocketServerTestCase.cpp
+++ b/src/C++/test/SocketServerTestCase.cpp
@@ -42,24 +42,24 @@ public:
     dataSocket( 0 ), disconnectSocket( 0 ),
     bufLen( 0 ) {}
 
-  void onConnect( SocketServer&, int accept, int socket )
+  void onConnect( SocketServer&, socket_handle accept, socket_handle socket )
   { connect++; connectSocket = socket; }
-  void onWrite( SocketServer&, int socket )
+  void onWrite( SocketServer&, socket_handle socket )
   { write++; writeSocket = socket; }
-  bool onData( SocketServer& server, int socket )
+  bool onData( SocketServer& server, socket_handle socket )
   {
     data++; dataSocket = socket;
     bufLen = recv( socket, buf, 1, 0 );
     return bufLen > 0;
   }
-  void onDisconnect( SocketServer&, int socket )
+  void onDisconnect( SocketServer&, socket_handle socket )
   { disconnect++; disconnectSocket = socket; }
   void onError( SocketServer& )
   {}
 
   int connect, write, data, disconnect;
-  int connectSocket, writeSocket;
-  int dataSocket, disconnectSocket;
+  socket_handle connectSocket, writeSocket;
+  socket_handle dataSocket, disconnectSocket;
   char buf[ 1 ]; size_t bufLen;
 };
 
@@ -69,27 +69,27 @@ SUITE(SocketServerTests)
 TEST_FIXTURE(socketServerFixture, accept)
 {
   SocketServer object( 0 );
-  int serverS1 = object.add( TestSettings::port, true, true );
-  int clientS1 = createSocket( TestSettings::port, "127.0.0.1" );
+  socket_handle serverS1 = object.add( TestSettings::port, true, true );
+  socket_handle clientS1 = createSocket( TestSettings::port, "127.0.0.1" );
   CHECK( clientS1 > 0 );
   process_sleep(0.1);
-  int s1 = object.accept( serverS1 );
+  socket_handle s1 = object.accept( serverS1 );
   CHECK( s1 >= 0 );
   object.block( *this );
   CHECK( object.numConnections() == 1 );
 
-  int clientS2 = createSocket( TestSettings::port, "127.0.0.1" );
+  socket_handle clientS2 = createSocket( TestSettings::port, "127.0.0.1" );
   CHECK( clientS2 > 0 );
   process_sleep(0.1);
-  int s2 = object.accept( serverS1 );
+  socket_handle s2 = object.accept( serverS1 );
   CHECK( s2 >= 0 );
   object.block( *this );
   CHECK( object.numConnections() == 2 );
 
-  int clientS3 = createSocket( TestSettings::port, "127.0.0.1" );
+  socket_handle clientS3 = createSocket( TestSettings::port, "127.0.0.1" );
   CHECK( clientS3 > 0 );
   process_sleep(0.1);
-  int s3 = object.accept( serverS1 );
+  socket_handle s3 = object.accept( serverS1 );
   CHECK( s3 >= 0 );
   object.block( *this );
   CHECK( object.numConnections() == 3 );
@@ -113,7 +113,7 @@ TEST_FIXTURE(socketServerFixture, block)
 {
   SocketServer object( 0 );
   object.add( TestSettings::port, true, true );
-  int clientS = createSocket( TestSettings::port, "127.0.0.1" );
+  socket_handle clientS = createSocket( TestSettings::port, "127.0.0.1" );
   CHECK( clientS >= 0 );
 
   object.block( *this );

--- a/src/C++/test/TestHelper.h
+++ b/src/C++/test/TestHelper.h
@@ -28,15 +28,15 @@ inline void deleteSession( std::string sender, std::string target )
   file_unlink( ( "store/FIX.4.2-" + sender + "-" + target + ".session" ).c_str() );
 }
 
-inline void destroySocket( int s )
+inline void destroySocket( socket_handle s )
 {
   socket_close( s );
   socket_invalidate( s );
 }
 
-int inline createSocket( int port, const char* address )
+socket_handle inline createSocket( int port, const char* address )
 {
-  int sock = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );
+  socket_handle sock = socket( PF_INET, SOCK_STREAM, IPPROTO_TCP );
 
   sockaddr_in addr;
   addr.sin_family = PF_INET;
@@ -48,7 +48,7 @@ int inline createSocket( int port, const char* address )
   if ( result != 0 )
   {
     destroySocket( sock );
-    return -1;
+    return INVALID_SOCKET_HANDLE;
   }
   return sock;
 }


### PR DESCRIPTION
In Linux, a socket descriptor is an **int** (32 bits) where as in windows, a socket is of type **SOCKET**.
SOCKET when the project is built as a x64 project is 64 bits.
To improve compatibility with x64 builds on windows, we added a typedef

typedef SOCKET socket_handle; <-- for _MSC_VER

typedef int socket_handle;  <-- for non _MSC_VER

Other than that, we updated the few checks for invalid socket since in windows SOCKET is unsigned and defined as INVALID_SOCKET where as in Linux an invalid socket is -1. Likewise for the return values of bind() and listen() we check against what is defined in the windows spec. 
These are the defines found in Utility.h

**From the quickfix project the following files were modified (in modification order):**
src/C++/Utility.h
src/C++/Utility.cpp
src/C++/SocketServer.cpp
src/C++/SocketServer.h
src/C++/SocketMonitor.cpp
src/C++/SocketMonitor.h
src/C++/SocketConnector.cpp
src/C++/SocketConnector.h
src/C++/HttpServer.cpp
src/C++/HttpServer.h
src/C++/HttpConnection.cpp
src/C++/HttpConnection.h
src/C++/SocketAcceptor.cpp
src/C++/SocketAcceptor.h
src/C++/ThreadedSocketAcceptor.cpp
src/C++/ThreadedSocketAcceptor.h
src/C++/SSLSocketAcceptor.cpp
src/C++/SSLSocketAcceptor.h
src/C++/ThreadedSSLSocketAcceptor.cpp
src/C++/ThreadedSSLSocketAcceptor.h
src/C++/SocketInitiator.cpp
src/C++/SocketInitiator.h
src/C++/SSLSocketInitiator.cpp
src/C++/SSLSocketInitiator.h
src/C++/ThreadedSocketInitiator.cpp
src/C++/ThreadedSocketInitiator.h
src/C++/ThreadedSSLSocketInitiator.cpp
src/C++/ThreadedSSLSocketInitiator.h
src/C++/SocketConnection.cpp
src/C++/SocketConnection.h
src/C++/SSLSocketConnection.cpp
src/C++/SSLSocketConnection.h
src/C++/ThreadedSocketConnection.cpp
src/C++/ThreadedSocketConnection.h
src/C++/ThreadedSSLSocketConnection.cpp
src/C++/ThreadedSSLSocketConnection.h

**From the unittests project the following files were modified:**
src/C++/test/SocketAcceptorTestCase.cpp
src/C++/test/SocketConnectorTestCase.cpp
src/C++/test/SocketServerTestCase.cpp
src/C++/test/TestHelper.h

There are 4 calls to OpenSSL's function BIO_new_socket which unfortunately still use int for socket, since OpenSSL uses int in their interface, in this case on a x64 machine it will do a narrowing conversion to an int. Although perfection can't be achieved until OpenSSL updates their API, our changes in no way harm what was already guaranteed by the library.