### PR TITLE
Add GitHub pipelines

### DIFF
--- a/.github/workflows/build_sln.yml
+++ b/.github/workflows/build_sln.yml
@@ -29,3 +29,18 @@ jobs:
           TargetFrameworkVersion: ${{ matrix.targetframeworkversion }}
           PlatformToolset: ${{ matrix.platformtoolset }}
           WindowsTargetPlatformVersion: ${{ matrix.windowstargetplatformversion }}
+      - name: Upload lib
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-lib
+          path: ./**/lib/**
+      - name: Upload bin
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-bin
+          path: ./**/bin/**
+      - name: Upload test
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-test
+          path: ./**/test/**

--- a/.github/workflows/build_sln.yml
+++ b/.github/workflows/build_sln.yml
@@ -15,6 +15,10 @@ jobs:
                   targetframeworkversion: v4.8
                   platformtoolset: v142
                   windowstargetplatformversion: 10.0
+                - runner: windows-2019
+                  platform: Win32
+                  configuration: Release
+                  copyheaders: true
       steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -29,18 +33,24 @@ jobs:
           TargetFrameworkVersion: ${{ matrix.targetframeworkversion }}
           PlatformToolset: ${{ matrix.platformtoolset }}
           WindowsTargetPlatformVersion: ${{ matrix.windowstargetplatformversion }}
+      - name: Upload Headers
+        if: ${{ matrix.copyheaders }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop-headers
+          path: ./include/**
       - name: Upload lib
         uses: actions/upload-artifact@v2
         with:
           name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-lib
-          path: ./**/lib/**
+          path: ./lib/**
       - name: Upload bin
         uses: actions/upload-artifact@v2
         with:
           name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-bin
-          path: ./**/bin/**
+          path: ./bin/**
       - name: Upload test
         uses: actions/upload-artifact@v2
         with:
           name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-test
-          path: ./**/test/**
+          path: ./test/**

--- a/.github/workflows/build_sln.yml
+++ b/.github/workflows/build_sln.yml
@@ -1,0 +1,31 @@
+name: Build Visual Studio Solution
+on: [pull_request, push]
+
+jobs:
+    build:
+      runs-on: ${{ matrix.runner }}
+      strategy:
+          matrix:
+              runner: [windows-2019]
+              platform: [Mixed Platforms, Win32]
+              configuration: [Debug, Release]
+              include:
+                - runner: windows-2019
+                  solution: quickfix_vs15.sln
+                  targetframeworkversion: v4.8
+                  platformtoolset: v142
+                  windowstargetplatformversion: 10.0
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.0.0
+      - name: Build
+        run: msbuild $env:Solution /t:Build /p:Platform=$env:Platform /p:Configuration=$env:Configuration /p:TargetFrameworkVersion=$env:TargetFrameworkVersion /p:PlatformToolset=$env:PlatformToolset /p:WindowsTargetPlatformVersion=$env:WindowsTargetPlatformVersion
+        env:
+          Configuration: ${{ matrix.configuration }}
+          Platform: ${{ matrix.platform }}
+          Solution: ${{ matrix.solution }}
+          TargetFrameworkVersion: ${{ matrix.targetframeworkversion }}
+          PlatformToolset: ${{ matrix.platformtoolset }}
+          WindowsTargetPlatformVersion: ${{ matrix.windowstargetplatformversion }}

--- a/.github/workflows/build_test_autotools.yml
+++ b/.github/workflows/build_test_autotools.yml
@@ -12,6 +12,8 @@ jobs:
               include:
                 - runner: ubuntu-latest
                   compiler-settings: CXX=clang++ CC=clang
+                - runner: macos-latest
+                  compiler-settings: CXX=g++ CC=gcc
       steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/build_test_autotools.yml
+++ b/.github/workflows/build_test_autotools.yml
@@ -8,9 +8,10 @@ jobs:
           matrix:
               runner: [ubuntu-latest, macos-latest]
               configuration: [Release]
+              compiler-settings: ['']
               include:
-                - configuration: Release
-                  config: release
+                - runner: ubuntu-latest
+                  compiler-settings: CXX=clang++ CC=clang
       steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -23,9 +24,15 @@ jobs:
         shell: bash
         run: ./bootstrap
 
+      - name: Configure ${{ matrix.compiler-settings }}
+        shell: bash
+        run: ${{ matrix.compiler-settings }} ./configure
+        if: ${{ success() && matrix.compiler-settings != '' }}
+
       - name: Configure
         shell: bash
         run: ./configure
+        if: ${{ success() && matrix.compiler-settings == '' }}
 
       - name: Make
         shell: bash

--- a/.github/workflows/build_test_autotools.yml
+++ b/.github/workflows/build_test_autotools.yml
@@ -1,0 +1,36 @@
+name: Build with Autotools
+on: [pull_request, push]
+
+jobs:
+    build:
+      runs-on: ${{ matrix.runner }}
+      strategy:
+          matrix:
+              runner: [ubuntu-latest, macos-latest]
+              configuration: [Release]
+              include:
+                - configuration: Release
+                  config: release
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install autoconf and automake for macOS
+        if: matrix.runner == 'macos-latest'
+        run: brew install autoconf automake
+
+      - name: Bootstrap
+        shell: bash
+        run: ./bootstrap
+
+      - name: Configure
+        shell: bash
+        run: ./configure
+
+      - name: Make
+        shell: bash
+        run:  make -j
+
+      - name: Make check
+        shell: bash
+        run: make check

--- a/.github/workflows/build_test_autotools.yml
+++ b/.github/workflows/build_test_autotools.yml
@@ -33,6 +33,10 @@ jobs:
 
       - name: Make check
         shell: bash
+        run: make check
+
+      - name: Cat test-suite.log
+        if: ${{ always() }}
+        shell: bash
         run: |
-          make check
-          cat test/test-suite.log
+          test -f test/test-suite.log && cat test/test-suite.log

--- a/.github/workflows/build_test_autotools.yml
+++ b/.github/workflows/build_test_autotools.yml
@@ -33,4 +33,6 @@ jobs:
 
       - name: Make check
         shell: bash
-        run: make check
+        run: |
+          make check
+          cat test/test-suite.log

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -31,37 +31,29 @@ jobs:
           cmake --build . --config $Configuration
         env:
           Configuration: ${{ matrix.configuration }}
-      - name: Make symbolic links for testing apps
-        shell: bash
-        if: ${{ matrix.runner == 'ubuntu-latest' }}
-        run: |
-          cd build
-          cmake --build . --target at_target
-          cmake --build . --target pt_target
-          cmake --build . --target ut_target
       - name: Set tests paths windows-2019
         shell: bash
         if: ${{ matrix.runner == 'windows-2019' }}
         run: |
-          echo "::set-env name=at::test/$Config/at/at.exe"
-          echo "::set-env name=pt::test/$Config/pt/pt.exe"
-          echo "::set-env name=ut::test/$Config/ut/ut.exe"
+          echo "::set-env name=at::$PWD/test/$Config/at/at.exe"
+          echo "::set-env name=pt::$PWD/test/$Config/pt/pt.exe"
+          echo "::set-env name=ut::$PWD/test/$Config/ut/ut.exe"
         env:
           Config: ${{ matrix.config }}
       - name: Set tests paths ubuntu-latest
         shell: bash
         if: ${{ matrix.runner == 'ubuntu-latest' }}
         run: |
-          echo "::set-env name=at::test/at"
-          echo "::set-env name=pt::test/pt"
-          echo "::set-env name=ut::test/ut"
+          echo "::set-env name=at::$PWD/test/at"
+          echo "::set-env name=pt::$PWD/test/pt"
+          echo "::set-env name=ut::$PWD/test/ut"
       - name: Set tests paths macos-latest
         shell: bash
         if: ${{ matrix.runner == 'macos-latest' }}
         run: |
-          echo "::set-env name=at::test/at"
-          echo "::set-env name=pt::test/pt"
-          echo "::set-env name=ut::test/ut"
+          echo "::set-env name=at::$PWD/test/at"
+          echo "::set-env name=pt::$PWD/test/pt"
+          echo "::set-env name=ut::$PWD/test/ut"
       - name: Echo test paths ${{ matrix.runner }}
         shell: bash
         run: |
@@ -96,3 +88,14 @@ jobs:
           at_check: ${{ env.at_check }}
           pt_check: ${{ env.pt_check }}
           ut_check: ${{ env.ut_check }}
+      - name: Run unit tests
+        if: ${{ env.ut_check == 'true' }}
+        shell: bash
+        working-directory: ./test
+        run: |
+          $ut -p $PORT -f cfg/ut.cfg
+        env:
+          PORT: 6666
+          at: ${{ env.at }}
+          pt: ${{ env.pt }}
+          ut: ${{ env.ut }}

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -118,7 +118,7 @@ jobs:
           $pt -p $PORT -c 500000
         env:
           pt: ${{ env.pt }}
-          PORT: 6666
+          PORT: 6667
       - name: Run unit tests
         if: ${{ env.ut_check == 'true' }}
         shell: bash
@@ -127,4 +127,4 @@ jobs:
           $ut -p $PORT -f cfg/ut.cfg
         env:
           ut: ${{ env.ut }}
-          PORT: 6666
+          PORT: 6668

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -1,0 +1,23 @@
+name: Build with CMake
+on: [pull_request, push]
+
+jobs:
+    build:
+      runs-on: ${{ matrix.runner }}
+      strategy:
+          matrix:
+              runner: [windows-2019, ubuntu-latest, macos-latest]
+              configuration: [Debug, Release]
+              include:
+                - runner: windows-2019
+                  solution: quickfix_vs15.sln
+                  targetframeworkversion: v4.8
+                  platformtoolset: v142
+                  windowstargetplatformversion: 10.0
+                - runner: windows-2019
+                  platform: Win32
+                  configuration: Release
+                  copyheaders: true
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v2

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -11,8 +11,10 @@ jobs:
               include:
                 - configuration: Debug
                   config: debug
+                  portoffset: 0
                 - configuration: Release
                   config: release
+                  portoffset: 1
       steps:
       - name: Echo event_name ${{ github.event_name }}
         shell: bash
@@ -98,33 +100,38 @@ jobs:
         shell: cmd
         working-directory: ./test
         run: |
+          set /a "PORT=%PortBase%+%Offset%"
           runat %CONFIG% %PORT%
         env:
           CONFIG: ${{ matrix.config }}
-          PORT: 6666
+          PortBase: 6666
+          Offset: ${{ matrix.portoffset }}
       - name: Run acceptance tests for ${{ matrix.runner }}
         if: ${{ env.at_check == 'true' && matrix.runner != 'windows-2019' && github.event_name == 'pull_request' }}
         shell: bash
         working-directory: ./test
         run: |
-          ./runat.sh $PORT
+          ./runat.sh $(($PortBase + $Offset))
         env:
-          PORT: 6666
+          PortBase: 6666
+          Offset: ${{ matrix.portoffset }}
       - name: Run performance tests
         if: ${{ env.pt_check == 'true' && matrix.configuration == 'Release' }}
         shell: bash
         working-directory: ./test
         run: |
-          $pt -p $PORT -c 500000
+          $pt -p $(($PortBase + $Offset)) -c 500000
         env:
           pt: ${{ env.pt }}
-          PORT: 6667
+          PortBase: 6668
+          Offset: ${{ matrix.portoffset }}
       - name: Run unit tests
         if: ${{ env.ut_check == 'true' }}
         shell: bash
         working-directory: ./test
         run: |
-          $ut -p $PORT -f cfg/ut.cfg
+          $ut -p $(($PortBase + $Offset)) -f cfg/ut.cfg
         env:
           ut: ${{ env.ut }}
-          PORT: 6668
+          PortBase: 6670
+          Offset: ${{ matrix.portoffset }}

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_BUILD_TYPE=$Configuration
+          cmake .. -DCMAKE_BUILD_TYPE=$Configuration -DCMAKE_INSTALL_PREFIX=../install_prefix/$Configuration
         env:
           Configuration: ${{ matrix.configuration }}
       - name: Build
@@ -24,5 +24,12 @@ jobs:
         run: |
           cd build
           cmake --build . --config $Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}
+      - name: Install
+        shell: bash
+        run: |
+          cd build
+          cmake --install . --config $Configuration
         env:
           Configuration: ${{ matrix.configuration }}

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -8,16 +8,21 @@ jobs:
           matrix:
               runner: [windows-2019, ubuntu-latest, macos-latest]
               configuration: [Debug, Release]
-              include:
-                - runner: windows-2019
-                  solution: quickfix_vs15.sln
-                  targetframeworkversion: v4.8
-                  platformtoolset: v142
-                  windowstargetplatformversion: 10.0
-                - runner: windows-2019
-                  platform: Win32
-                  configuration: Release
-                  copyheaders: true
       steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Generate
+        shell: bash
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_BUILD_TYPE=$Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}
+      - name: Build
+        shell: bash
+        run: |
+          cd build
+          cmake --build . --config $Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -14,6 +14,11 @@ jobs:
                 - configuration: Release
                   config: release
       steps:
+      - name: Echo event_name ${{ github.event_name }}
+        shell: bash
+        run: echo "github.event_name $event_name"
+        env:
+          event_name: ${{ github.event_name }}
       - name: Checkout
         uses: actions/checkout@v2
       - name: Generate
@@ -88,15 +93,23 @@ jobs:
           at_check: ${{ env.at_check }}
           pt_check: ${{ env.pt_check }}
           ut_check: ${{ env.ut_check }}
-      - name: Run unit tests
-        if: ${{ env.ut_check == 'true' }}
+      - name: Run acceptance tests for windows-2019
+        if: ${{ env.at_check == 'true' && matrix.runner == 'windows-2019' }}
+        shell: cmd
+        working-directory: ./test
+        run: |
+          runat %CONFIG% %PORT%
+        env:
+          CONFIG: ${{ matrix.config }}
+          PORT: 6666
+      - name: Run acceptance tests for ${{ matrix.runner }}
+        if: ${{ env.at_check == 'true' && matrix.runner != 'windows-2019' }}
         shell: bash
         working-directory: ./test
         run: |
-          $ut -p $PORT -f cfg/ut.cfg
+          ./runat.sh $PORT
         env:
           PORT: 6666
-          ut: ${{ env.ut }}
       - name: Run performance tests
         if: ${{ env.pt_check == 'true' && matrix.configuration == 'Release' }}
         shell: bash
@@ -104,5 +117,14 @@ jobs:
         run: |
           $pt -p $PORT -c 500000
         env:
-          PORT: 6666
           pt: ${{ env.pt }}
+          PORT: 6666
+      - name: Run unit tests
+        if: ${{ env.ut_check == 'true' }}
+        shell: bash
+        working-directory: ./test
+        run: |
+          $ut -p $PORT -f cfg/ut.cfg
+        env:
+          ut: ${{ env.ut }}
+          PORT: 6666

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -96,6 +96,13 @@ jobs:
           $ut -p $PORT -f cfg/ut.cfg
         env:
           PORT: 6666
-          at: ${{ env.at }}
-          pt: ${{ env.pt }}
           ut: ${{ env.ut }}
+      - name: Run performance tests
+        if: ${{ env.pt_check == 'true' && matrix.configuration == 'Release' }}
+        shell: bash
+        working-directory: ./test
+        run: |
+          $pt -p $PORT -c 500000
+        env:
+          PORT: 6666
+          pt: ${{ env.pt }}

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -94,7 +94,7 @@ jobs:
           pt_check: ${{ env.pt_check }}
           ut_check: ${{ env.ut_check }}
       - name: Run acceptance tests for windows-2019
-        if: ${{ env.at_check == 'true' && matrix.runner == 'windows-2019' }}
+        if: ${{ env.at_check == 'true' && matrix.runner == 'windows-2019' && github.event_name == 'pull_request' }}
         shell: cmd
         working-directory: ./test
         run: |
@@ -103,7 +103,7 @@ jobs:
           CONFIG: ${{ matrix.config }}
           PORT: 6666
       - name: Run acceptance tests for ${{ matrix.runner }}
-        if: ${{ env.at_check == 'true' && matrix.runner != 'windows-2019' }}
+        if: ${{ env.at_check == 'true' && matrix.runner != 'windows-2019' && github.event_name == 'pull_request' }}
         shell: bash
         working-directory: ./test
         run: |

--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -8,6 +8,11 @@ jobs:
           matrix:
               runner: [windows-2019, ubuntu-latest, macos-latest]
               configuration: [Debug, Release]
+              include:
+                - configuration: Debug
+                  config: debug
+                - configuration: Release
+                  config: release
       steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -26,10 +31,68 @@ jobs:
           cmake --build . --config $Configuration
         env:
           Configuration: ${{ matrix.configuration }}
-      - name: Install
+      - name: Make symbolic links for testing apps
         shell: bash
+        if: ${{ matrix.runner == 'ubuntu-latest' }}
         run: |
           cd build
-          cmake --install . --config $Configuration
+          cmake --build . --target at_target
+          cmake --build . --target pt_target
+          cmake --build . --target ut_target
+      - name: Set tests paths windows-2019
+        shell: bash
+        if: ${{ matrix.runner == 'windows-2019' }}
+        run: |
+          echo "::set-env name=at::test/$Config/at/at.exe"
+          echo "::set-env name=pt::test/$Config/pt/pt.exe"
+          echo "::set-env name=ut::test/$Config/ut/ut.exe"
         env:
-          Configuration: ${{ matrix.configuration }}
+          Config: ${{ matrix.config }}
+      - name: Set tests paths ubuntu-latest
+        shell: bash
+        if: ${{ matrix.runner == 'ubuntu-latest' }}
+        run: |
+          echo "::set-env name=at::test/at"
+          echo "::set-env name=pt::test/pt"
+          echo "::set-env name=ut::test/ut"
+      - name: Set tests paths macos-latest
+        shell: bash
+        if: ${{ matrix.runner == 'macos-latest' }}
+        run: |
+          echo "::set-env name=at::test/at"
+          echo "::set-env name=pt::test/pt"
+          echo "::set-env name=ut::test/ut"
+      - name: Echo test paths ${{ matrix.runner }}
+        shell: bash
+        run: |
+          echo "at: $at"
+          echo "pt: $pt"
+          echo "ut: $ut"
+        env:
+          at: ${{ env.at }}
+          pt: ${{ env.pt }}
+          ut: ${{ env.ut }}
+      - name: Check if tests were built
+        id: check_files
+        shell: bash
+        run: |
+          AT=$( test -f $at && echo "true" || echo "false" )
+          PT=$( test -f $pt && echo "true" || echo "false" )
+          UT=$( test -f $ut && echo "true" || echo "false" )
+          echo "::set-env name=at_check::$AT"
+          echo "::set-env name=pt_check::$PT"
+          echo "::set-env name=ut_check::$UT"
+        env:
+          at: ${{ env.at }}
+          pt: ${{ env.pt }}
+          ut: ${{ env.ut }}
+      - name: Echo test checks ${{ matrix.runner }}
+        shell: bash
+        run: |
+          echo "at_check: $at_check"
+          echo "pt_check: $pt_check"
+          echo "ut_check: $ut_check"
+        env:
+          at_check: ${{ env.at_check }}
+          pt_check: ${{ env.pt_check }}
+          ut_check: ${{ env.ut_check }}

--- a/.github/workflows/build_test_sln.yml
+++ b/.github/workflows/build_test_sln.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           name: drop-headers
           path: ./include/**
+      - name: Upload Specs
+        if: ${{ matrix.copyheaders }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: drop-specs
+          path: ./spec/**
       - name: Upload lib
         uses: actions/upload-artifact@v2
         with:
@@ -54,3 +60,36 @@ jobs:
         with:
           name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-test
           path: ./test/**
+
+    test:
+      runs-on: ${{ matrix.runner }}
+      needs: build
+      strategy:
+          matrix:
+              runner: [windows-2019]
+              platform: [Mixed Platforms, Win32]
+              configuration: [Debug, Release]
+              include:
+                - configuration: Debug
+                  configrun: debug
+                - configuration: Release
+                  configrun: release
+      steps:
+      - name: Download
+        uses: actions/download-artifact@v2
+        with:
+          name: drop-${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}-test
+          path: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
+      - name: Download Specs
+        uses: actions/download-artifact@v2
+        with:
+          name: drop-specs
+          path: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}
+      - name: Run Unit Tests
+        working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/tests
+        run: |
+          echo %CD%\runut %CONFIGURATION% 6666
+          runut %CONFIGURATION% 6666
+        shell: cmd
+        env:
+          CONFIGURATION: ${{ matrix.configrun }}

--- a/.github/workflows/build_test_sln.yml
+++ b/.github/workflows/build_test_sln.yml
@@ -74,6 +74,18 @@ jobs:
                   configrun: debug
                 - configuration: Release
                   configrun: release
+                - platform: Mixed Platforms
+                  configuration: Debug
+                  port: 6666
+                - platform: Mixed Platforms
+                  configuration: Release
+                  port: 6667
+                - platform: Win32
+                  configuration: Debug
+                  port: 6668
+                - platform: Win32
+                  configuration: Release
+                  port: 6669
       steps:
       - name: Download
         uses: actions/download-artifact@v2
@@ -88,8 +100,8 @@ jobs:
       - name: Run Unit Tests
         working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
         run: |
-          echo %CD%\runut %CONFIGURATION% 6666
-          runut %CONFIGURATION% 6666
+          runut %CONFIGURATION% %PORT%
         shell: cmd
         env:
           CONFIGURATION: ${{ matrix.configrun }}
+          PORT: ${{ matrix.port }}

--- a/.github/workflows/build_test_sln.yml
+++ b/.github/workflows/build_test_sln.yml
@@ -105,3 +105,12 @@ jobs:
         env:
           CONFIGURATION: ${{ matrix.configrun }}
           PORT: ${{ matrix.port }}
+      - name: Run Performance Tests
+        if: ${{ matrix.configuration == 'Release' }}
+        working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
+        run: |
+          runpt %CONFIGURATION% %PORT%
+        shell: cmd
+        env:
+          CONFIGURATION: ${{ matrix.configrun }}
+          PORT: ${{ matrix.port }}

--- a/.github/workflows/build_test_sln.yml
+++ b/.github/workflows/build_test_sln.yml
@@ -97,10 +97,10 @@ jobs:
         with:
           name: drop-specs
           path: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/spec
-      - name: Run Unit Tests
+      - name: Run Acceptance Tests
         working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
         run: |
-          runut %CONFIGURATION% %PORT%
+          runat %CONFIGURATION% %PORT%
         shell: cmd
         env:
           CONFIGURATION: ${{ matrix.configrun }}
@@ -110,6 +110,14 @@ jobs:
         working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
         run: |
           runpt %CONFIGURATION% %PORT%
+        shell: cmd
+        env:
+          CONFIGURATION: ${{ matrix.configrun }}
+          PORT: ${{ matrix.port }}
+      - name: Run Unit Tests
+        working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
+        run: |
+          runut %CONFIGURATION% %PORT%
         shell: cmd
         env:
           CONFIGURATION: ${{ matrix.configrun }}

--- a/.github/workflows/build_test_sln.yml
+++ b/.github/workflows/build_test_sln.yml
@@ -98,6 +98,7 @@ jobs:
           name: drop-specs
           path: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/spec
       - name: Run Acceptance Tests
+        if: ${{ matrix.configuration == 'Release' && github.event_name == 'pull_request' }}
         working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
         run: |
           runat %CONFIGURATION% %PORT%

--- a/.github/workflows/build_test_sln.yml
+++ b/.github/workflows/build_test_sln.yml
@@ -84,9 +84,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: drop-specs
-          path: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}
+          path: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/spec
       - name: Run Unit Tests
-        working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/tests
+        working-directory: ./${{ matrix.runner }}-${{ matrix.platform }}-${{ matrix.configuration }}/test
         run: |
           echo %CD%\runut %CONFIGURATION% 6666
           runut %CONFIGURATION% 6666


### PR DESCRIPTION
This PR adds three pipelines to the repo, watching push and pull request events:

1. Build with Autotools ([build_test_autotools.yml](https://github.com/tarc/quickfix/blob/89981c9d8243b179bbad82d5fce966e19553887f/.github/workflows/build_test_autotools.yml)).
2. Build with CMake ([build_test_cmake.yml](https://github.com/tarc/quickfix/blob/89981c9d8243b179bbad82d5fce966e19553887f/.github/workflows/build_test_cmake.yml)).
3. Build Visual Studio Solution ([build_test_sln.yml](https://github.com/tarc/quickfix/blob/89981c9d8243b179bbad82d5fce966e19553887f/.github/workflows/build_test_sln.yml)).

They make use of the integrated GitHub actions.

As the pipelines were being developed, some "bugs" were catched:

- A copy of Except.h was missing for WIN32 builds from cmake/QuickfixPrebuildSetup.cmake.
- `DataDictionaryTestCase` is buggy on Windows.
- `resetBeforeAndAfterWithTestFileManager` fixture from `FileStoreTestCase` is also buggy on Windows.

So a `#ifndef _MSC_VER` was added to take `resetBeforeAndAfterWithTestFileManager` out of the Windows compilation and the entries for `DataDictionaryTestCase` were commented out from src/CMakeLists.txt and from src/test_unit_vs15.vcxproj.
 
However, #280  fixes the issue with `DataDictionaryTestCase`, as it's possible to check by merging the present PR with that, reversing the last commit from the present PR and waiting for the tests to complete.

I understand that there's already a CI with Travis, but the present PR covers a more complete range of configurations. The Autotools pipeline runs on Linux and macOS; the CMake one, on Windows, Linux and macOS. The Visual Studio pipeline is the only one that covers only Windows runs.

As to configurations, the CMake pipeline covers debug and release, but do not touch architecture. The Visual Studio is the most complete in this regard, as it covers debug and release for the Win32 and Mixed Platforms architectures (those being the ones that make sense to build from quickfix_vs15.sln). The Autotools pipeline also do not touch on architecture and covers only release.

When it is possible the pipelines cover building and the three kinds of testing present - `at`, `pt` and `ut`. I think they stood for "Acceptance Tests", "Performance Tests" and "Unit Tests". Although it can be easily implemented, there are no tests for macOS. Also, the acceptance tests are set to be performed only for release builds triggered by pull requests. Performance tests also run only for release builds (but do so for both push and pull requests). Unit tests run always (except for macOS, as said earlier).

The Autotools pipeline just runs a `make check` after the build and then cats test/test-suite.log. The same actions as the ones done by Travis.

The only solution being used by the Visual Studio pipeline is quickfix_vs15.sln for GitHub's test runners only come with Visual Studio 2019 anyway. It was necessary to pass command line arguments to `msbuild` to force it to use the installed versions of `PlatformToolset` and `WindowsTargetPlatformVersion`:

https://github.com/quickfix/quickfix/blob/89981c9d8243b179bbad82d5fce966e19553887f/.github/workflows/build_test_sln.yml#L27-L35

If there's interest in merging this PR, I can address any issues that may arise.