### PR TITLE
Fix buffer overflow by making precision bounded.

### DIFF
--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -30,6 +30,7 @@
 #include "Exceptions.h"
 #include "Utility.h"
 #include "config-all.h"
+#include <assert.h>
 #include <string>
 #include <sstream>
 #include <iomanip>
@@ -136,6 +137,16 @@ inline char* integer_to_string_padded
   while( p > buf )
     *--p = paddingChar;
   return p;
+}
+
+template<typename T>
+T clamp_of( const T& value, const T& lowerBound, const T& upperBound )
+{
+  assert( lowerBound <= upperBound );
+  if( value < lowerBound )
+    return lowerBound;
+  else
+    return ( value > upperBound ) ? upperBound : value;
 }
 
 /// Empty converter is a no-op.
@@ -428,6 +439,8 @@ struct UtcTimeStampConvertor
     char result[ 17+10 ]; // Maximum
     int year, month, day, hour, minute, second, fraction;
 
+    precision = clamp_of( precision, 0, 9 );
+
     value.getYMD( year, month, day );
     value.getHMS( hour, minute, second, fraction, precision );
 
@@ -537,6 +550,8 @@ struct UtcTimeOnlyConvertor
   {
     char result[ 8+10 ]; // Maximum
     int hour, minute, second, fraction;
+
+    precision = clamp_of( precision, 0, 9 );
 
     value.getHMS( hour, minute, second, fraction, precision );
 

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -263,6 +263,15 @@ TEST(utcTimeStampConvertToNano)
   CHECK_EQUAL( "20000426-12:05:06.555555555", UtcTimeStampConvertor::convert( input, 9 ) );
 }
 
+TEST(utcTimeStampConvertToPrecisionBounds)
+{
+  UtcTimeStamp input;
+  input.setHMS( 12, 5, 6, 555555555, 9 );
+  input.setYMD( 2000, 4, 26 );
+  CHECK_EQUAL( "20000426-12:05:06", UtcTimeStampConvertor::convert( input, -1000 ) );
+  CHECK_EQUAL( "20000426-12:05:06.555555555", UtcTimeStampConvertor::convert( input, 1000 ) );
+}
+
 TEST(utcTimeStampConvertFromSecond)
 {
   UtcTimeStamp result = UtcTimeStampConvertor::convert
@@ -385,6 +394,14 @@ TEST(utcTimeOnlyConvertToNano)
   input.setHMS( 12, 5, 6, 555555555, 9 );
   CHECK_EQUAL( "12:05:06", UtcTimeOnlyConvertor::convert( input ) );
   CHECK_EQUAL( "12:05:06.555555555", UtcTimeOnlyConvertor::convert( input, 9 ) );
+}
+
+TEST(utcTimeOnlyConvertToPrecisionBounds)
+{
+  UtcTimeOnly input;
+  input.setHMS( 12, 5, 6, 555555555, 9 );
+  CHECK_EQUAL( "12:05:06", UtcTimeOnlyConvertor::convert( input, -1000 ) );
+  CHECK_EQUAL( "12:05:06.555555555", UtcTimeOnlyConvertor::convert( input, 1000 ) );
 }
 
 TEST(utcTimeOnlyConvertFromMicro)


### PR DESCRIPTION
This patch fixes a buffer overflow issue, as illustrated in #229 

It is caused by unbounded precision input when converting time to string. The buffer only supports a maximum of 9 chars, and thus buffer overflow happens if the input precision is greater than 9 (i.e., upper bound). This solution is to set precision to the lower (upper) bound when it underflows (overflows).