### PR TITLE
Change "const int" return type to plain "int"

### DIFF
--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -415,7 +415,7 @@ public:
       { return IntConvertor::convert( getString() ); }
       catch( FieldConvertError& )
       { throw IncorrectDataFormat( getTag(), getString() ); } }
-  operator const int() const
+  operator int() const
     { return getValue(); }
 };
 
@@ -536,7 +536,7 @@ public:
       { return CheckSumConvertor::convert( getString() ); }
       catch( FieldConvertError& )
       { throw IncorrectDataFormat( getTag(), getString() ); } }
-  operator const int() const
+  operator int() const
     { return getValue(); }
 };
 


### PR DESCRIPTION
Fix gcc warning "type qualifiers ignored on function return type"