### PR TITLE
Fix: private key password now read from proper instance & SSL Connection Fix

### DIFF
--- a/src/C++/SSLSocketAcceptor.h
+++ b/src/C++/SSLSocketAcceptor.h
@@ -143,9 +143,9 @@ public:
 
   void setPassword(const std::string &pwd) { m_password.assign(pwd); }
 
-  int passwordHandleCallback(char *buf, size_t bufsize, int verify, void *job);
+  int passwordHandleCallback(char *buf, size_t bufsize, int verify);
 
-  static int passPhraseHandleCB(char *buf, int bufsize, int verify, void *job);
+  static int passPhraseHandleCB(char *buf, int bufsize, int verify, void *instance);
 
 private:
   bool readSettings( const SessionSettings& );

--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -357,8 +357,14 @@ void SSLSocketInitiator::onConnect( SocketConnector& connector, socket_handle s 
   }else
   {
       setDisconnected(pSocketConnection->getSession()->getSessionID());
-      m_pendingConnections.erase(i);
+	  Session* pSession = pSocketConnection->getSession();
+      if (pSession)
+      {
+          pSession->disconnect();
+          setDisconnected(pSession->getSessionID());
+      }      
       delete pSocketConnection;
+	  m_pendingConnections.erase(i);
   }
 }
 

--- a/src/C++/SSLSocketInitiator.h
+++ b/src/C++/SSLSocketInitiator.h
@@ -148,9 +148,9 @@ public:
     m_key = key;
   }
 
-  int passwordHandleCallback(char *buf, size_t bufsize, int verify, void *job);
+  int passwordHandleCallback(char *buf, size_t bufsize, int verify);
 
-  static int passwordHandleCB(char *buf, int bufsize, int verify, void *job);
+  static int passwordHandleCB(char *buf, int bufsize, int verify, void *instance);
 
 private:
   typedef std::map < socket_handle, SSLSocketConnection* > SocketConnections;

--- a/src/C++/ThreadedSSLSocketAcceptor.h
+++ b/src/C++/ThreadedSSLSocketAcceptor.h
@@ -144,9 +144,9 @@ public:
 
   void setPassword(const std::string &pwd) { m_password.assign(pwd); }
 
-  int passwordHandleCallback(char *buf, size_t bufsize, int verify, void *job);
+  int passwordHandleCallback(char *buf, size_t bufsize, int verify);
 
-  static int passPhraseHandleCB(char *buf, int bufsize, int verify, void *job);
+  static int passPhraseHandleCB(char *buf, int bufsize, int verify, void *instance);
 
 private:
   struct AcceptorThreadInfo

--- a/src/C++/ThreadedSSLSocketInitiator.h
+++ b/src/C++/ThreadedSSLSocketInitiator.h
@@ -152,9 +152,9 @@ public:
     m_key = key;
   }
 
-  int passwordHandleCallback(char *buf, size_t bufsize, int verify, void *job);
+  int passwordHandleCallback(char *buf, size_t bufsize, int verify);
 
-  static int passwordHandleCB(char *buf, int bufsize, int verify, void *job);
+  static int passwordHandleCB(char *buf, int bufsize, int verify, void *instance);
 
 private:
   typedef std::pair< socket_handle, SSL * > SocketKey;

--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <algorithm>
 #include <fstream>
+#include <sstream>
 
 namespace FIX
 {
@@ -186,6 +187,26 @@ void socket_close(socket_handle s )
 #else
   close( s );
 #endif
+}
+
+std::string socket_get_last_error()
+{
+    std::stringstream errorMessage;
+#ifdef _MSC_VER
+    int winsockErrorCode = WSAGetLastError();
+
+    char* s = NULL;
+    FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        NULL, winsockErrorCode,
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        (LPSTR)&s, 0, NULL);
+    errorMessage << "Winsock error " << winsockErrorCode << ": " << s;
+    LocalFree(s);
+#else
+    int errorNumber = errno;    
+    errorMessage << "Winsock error " << errorNumber << ": " << strerror(errorNumber);
+#endif
+    return errorMessage.str();
 }
 
 bool socket_fionread(socket_handle s, int& bytes )

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -160,6 +160,7 @@ socket_handle socket_accept(socket_handle s );
 ssize_t socket_recv(socket_handle s, char* buf, size_t length );
 ssize_t socket_send(socket_handle s, const char* msg, size_t length );
 void socket_close(socket_handle s );
+std::string socket_get_last_error();
 bool socket_fionread(socket_handle s, int& bytes );
 bool socket_disconnected(socket_handle s );
 int socket_setsockopt(socket_handle s, int opt );

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -1227,7 +1227,7 @@ SSL_CTX *createSSLContext(bool server, const SessionSettings &settings,
 }
 
 bool loadSSLCert(SSL_CTX *ctx, bool server, const SessionSettings &settings,
-                 Log *log, passPhraseHandleCallbackType cb, std::string &errStr)
+                 Log *log, passPhraseHandleCallbackType cb, void* passwordCallbackParam, std::string &errStr)
 {
   errStr.erase();
 
@@ -1281,6 +1281,12 @@ bool loadSSLCert(SSL_CTX *ctx, bool server, const SessionSettings &settings,
     else
       key.assign(cert);
   }
+
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+  ::SSL_CTX_set_default_passwd_cb_userdata(ctx, passwordCallbackParam);
+#else
+  ctx->default_passwd_callback_userdata = passwordCallbackParam;
+#endif
 
   SSL_CTX_set_default_passwd_cb(ctx, cb);
 

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -853,13 +853,13 @@ X509_STORE *createX509Store(const char *cpFile, const char *cpPath)
   }
   return pStore;
 }
