### PR TITLE
fix issue for enabling ssl in cmake build

### DIFF
--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -7,5 +7,6 @@
 #cmakedefine HAVE_SHARED_PTR_IN_TR1_NAMESPACE
 #cmakedefine HAVE_STD_TR1_SHARED_PTR_FROM_TR1_MEMORY_HEADER
 #cmakedefine HAVE_STD_UNIQUE_PTR
+#cmakedefine HAVE_SSL 1
 
 #endif


### PR DESCRIPTION
This was required by SSLSocketInitiator.cpp and other SSL related source code. Otherwise, the generated .so lib from cmake will not have any SSL related function/method/class symbols.