### PR TITLE
Fix buffer overflows when buffers are misused.

### DIFF
--- a/src/C++/test/DataDictionaryTestCase.cpp
+++ b/src/C++/test/DataDictionaryTestCase.cpp
@@ -1211,7 +1211,7 @@ TEST(readFromDocument_FIXNodeNotAtRoot) {
 
   std::stringbuf buffer;
   std::string dictionaryXml = "<notFIXRoot></notFIXroot>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1225,7 +1225,7 @@ TEST(readFromDocument_TypeAttributeNotFIXorFIXT) {
 
   std::stringbuf buffer;
   std::string dictionaryXml = "<fix type='WrongType' major='4' minor='2' servicepack='0'></fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1239,7 +1239,7 @@ TEST(readFromDocument_MajorAttributeMissing) {
 
   std::stringbuf buffer;
   std::string dictionaryXml = "<fix type='FIX' minor='2' servicepack='0'></fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1253,7 +1253,7 @@ TEST(readFromDocument_MinorAttributeMissing) {
 
   std::stringbuf buffer;
   std::string dictionaryXml = "<fix type='FIX' major='4' servicepack='0'></fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1267,7 +1267,7 @@ TEST(readFromDocument_FieldsSectionMissing) {
 
   std::stringbuf buffer;
   std::string dictionaryXml = "<fix type='FIX' major='4' minor='2' servicepack='0'></fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1286,7 +1286,7 @@ TEST(readFromDocument_FieldNameAttributeMissing) {
           "<field number='8' type='STRING' />" // name attribute missing
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1305,7 +1305,7 @@ TEST(readFromDocument_FieldNumberAttributeMissing) {
           "<field name='BeginString' type='STRING' />" // number attribute missing
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1324,7 +1324,7 @@ TEST(readFromDocument_FieldTypeAttributeMissing) {
           "<field number='8' name='BeginString' />" // type attribute missing
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1345,7 +1345,7 @@ TEST(readFromDocument_FieldValueNodeMissingEnumAttribute) {
           "</field>"
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1366,7 +1366,7 @@ TEST(readFromDocument_HeaderNodeMissing) {
           "</field>"
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1390,7 +1390,7 @@ TEST(readFromDocument_HeaderFieldNodeMissingNameAttribute) {
           "</field>"
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1414,7 +1414,7 @@ TEST(readFromDocument_TrailerNodeMissing) {
           "</field>"
         "</fields>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1441,7 +1441,7 @@ TEST(readFromDocument_TrailerFieldNodeMissingNameAttribute) {
           "<field required='Y' />" // name attribute missing
         "</trailer>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1474,7 +1474,7 @@ TEST(readFromDocument_MessagesNodeMissing) {
           "</group>"
         "</trailer>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1510,7 +1510,7 @@ TEST(readFromDocument_MessageNodeMissingMsgTypeAttribute) {
           "</group>"
         "</trailer>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1548,7 +1548,7 @@ TEST(readFromDocument_MessagesFieldNodeMissingNameAttribute) {
           "</group>"
         "</trailer>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1595,7 +1595,7 @@ TEST(readFromDocument_GroupNodeMissingNameAttribute) {
             "</component>"
           "</components>"
         "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1637,7 +1637,7 @@ TEST(readFromDocument_MessagesGroupNodeFieldNodeMissingNameAttribute) {
           "</group>"
         "</trailer>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1674,7 +1674,7 @@ TEST(readFromDocument_GroupFieldMissingAssociatedFieldNodeInFieldsNode) {
           "</group>"
         "</trailer>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1719,7 +1719,7 @@ TEST(readFromDocument_ComponentNodeMissingNameAttribute) {
           "</component>"
         "</components>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1764,7 +1764,7 @@ TEST(readFromDocument_ComponentNodeInMessageNotFound) {
           "</component>"
         "</components>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1809,7 +1809,7 @@ TEST(readFromDocument_ComponentNodeHasFieldNodeWithMissingNameAttribute) {
           "</component>"
         "</components>"
       "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());
@@ -1846,7 +1846,7 @@ TEST(readFromDocument_VersionPreFIX42_FieldTypeCharTreatedAsString) {
             "<field name='SignatureLength' required='Y' />"
           "</trailer>"
         "</fix>";
-  buffer.sputn(dictionaryXml.c_str(),1000);
+  buffer.sputn(dictionaryXml.c_str(), dictionaryXml.size());
   std::istream is(&buffer);
 
   DOMDocumentPtr pDoc(new PUGIXML_DOMDocument());

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -429,7 +429,7 @@ TEST(checkSumConvertTo)
 
 TEST(integerToStringPadded)
 {
-  char result[5];
+  char result[6] = {'\0'};
   int fraction = 1234;
   int precision = 5;
   CHECK_EQUAL(result, integer_to_string_padded(result, precision, fraction));

--- a/src/C++/test/FieldMapTestCase.cpp
+++ b/src/C++/test/FieldMapTestCase.cpp
@@ -36,7 +36,7 @@ SUITE(FieldMapTests)
 
 TEST(setMessageOrder)
 {
-  int order[] = {1, 2, 3};
+  int order[] = {1, 2, 3, 0}; // '0' is used to signify the end of array passed to FieldMap()
   FieldMap fieldMap(order);
   fieldMap.setField(3, "account");
   fieldMap.setField(1, "adv_id");


### PR DESCRIPTION
This PR fixes some buffer overflow errors, as mentioned in #277 .

In general, to know the bounds of a buffer (i.e., a contiguous chunk of memory), we can either (1) find a terminating value in the buffer itself (e.g., '\0' for C string), or (2) use an additional variable to indicate the size. Buffer overflows can happen if the terminating value is not properly set, or the size information is incorrect. This patch fixes those errors.