### PR TITLE
FieldConvertors Visual Studio Compilation Fix

### DIFF
--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -249,15 +249,15 @@ public:
   static const int SIGNIFICANT_DIGITS = 15;
   static const int BUFFFER_SIZE = 32;
 
-  static std::string convert( double value, int padding = 0, int significant_digits = SIGNIFICANT_DIGITS, int buffer_size = BUFFFER_SIZE )
+  static std::string convert( double value, int padding = 0, int significant_digits = SIGNIFICANT_DIGITS)
   {
-    char result[buffer_size];
+    char result[BUFFFER_SIZE];
     char *end = 0;
 
     int size;
     if( value == 0 || value > 0.0001 || value < -0.0001 )
     {
-      size = fast_dtoa( result, buffer_size, value, significant_digits);
+      size = fast_dtoa( result, BUFFFER_SIZE, value, significant_digits);
       if( size == 0 )
         return std::string();
 
@@ -285,7 +285,7 @@ public:
     }
     else
     {
-      size = fast_fixed_dtoa( result, buffer_size, value, significant_digits );
+      size = fast_fixed_dtoa( result, BUFFFER_SIZE, value, significant_digits );
       if( size == 0 )
         return std::string();
 

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -168,7 +168,6 @@ TEST(doubleConvertTo)
   CHECK_EQUAL( "0.0", DoubleConvertor::convert( 0.0, 1) );
 
   CHECK_EQUAL( "", DoubleConvertor::convert( 0.01, 0, -1));
-  CHECK_EQUAL( "", DoubleConvertor::convert( 0.00000000000000000000000000000000000000000000000000000000000000001, 0, 61, 100));
 }
 
 TEST(doubleConvertFrom)


### PR DESCRIPTION
Fixes an Visual Studio Compilation issue in the FieldConvertors.h header file. Visual Studio compilation has stricter rules on dynamic arrays