### PR TITLE
Using mutex instead of assembly code

### DIFF
--- a/src/C++/AtomicCount.h
+++ b/src/C++/AtomicCount.h
@@ -24,7 +24,7 @@
 
 #include "Utility.h"
 
-#if defined(__SUNPRO_CC) ||  defined(__TOS_AIX__)
+#if !defined(ENABLE_BOOST_ATOMIC_COUNT) && !defined(_MSC_VER)
 #include "Mutex.h"
 #endif
 
@@ -70,7 +70,7 @@ typedef boost::detail::atomic_count atomic_count;
     long volatile m_counter;
   };
 
-#elif defined(__SUNPRO_CC) ||  defined(__TOS_AIX__)
+#else
 
 // general purpose atomic counter using mutexes
 class atomic_count
@@ -105,71 +105,6 @@ private:
   Mutex m_mutex;
   long m_counter;
 };
-
-#else
-
-  //
-  //  boost/detail/atomic_count_gcc_x86.hpp
-  //
-  //  atomic_count for g++ on 486+/AMD64
-  //
-  //  Copyright 2007 Peter Dimov
-  //
-  //  Distributed under the Boost Software License, Version 1.0. (See
-  //  accompanying file LICENSE_1_0.txt or copy at
-  //  http://www.boost.org/LICENSE_1_0.txt)
-  //
-
-  class atomic_count
-  {
-  public:
-
-    explicit atomic_count( long v ) : value_(static_cast<int>(v)) {}
-
-    long operator++()
-    {
-      return atomic_exchange_and_add( &value_, 1 ) + 1;
-    }
-
-    long operator--()
-    {
-      return atomic_exchange_and_add( &value_, -1 ) - 1;
-    }
-
-    operator long() const
-    {
-      return atomic_exchange_and_add( &value_, 0 );
-    }
-
-  private:
-
-    atomic_count( atomic_count const & );
-    atomic_count & operator=( atomic_count const & );
-
-    mutable int value_;
-
-  private:
-
-    static int atomic_exchange_and_add(int * pw, int dv)
-    {
-      // int r = *pw;
-      // *pw += dv;
-      // return r;
-
-      int r;
-
-      __asm__ __volatile__
-        (
-          "lock\n\t"
-          "xadd %1, %0":
-          "+m"(*pw), "=r"(r) : // outputs (%0, %1)
-          "1"(dv) : // inputs (%2 == %1)
-          "memory", "cc" // clobbers
-        );
-
-      return r;
-    }
-  };
 
 #endif
 


### PR DESCRIPTION
Removed the specific assembly code for x86_64 architecture. Left only generic C++ code that uses mutex to respect the atomic increment.
This PR is to solve the issue #206 