### PR TITLE
AtomicCount: add arch guards and fallback to compiler intrinsics (#206)

### DIFF
--- a/src/C++/AtomicCount.h
+++ b/src/C++/AtomicCount.h
@@ -156,6 +156,7 @@ private:
       // *pw += dv;
       // return r;
 
+#if ( defined( __i386__ ) || defined( __x86_64__ ) )
       int r;
 
       __asm__ __volatile__
@@ -168,6 +169,13 @@ private:
         );
 
       return r;
+#elif ( defined( __arm__ ) || defined( __aarch64__ ) )
+      // supported on gcc and clang
+      return __atomic_fetch_add(pw, dv, __ATOMIC_SEQ_CST);
+#else // other architectures
+      // supported on gcc and clang
+      return __atomic_fetch_add(pw, dv, __ATOMIC_SEQ_CST);
+#endif
     }
   };
 


### PR DESCRIPTION
The current implementation of `atomic_count` has unguarded inline
x86 assembly, causing failure on arm #206.

This commit adds preprocessor guards on the x86 assembly and falls back
to compiler intrinsic `__atomic_fetch_add` for other architectures.

----

Compared to previous attempts on this issue, the change is scoped to just the assembly language portion of the code.  It is minimal and there is zero change to platforms that work (x86).   

I broke out `arm` as its own `#elif` block as that's the platform that was failing and in case somebody with ARM assembly skills wants to fill that in.    Happy to change it to one `#else` if that is preferred.

