### PR TITLE
fix double close socket

### DIFF
--- a/src/C++/SSLSocketAcceptor.cpp
+++ b/src/C++/SSLSocketAcceptor.cpp
@@ -323,7 +323,7 @@ void SSLSocketAcceptor::onConnect( SocketServer& server, socket_handle a, socket
 
   SSL *ssl = SSL_new(m_ctx);
   SSL_clear(ssl);
-  BIO *sBio = BIO_new_socket(s, BIO_CLOSE); //Unfortunately OpenSSL assumes socket is int
+  BIO *sBio = BIO_new_socket(s, BIO_NOCLOSE); //Unfortunately OpenSSL assumes socket is int
   SSL_set_bio(ssl, sBio, sBio);
   // TODO - check this
   SSL_set_app_data(ssl, m_revocationStore);

--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -398,8 +398,6 @@ void SSLSocketInitiator::onDisconnect( SocketConnector&, socket_handle s )
   if( !pSocketConnection )
     return;
 
-  setDisconnected( pSocketConnection->getSession()->getSessionID() );
-
   Session* pSession = pSocketConnection->getSession();
   if ( pSession )
   {

--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -306,7 +306,7 @@ void SSLSocketInitiator::doConnect( const SessionID& s, const Dictionary& d )
       return;
     }
     SSL_clear(ssl);
-    BIO *sbio = BIO_new_socket(result, BIO_CLOSE); //unfortunately OpenSSL assumes socket is int
+    BIO *sbio = BIO_new_socket(result, BIO_NOCLOSE); //unfortunately OpenSSL assumes socket is int
     
     if (sbio == 0)
     {


### PR DESCRIPTION
# double close socket

sockets create in

```cpp
// SSLSocketInitiator.cpp line 300
socket_handle result = m_connector.connect( address, port, m_noDelay, m_sendBufSize, m_rcvBufSize, sourceAddress, sourcePort );
```

if set

```cpp
// SSLSocketInitiator.cpp line 309
BIO *sbio = BIO_new_socket(result, BIO_CLOSE); //unfortunately OpenSSL assumes socket is int
```

will cause socket to be closed twice

1. first close

```cpp
// SocketMonitor.cpp line 108
socket_close( s );

// call stack
// SSLSocketInitiator::onDisconnect				SSLSocketInitiator.cpp
// SSLSocketConnection::disconnect				SSLSocketConnection.cpp
// SocketMonitor::drop						SocketMonitor.cpp
// socket_close							Utility.cpp
// close
```

2. second close

```cpp
// SSLSocketConnection.cpp line 160
SSL_free(m_ssl);

// call stack
// SSLSocketInitiator::onDisconnect			SSLSocketInitiator.cpp
// SSLSocketConnection::~SSLSocketConnection		SSLSocketConnection.cpp
// SSL_free
```

SSL_free close socket because set BIO_new_socket(result, BIO_CLOSE) before.

and SSLSocketAcceptor.cpp is the same as above.

## influences

if program open a new fd between two close, and get fd num equal to the socket fd num. the new open fd will be closed without knowledge. this may cause program crash.

# remove duplicate `setDisconnected`

it seems that `setDisconnected` call in src/C++/SSLSocketInitiator.cpp line 401 is duplicate and will cause crash if `pSocketConnection->getSession()` return nullptr.