### PR TITLE
Allow exception to be thrown in ~FixtureDtorThrows()

### DIFF
--- a/UnitTest++/src/TestMacros.h
+++ b/UnitTest++/src/TestMacros.h
@@ -109,5 +109,10 @@
 
 #define TEST_FIXTURE(Fixture,Name) TEST_FIXTURE_EX(Fixture, Name, UnitTest::Test::GetTestList())
 
+#if __cplusplus >= 201103L
+#define NOEXCEPT_FALSE noexcept(false)
+#else
+#define NOEXCEPT_FALSE
+#endif
 
 #endif

--- a/UnitTest++/src/tests/TestTestMacros.cpp
+++ b/UnitTest++/src/tests/TestTestMacros.cpp
@@ -131,7 +131,7 @@ TEST(FixturesWithThrowingCtorsAreFailures)
 
 struct FixtureDtorThrows
 {
-	~FixtureDtorThrows() { throw "exception"; }
+	~FixtureDtorThrows() NOEXCEPT_FALSE { throw "exception"; }
 };
 
 TestList throwingFixtureTestList2;


### PR DESCRIPTION
This change allows buiding and running the tests with c++11 and above.

xref: https://akrzemi1.wordpress.com/2013/08/20/noexcept-destructors/

Fixes #61, #47