### PR TITLE
NoSides values in FixValues.h are int not char

### DIFF
--- a/spec/Values.xsl
+++ b/spec/Values.xsl
@@ -39,7 +39,7 @@ namespace FIX
  
 <xsl:template match="fix/fields/field/value">
 <xsl:choose>
-  <xsl:when test="../@type='INT'">
+  <xsl:when test="(../@type='INT') or (../@type='NUMINGROUP')">
  const int <xsl:value-of select="../@name"/>_<xsl:value-of select="@description"/> = <xsl:value-of select="@enum"/>;</xsl:when>
   <xsl:when test="../@type='STRING'">
  const char <xsl:value-of select="../@name"/>_<xsl:value-of select="@description"/>[] = "<xsl:value-of select="@enum"/>";</xsl:when>

--- a/spec/generate_c++.sh
+++ b/spec/generate_c++.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+xsltproc -o ../src/C++/FixValues.h Values.xsl FIX50.xml 
+xsltproc -o ../src/C++/FixTValues.h Values.xsl FIXT11.xml 
 xsltproc -o ../src/C++/fix40/MessageCracker.h MessageCracker.xsl FIX40.xml
 xsltproc -o ../src/C++/fix41/MessageCracker.h MessageCracker.xsl FIX41.xml
 xsltproc -o ../src/C++/fix42/MessageCracker.h MessageCracker.xsl FIX42.xml


### PR DESCRIPTION
NoSides is the only NUMINGROUP field that has enum values. The
code generator was generating chars for those values instead of ints.
This commit causes the generator to use int instead of char if the type
is NUMINGROUP (again, only affects NoSides currently).

Also, the sh version of the c++ generate script was not actually generating
FixValues.h and FixTValues.h (but the bat version was).