### PR TITLE
Remove custom code for EMX exchange

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,6 @@
 cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
 
-option(HAVE_EMX "Build with EMX")
-
-if(HAVE_EMX)
-  message("-- Building with EMX")
-  set (quickfix_PROJECT_NAME quickfix-emx)
-else()
-  set (quickfix_PROJECT_NAME quickfix)
-endif()
+set (quickfix_PROJECT_NAME quickfix)
 
 project(${quickfix_PROJECT_NAME} VERSION 0.1 LANGUAGES CXX C)
 message("-- Project name ${CMAKE_PROJECT_NAME}")

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -1,7 +1,6 @@
 #ifndef CONFIG_H_IN
 #define CONFIG_H_IN
 
-#cmakedefine HAVE_EMX
 #cmakedefine HAVE_CXX17
 #cmakedefine HAVE_STD_SHARED_PTR
 #cmakedefine HAVE_SHARED_PTR_IN_TR1_NAMESPACE

--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -127,15 +127,8 @@ EXCEPT ( FIX::Exception )
 {  
   const Header& header = message.getHeader();
   const BeginString& beginString = FIELD_GET_REF( header, BeginString );
-#ifdef HAVE_EMX
-  const std::string & msgType = message.getSubMessageType();
-  if (msgType.empty())
-  {
-    throw InvalidMessageType("empty subMsgType, check Tag 9426/MESSAGE_ID");
-  }
-#else
   const MsgType& msgType = FIELD_GET_REF( header, MsgType );
-#endif
+
   if ( pSessionDD != 0 && pSessionDD->m_hasVersion )
   {
     if( pSessionDD->getVersion() != beginString )

--- a/src/C++/Message.cpp
+++ b/src/C++/Message.cpp
@@ -355,21 +355,6 @@ EXCEPT ( InvalidMessage )
         if ( isAdminMsgType( msg ) )
         {
           pApplicationDataDictionary = pSessionDataDictionary;
-#ifdef HAVE_EMX
-          m_subMsgType.assign(msg);
-        }
-        else
-        {
-          std::string::size_type equalSign = string.find("\0019426=", pos);
-          if (equalSign == std::string::npos)
-            throw InvalidMessage("EMX message type (9426) not found");
-
-          equalSign += 6;
-          std::string::size_type soh = string.find_first_of('\001', equalSign);
-          if (soh == std::string::npos)
-            throw InvalidMessage("EMX message type (9426) soh char not found");
-          m_subMsgType.assign(string.substr(equalSign, soh - equalSign ));
-#endif
         }
       }
 
@@ -398,11 +383,7 @@ EXCEPT ( InvalidMessage )
       appendField( field );
 
       if ( pApplicationDataDictionary )
-#ifdef HAVE_EMX
-        setGroup(m_subMsgType, field, string, pos, *this, *pApplicationDataDictionary);
-#else
         setGroup( msg, field, string, pos, *this, *pApplicationDataDictionary );
-#endif
     }
   }
 

--- a/src/C++/Message.h
+++ b/src/C++/Message.h
@@ -369,11 +369,6 @@ public:
   /// Sets the session ID of the intended recipient
   void setSessionID( const SessionID& sessionID );
 
-#ifdef HAVE_EMX
-  void  setSubMessageType(const std::string & subMsgType) { m_subMsgType.assign(subMsgType); }
-  const std::string & getSubMessageType() const { return m_subMsgType; }
-#endif
-
 private:
   FieldBase extractField(
     const std::string& string, std::string::size_type& pos,
@@ -402,9 +397,6 @@ protected:
   mutable Trailer m_trailer;
   bool m_validStructure;
   int m_tag;
-#ifdef HAVE_EMX
-  std::string m_subMsgType;
-#endif
   static SmartPtr<DataDictionary> s_dataDictionary;
 };
 /*! @} */

--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -383,20 +383,6 @@ void Session::nextResendRequest( const Message& resendRequest, const UtcTimeStam
       equalSign += 4;
       std::string::size_type soh = (*i).find_first_of('\001', equalSign);
       strMsgType = (*i).substr(equalSign, soh - equalSign);
-#ifdef HAVE_EMX
-      if (FIX::Message::isAdminMsgType(strMsgType) == false)
-      {
-        equalSign = (*i).find("\0019426=", soh);
-        if (equalSign == std::string::npos)
-          throw FIX::IOException("EMX message type (9426) not found");
-
-        equalSign += 6;
-        soh = (*i).find_first_of('\001', equalSign);
-        if (soh == std::string::npos)
-          throw FIX::IOException("EMX message type (9426) soh char not found");
-        strMsgType.assign((*i).substr(equalSign, soh - equalSign));
-      }
-#endif
     }
 
     if( m_sessionID.isFIXT() )


### PR DESCRIPTION
Looks like there was quite a bit of code in the core library objects (DataDictionary, Message, Session) pertaining to a specific exchange. This isn't an appropriate place for exchange customization.