### PR TITLE
Detect overflow in IntConvertor, send Reject

### DIFF
--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -161,8 +161,8 @@ typedef EmptyConvertor StringConvertor;
 /// Converts integer to/from a string
 struct IntConvertor
 {
-  static const signed_int VALUE_MIN = std::numeric_limits<signed_int>::min();
-  static const signed_int VALUE_MAX = std::numeric_limits<signed_int>::max();
+  static const signed_int VALUE_MIN = (std::numeric_limits<signed_int>::min)();
+  static const signed_int VALUE_MAX = (std::numeric_limits<signed_int>::max)();
   static const signed_int OVERFLOW_MAX = VALUE_MAX / 10;
 
   static std::string convert( signed_int value )

--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -161,6 +161,10 @@ typedef EmptyConvertor StringConvertor;
 /// Converts integer to/from a string
 struct IntConvertor
 {
+  static const signed_int VALUE_MIN = std::numeric_limits<signed_int>::min();
+  static const signed_int VALUE_MAX = std::numeric_limits<signed_int>::max();
+  static const signed_int OVERFLOW_MAX = VALUE_MAX / 10;
+
   static std::string convert( signed_int value )
   {
     // buffer is big enough for significant digits and extra digit,
@@ -191,9 +195,11 @@ struct IntConvertor
 
     do
     {
+      if( x < 0 || x > OVERFLOW_MAX ) return false; // overflow
       const unsigned_int c = *str - '0';
       if( c > 9 ) return false;
       x = 10 * x + c;
+      if( x < 0 && ( !isNegative || x != VALUE_MIN )) return false; // overflow
     } while ( ++str != end );
 
     if( isNegative )

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -122,14 +122,22 @@ TEST(integerConvertFrom)
   CHECK_EQUAL( 12, IntConvertor::convert( "12" ) );
   CHECK_EQUAL( 100, IntConvertor::convert( "100" ) );
   CHECK_EQUAL( 1234, IntConvertor::convert( "1234" ) );
+  CHECK_EQUAL( 214748365, IntConvertor::convert( "214748365" ) );
   CHECK_EQUAL( MAX_INT, IntConvertor::convert( "2147483647" ) );
+  CHECK_THROW( IntConvertor::convert( "2147483648" ), FieldConvertError ); // overflow
+  CHECK_THROW( IntConvertor::convert( "2147483650" ), FieldConvertError ); // overflow
+  CHECK_THROW( IntConvertor::convert( "9999999999" ), FieldConvertError ); // overflow
 
   CHECK_EQUAL( -1, IntConvertor::convert( "-1" ) );
   CHECK_EQUAL( -12, IntConvertor::convert( "-12" ) );
   CHECK_EQUAL( -100, IntConvertor::convert( "-100" ) );
   CHECK_EQUAL( -1234, IntConvertor::convert( "-1234" ) );
+  CHECK_EQUAL( -214748365, IntConvertor::convert( "-214748365" ) );
   CHECK_EQUAL( -2147483647, IntConvertor::convert( "-2147483647" ) );
   CHECK_EQUAL( MIN_INT, IntConvertor::convert( "-2147483648" ) );
+  CHECK_THROW( IntConvertor::convert( "-2147483649" ), FieldConvertError ); // overflow
+  CHECK_THROW( IntConvertor::convert( "-2147483650" ), FieldConvertError ); // overflow
+  CHECK_THROW( IntConvertor::convert( "-9999999999" ), FieldConvertError ); // overflow
 
   CHECK_THROW( IntConvertor::convert( "" ), FieldConvertError );
   CHECK_THROW( IntConvertor::convert( "abc" ), FieldConvertError );


### PR DESCRIPTION
Instead of ignoring/allowing Int fields to overflow, detect this
condition and raise an exception (which will trigger a Reject).