### PR TITLE
Add QF/J's 'appMessageJustSent' logic for Resend

### DIFF
--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -367,10 +367,12 @@ void Session::nextResendRequest( const Message& resendRequest, const UtcTimeStam
   MsgType msgType;
   int begin = 0;
   int current = beginSeqNo;
+  bool appMessageJustSent = false;
   std::string messageString;
 
   for ( i = messages.begin(); i != messages.end(); ++i )
   {
+    appMessageJustSent = false;
     SmartPtr<FIX::Message> pMsg;
     std::string strMsgType;
     const DataDictionary& sessionDD =
@@ -451,6 +453,7 @@ void Session::nextResendRequest( const Message& resendRequest, const UtcTimeStam
         m_state.onEvent( "Resending Message: "
                          + IntConvertor::convert( msgSeqNum ) );
         begin = 0;
+        appMessageJustSent = true;
       }
       else
       { if ( !begin ) begin = msgSeqNum; }
@@ -468,6 +471,8 @@ void Session::nextResendRequest( const Message& resendRequest, const UtcTimeStam
     int next = m_state.getNextSenderMsgSeqNum();
     if( endSeqNo > next )
       endSeqNo = EndSeqNo(next);
+    if ( appMessageJustSent )
+      beginSeqNo = msgSeqNum + 1;
     generateSequenceReset( beginSeqNo, endSeqNo );
   }
 


### PR DESCRIPTION
This commit addresses an error reported by a user that has migrated
their platform from QF/J to QF/C++:

- If Resend is requested
- With an EndSeqNo specified (i.e. EndSeqNo is not
zero/infinity)
- And EndSeqNo is greater than the MsgSeqNum at the end of
the Resend
- And the last message resent was an app-level message
- Then the SequenceReset-GapFill message sent after the last resent app-level
  message will have the same MsgSeqNum as that last app-level message
- Which is an error: the seqnum should be the same MsgSeqNum + 1

One way to reproduce this is to send app-level messages while the
counterparty is not logged on, causing them to be queued for send, and
to advance the seqnums forward causing a gap (e.g. in the case of a
failover where seqnums are advanced to mitigate duplication).  If the
counterparty logs on, and requests resend without an infinite EndSeqNo,
the error described above will occur.  It does not occur if EndSeqNo is
infinite.

This error does not occur in QF/J due to the 'appMessageJustSent' logic
which is added in this commit.