### PR TITLE
Extract and test sub second precision

### DIFF
--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -90,25 +90,12 @@ Session::~Session()
 
 void Session::insertSendingTime( Header& header )
 {
-  UtcTimeStamp now;
-  bool showMilliseconds = false;
-  if( m_sessionID.getBeginString() == BeginString_FIXT11 )
-    showMilliseconds = true;
-  else
-    showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;
-
-  header.setField( SendingTime(now, showMilliseconds ? m_timestampPrecision : 0) );
+  header.setField( SendingTime(UtcTimeStamp(), getSupportedTimestampPrecision()) );
 }
 
 void Session::insertOrigSendingTime( Header& header, const UtcTimeStamp& when )
 {
-  bool showMilliseconds = false;
-  if( m_sessionID.getBeginString() == BeginString_FIXT11 )
-    showMilliseconds = true;
-  else
-    showMilliseconds = m_sessionID.getBeginString() >= BeginString_FIX42;
-
-  header.setField( OrigSendingTime(when, showMilliseconds ? m_timestampPrecision : 0) );
+  header.setField( OrigSendingTime(when, getSupportedTimestampPrecision()) );
 }
 
 void Session::fill( Header& header )

--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -199,9 +199,9 @@ public:
     }
   int getSupportedTimestampPrecision() 
     {
-      return supportsSubMillisecondTimestamps(m_sessionID.getBeginString()) ? m_timestampPrecision : 0;
+      return supportsSubSecondTimestamps(m_sessionID.getBeginString()) ? m_timestampPrecision : 0;
     }
-  static bool supportsSubMillisecondTimestamps(const std::string &beginString) 
+  static bool supportsSubSecondTimestamps(const std::string &beginString) 
   {
     if( beginString == BeginString_FIXT11 )
       return true;

--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -105,6 +105,7 @@ public:
 
   static size_t numSessions();
 
+
   bool isSessionTime(const UtcTimeStamp& time)
     { return m_sessionTime.isInRange(time); }
   bool isLogonTime(const UtcTimeStamp& time)
@@ -196,6 +197,18 @@ public:
 
       m_timestampPrecision = precision;
     }
+  int getSupportedTimestampPrecision() 
+    {
+      return supportsSubMillisecondTimestamps(m_sessionID.getBeginString()) ? m_timestampPrecision : 0;
+    }
+  static bool supportsSubMillisecondTimestamps(const std::string &beginString) 
+  {
+    if( beginString == BeginString_FIXT11 )
+      return true;
+    else
+      return beginString >= BeginString_FIX42;
+  }
+    
 
   bool getPersistMessages()
     { return m_persistMessages; }

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -233,7 +233,7 @@ private:
 
 };
 
- void fillHeader( FIX::Header& header, const char* sender, const char* target, int seq )
+void fillHeader( FIX::Header& header, const char* sender, const char* target, int seq )
 {
   header.setField( SenderCompID( sender ) );
   header.setField( TargetCompID( target ) );
@@ -601,6 +601,16 @@ struct acceptorT11Fixture : public sessionT11Fixture
 {
   acceptorT11Fixture() : sessionT11Fixture( 0 ) {}
 };
+
+TEST(supportsSubMillisecondTimestamps)
+{
+  CHECK( !Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX40) );
+  CHECK( !Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX41) );
+  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX42) );
+  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX43) );
+  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX44) );
+  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIXT11) );
+}
 
 TEST_FIXTURE(acceptorFixture, nextLogon)
 {

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -604,12 +604,12 @@ struct acceptorT11Fixture : public sessionT11Fixture
 
 TEST(supportsSubMillisecondTimestamps)
 {
-  CHECK( !Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX40) );
-  CHECK( !Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX41) );
-  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX42) );
-  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX43) );
-  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIX44) );
-  CHECK( Session::supportsSubMillisecondTimestamps(FIX::BeginString_FIXT11) );
+  CHECK( !Session::supportsSubSecondTimestamps(FIX::BeginString_FIX40) );
+  CHECK( !Session::supportsSubSecondTimestamps(FIX::BeginString_FIX41) );
+  CHECK( Session::supportsSubSecondTimestamps(FIX::BeginString_FIX42) );
+  CHECK( Session::supportsSubSecondTimestamps(FIX::BeginString_FIX43) );
+  CHECK( Session::supportsSubSecondTimestamps(FIX::BeginString_FIX44) );
+  CHECK( Session::supportsSubSecondTimestamps(FIX::BeginString_FIXT11) );
 }
 
 TEST_FIXTURE(acceptorFixture, nextLogon)


### PR DESCRIPTION
Extract logic for determining is a FIX session can support sub second timestamps. Added unit tests.