### PR TITLE
Avoid valgrind error because of a memory leak

### DIFF
--- a/src/C++/SocketAcceptor.cpp
+++ b/src/C++/SocketAcceptor.cpp
@@ -103,6 +103,8 @@ throw ( RuntimeError )
   }
   catch( SocketException& e )
   {
+    delete m_pServer;
+    m_pServer = 0;
     throw RuntimeError( "Unable to create, bind, or listen to port "
                        + IntConvertor::convert( (unsigned short)port ) + " (" + e.what() + ")" );
   }


### PR DESCRIPTION
If the port is still used by another process, QF throws an exception and doesn't free `m_pServer` pointer. It also doesn't provide mechanism to free it otherwise after the exception.