-X509 *readX509(FILE *fp, X509 **x509, passPhraseHandleCallbackType cb)
+X509 *readX509(FILE *fp, X509 **x509, passPhraseHandleCallbackType cb, void* passwordCallbackParam)
 {
   X509 *rc;
   BIO *bioS;
   BIO *bioF;
 
-  rc = PEM_read_X509(fp, x509, cb, 0);
+  rc = PEM_read_X509(fp, x509, cb, passwordCallbackParam);
   if (rc == 0)
   {
     /* 2. try DER+Base64 */
@@ -896,13 +896,13 @@ X509 *readX509(FILE *fp, X509 **x509, passPhraseHandleCallbackType cb)
 }
 
 EVP_PKEY *readPrivateKey(FILE *fp, EVP_PKEY **key,
-                         passPhraseHandleCallbackType cb)
+                         passPhraseHandleCallbackType cb, void* passwordCallbackParam)
 {
   EVP_PKEY *rc;
   BIO *bioS;
   BIO *bioF;
 
-  rc = PEM_read_PrivateKey(fp, key, cb, 0);
+  rc = PEM_read_PrivateKey(fp, key, cb, passwordCallbackParam);
   if (rc == 0)
   {
     /* 2. try DER+Base64 */
@@ -1299,7 +1299,7 @@ bool loadSSLCert(SSL_CTX *ctx, bool server, const SessionSettings &settings,
     return false;
   }
 
-  X509 *X509Cert = readX509(fp, 0, 0);
+  X509 *X509Cert = readX509(fp, 0, 0, 0);
 
   fclose(fp);
 
@@ -1345,7 +1345,7 @@ bool loadSSLCert(SSL_CTX *ctx, bool server, const SessionSettings &settings,
     return false;
   }
 
-  EVP_PKEY *privateKey = readPrivateKey(fp, 0, cb);
+  EVP_PKEY *privateKey = readPrivateKey(fp, 0, cb, passwordCallbackParam);
 
   fclose(fp);
 

--- a/src/C++/UtilitySSL.h
+++ b/src/C++/UtilitySSL.h
@@ -260,7 +260,7 @@ SSL_CTX *createSSLContext(bool server, const SessionSettings &settings,
                           std::string &errStr);
 
 bool loadSSLCert(SSL_CTX *ctx, bool server, const SessionSettings &settings,
-                 Log *log, passPhraseHandleCallbackType cb,
+                 Log *log, passPhraseHandleCallbackType cb, void* passwordCallbackParam,
                  std::string &errStr);
 
 bool loadCAInfo(SSL_CTX *ctx, bool server, const SessionSettings &settings,

--- a/src/C++/UtilitySSL.h
+++ b/src/C++/UtilitySSL.h
@@ -203,9 +203,9 @@ int lookupX509Store(X509_STORE *pStore, int nType, X509_NAME *pName,
 int callbackVerify(int ok, X509_STORE_CTX *ctx);
 int callbackVerifyCRL(int ok, X509_STORE_CTX *ctx, X509_STORE *revStore);
 X509_STORE *createX509Store(const char *cpFile, const char *cpPath);
-X509 *readX509(FILE *fp, X509 **x509, passPhraseHandleCallbackType cb);
+X509 *readX509(FILE *fp, X509 **x509, passPhraseHandleCallbackType cb, void* passwordCallbackParam);
 EVP_PKEY *readPrivateKey(FILE *fp, EVP_PKEY **key,
-                         passPhraseHandleCallbackType cb);
+                         passPhraseHandleCallbackType cb, void* passwordCallbackParam);
 
 char *strCat(const char *a, ...);
 }


### PR DESCRIPTION
Solves issue #272. SSL Private key password is now properly read, when having multiple instances of Initiator/Acceptor

**Change summary:**
1. Added additional parameter `passwordCallbackParam` to the following functions:
- readPrivateKey
- readX509
- loadSSLCert

*Files: UtilitySSL.cpp/h*

2. The classes that use `loadSSLCert()` have been modified to pass `this` in the newly added `passwordCallbackParam`. This parameter will be wired by OpenSSL to the static callback method `passPhraseHandleCB()` as the forth argument.  The argument is of type `void*`, so it is cast to the appropriate class type and call to the member method `passwordHandleCallback`


*Files: SSLSocketAcceptor.cpp/h, SSLSocketInitiator.cpp/h, ThreadedSSLSocketAcceptor.cpp/h ThreadedSSLSocketInitiator.cpp/h*

---

Solves issue #284. When initial SSL handshake fails the initiator will no longer fail all subsequent reconnects.

**Change summary:**
1. The SSLSocketInitiator::onConnect is updated such that when `handshakeSSL()` fails, it will notify the session about the connection failure. The session will in turn close the connection, remove it from the monitor and remove it as a responder.

*Files: SSLSocketInitiator.cpp*