### PR TITLE
Generate BodyLength and CheckSum when testing validation performance

### DIFF
--- a/src/C++/Exceptions.h
+++ b/src/C++/Exceptions.h
@@ -32,9 +32,9 @@ namespace FIX
 /// Base QuickFIX exception type.
 struct Exception : public std::logic_error
 {
-  Exception( const std::string& t, const std::string& d )
-  : std::logic_error( d.size() ? t + ": " + d : t ),
-    type( t ), detail( d )
+  Exception( const std::string& type, const std::string& detail )
+  : std::logic_error( detail.size() ? type + ": " + detail : type),
+    type( type ), detail( detail )
   {}
   ~Exception() NOEXCEPT {}
 
@@ -45,9 +45,9 @@ struct Exception : public std::logic_error
 /// DataDictionary not found for BeginString or ApplVerID
 struct DataDictionaryNotFound : public Exception
 {
-  DataDictionaryNotFound( const std::string& v, const std::string& what = "" )
+  DataDictionaryNotFound( const std::string& version, const std::string& what = "" )
     : Exception( "Could not find data dictionary", what ),
-                 version( v ) {}
+                 version( version ) {}
   ~DataDictionaryNotFound() NOEXCEPT {}
 
   std::string version;
@@ -56,9 +56,9 @@ struct DataDictionaryNotFound : public Exception
 /// Field not found inside a message
 struct FieldNotFound : public Exception
 {
-  FieldNotFound( int f = 0, const std::string& what = "" )
+  FieldNotFound( int field = 0, const std::string& what = "" )
     : Exception( "Field not found", what ),
-                 field( f ) {}
+                 field( field ) {}
   int field;
 };
 
@@ -100,54 +100,54 @@ struct RuntimeError : public Exception
 /// Tag number does not exist in specification
 struct InvalidTagNumber : public Exception
 {
-  InvalidTagNumber( int f = 0, const std::string& what = "" )
-    : Exception( "Invalid tag number", what ),
-                 field( f ) {}
+  InvalidTagNumber( int field = 0, const std::string& what = "" )
+    : Exception( "Invalid tag number: " + std::to_string(field), what ),
+                 field( field ) {}
   int field;
 };
 
 /// Required field is not in message
 struct RequiredTagMissing : public Exception
 {
-  RequiredTagMissing( int f = 0, const std::string& what = "" )
-    : Exception( "Required tag missing", what ),
-                 field( f ) {}
+  RequiredTagMissing( int field = 0, const std::string& what = "" )
+    : Exception( "Required tag missing: " + std::to_string(field), what ),
+                 field( field ) {}
   int field;
 };
 
 /// Field does not belong to message
 struct TagNotDefinedForMessage : public Exception
 {
-  TagNotDefinedForMessage( int f = 0, const std::string& what = "" )
-    : Exception( "Tag not defined for this message type", what ),
-                 field( f ) {}
+  TagNotDefinedForMessage( int field = 0, const std::string& what = "" )
+    : Exception( "Tag not defined for this message type: " + std::to_string(field), what ),
+                 field( field ) {}
   int field;
 };
 
 /// Field exists in message without a value
 struct NoTagValue : public Exception
 {
-  NoTagValue( int f = 0, const std::string& what = "" )
-    : Exception( "Tag specified without a value", what ),
-                 field( f ) {}
+  NoTagValue( int field = 0, const std::string& what = "" )
+    : Exception( "Tag specified without a value: " + std::to_string(field), what ),
+                 field( field ) {}
   int field;
 };
 
 /// Field has a value that is out of range
 struct IncorrectTagValue : public Exception
 {
-  IncorrectTagValue( int f = 0, const std::string& what = "" )
-    : Exception( "Value is incorrect (out of range) for this tag", what ),
-                 field( f ) {}
+  IncorrectTagValue( int field = 0, const std::string& what = "" )
+    : Exception( "Value is incorrect (out of range) for this tag: " + std::to_string(field), what ),
+                 field( field ) {}
   int field;
 };
 
 /// Field has a badly formatted value
 struct IncorrectDataFormat : public Exception
 {
-  IncorrectDataFormat( int f = 0, const std::string& what = "" )
-    : Exception( "Incorrect data format for value", what ),
-                 field( f ) {}
+  IncorrectDataFormat( int field = 0, const std::string& what = "" )
+    : Exception( "Incorrect data format for value with tag: " + std::to_string(field), what ),
+                 field( field ) {}
   int field;
 };
 
@@ -189,27 +189,27 @@ struct UnsupportedVersion : public Exception
 /// Tag is not in the correct order
 struct TagOutOfOrder : public Exception
 {
-  TagOutOfOrder( int f = 0, const std::string& what = "" )
+  TagOutOfOrder( int field = 0, const std::string& what = "" )
     : Exception( "Tag specified out of required order", what ),
-                 field( f ) {}
+                 field( field ) {}
   int field;
 };
 
 /// Repeated tag not part of repeating group
 struct RepeatedTag : public Exception
 {
-  RepeatedTag( int f = 0, const std::string& what = "" )
+  RepeatedTag( int field = 0, const std::string& what = "" )
     : Exception( "Repeated tag not part of repeating group", what ),
-                 field( f ) {}
+                 field( field ) {}
   int field;
 };
 
 /// Repeated group count not equal to actual count
 struct RepeatingGroupCountMismatch : public Exception
 {
-  RepeatingGroupCountMismatch( int f = 0, const std::string& what = "" )
+  RepeatingGroupCountMismatch( int field = 0, const std::string& what = "" )
     : Exception( "Repeating group count mismatch", what ),
-                 field( f ) {}
+                 field( field ) {}
   int field;
 };
 

--- a/src/pt.cpp
+++ b/src/pt.cpp
@@ -115,82 +115,89 @@ int main( int argc, char** argv )
     }
   }
 
-  s_dataDictionary.reset( new FIX::DataDictionary( "../spec/FIX42.xml" ) );
+  try
+  {
+    s_dataDictionary.reset( new FIX::DataDictionary( "../spec/FIX42.xml" ) );
 
-  std::cout << "Converting integers to strings: ";
-  report( testIntegerToString( count ), count );
+    std::cout << "Converting integers to strings: ";
+    report( testIntegerToString( count ), count );
 
-  std::cout << "Converting strings to integers: ";
-  report( testStringToInteger( count ), count );
+    std::cout << "Converting strings to integers: ";
+    report( testStringToInteger( count ), count );
 
-  std::cout << "Converting doubles to strings: ";
-  report( testDoubleToString( count ), count );
+    std::cout << "Converting doubles to strings: ";
+    report( testDoubleToString( count ), count );
 
-  std::cout << "Converting strings to doubles: ";
-  report( testStringToDouble( count ), count );
+    std::cout << "Converting strings to doubles: ";
+    report( testStringToDouble( count ), count );
 
-  std::cout << "Creating Heartbeat messages: ";
-  report( testCreateHeartbeat( count ), count );
+    std::cout << "Creating Heartbeat messages: ";
+    report( testCreateHeartbeat( count ), count );
 
-  std::cout << "Identifying message types: ";
-  report( testIdentifyType( count ), count );
+    std::cout << "Identifying message types: ";
+    report( testIdentifyType( count ), count );
 
-  std::cout << "Serializing Heartbeat messages to strings: ";
-  report( testSerializeToStringHeartbeat( count ), count );
+    std::cout << "Serializing Heartbeat messages to strings: ";
+    report( testSerializeToStringHeartbeat( count ), count );
 
-  std::cout << "Serializing Heartbeat messages from strings: ";
-  report( testSerializeFromStringHeartbeat( count ), count );
+    std::cout << "Serializing Heartbeat messages from strings: ";
+    report( testSerializeFromStringHeartbeat( count ), count );
 
-  std::cout << "Serializing Heartbeat messages from strings and validation: ";
-  report( testSerializeFromStringAndValidateHeartbeat( count ), count );
+    std::cout << "Serializing Heartbeat messages from strings and validation: ";
+    report( testSerializeFromStringAndValidateHeartbeat( count ), count );
 
-  std::cout << "Creating NewOrderSingle messages: ";
-  report( testCreateNewOrderSingle( count ), count );
+    std::cout << "Creating NewOrderSingle messages: ";
+    report( testCreateNewOrderSingle( count ), count );
 
-  std::cout << "Serializing NewOrderSingle messages to strings: ";
-  report( testSerializeToStringNewOrderSingle( count ), count );
+    std::cout << "Serializing NewOrderSingle messages to strings: ";
+    report( testSerializeToStringNewOrderSingle( count ), count );
 
-  std::cout << "Serializing NewOrderSingle messages from strings: ";
-  report( testSerializeFromStringNewOrderSingle( count ), count );
+    std::cout << "Serializing NewOrderSingle messages from strings: ";
+    report( testSerializeFromStringNewOrderSingle( count ), count );
 
-  std::cout << "Serializing NewOrderSingle messages from strings and validation: ";
-  report( testSerializeFromStringAndValidateNewOrderSingle( count ), count );
+    std::cout << "Serializing NewOrderSingle messages from strings and validation: ";
+    report( testSerializeFromStringAndValidateNewOrderSingle( count ), count );
 
-  std::cout << "Creating QuoteRequest messages: ";
-  report( testCreateQuoteRequest( count ), count );
+    std::cout << "Creating QuoteRequest messages: ";
+    report( testCreateQuoteRequest( count ), count );
 
-  std::cout << "Serializing QuoteRequest messages to strings: ";
-  report( testSerializeToStringQuoteRequest( count ), count );
+    std::cout << "Serializing QuoteRequest messages to strings: ";
+    report( testSerializeToStringQuoteRequest( count ), count );
 
-  std::cout << "Serializing QuoteRequest messages from strings: ";
-  report( testSerializeFromStringQuoteRequest( count ), count );
+    std::cout << "Serializing QuoteRequest messages from strings: ";
+    report( testSerializeFromStringQuoteRequest( count ), count );
 
-  std::cout << "Serializing QuoteRequest messages from strings and validation: ";
-  report( testSerializeFromStringAndValidateQuoteRequest( count ), count );
+    std::cout << "Serializing QuoteRequest messages from strings and validation: ";
+    report( testSerializeFromStringAndValidateQuoteRequest( count ), count );
 
-  std::cout << "Reading fields from QuoteRequest message: ";
-  report( testReadFromQuoteRequest( count ), count );
+    std::cout << "Reading fields from QuoteRequest message: ";
+    report( testReadFromQuoteRequest( count ), count );
 
-  std::cout << "Storing NewOrderSingle messages: ";
-  report( testFileStoreNewOrderSingle( count ), count );
+    std::cout << "Storing NewOrderSingle messages: ";
+    report( testFileStoreNewOrderSingle( count ), count );
 
-  std::cout << "Validating NewOrderSingle messages with no data dictionary: ";
-  report( testValidateNewOrderSingle( count ), count );
+    std::cout << "Validating NewOrderSingle messages with no data dictionary: ";
+    report( testValidateNewOrderSingle( count ), count );
 
-  std::cout << "Validating NewOrderSingle messages with data dictionary: ";
-  report( testValidateDictNewOrderSingle( count ), count );
+    std::cout << "Validating NewOrderSingle messages with data dictionary: ";
+    report( testValidateDictNewOrderSingle( count ), count );
 
-  std::cout << "Validating QuoteRequest messages with no data dictionary: ";
-  report( testValidateQuoteRequest( count ), count );
+    std::cout << "Validating QuoteRequest messages with no data dictionary: ";
+    report( testValidateQuoteRequest( count ), count );
 
-  std::cout << "Validating QuoteRequest messages with data dictionary: ";
-  report( testValidateDictQuoteRequest( count ), count );
+    std::cout << "Validating QuoteRequest messages with data dictionary: ";
+    report( testValidateDictQuoteRequest( count ), count );
 
-  std::cout << "Sending/Receiving NewOrderSingle/ExecutionReports on Socket";
-  report( testSendOnSocket( count, port ), count );
+    std::cout << "Sending/Receiving NewOrderSingle/ExecutionReports on Socket";
+    report( testSendOnSocket( count, port ), count );
 
-  std::cout << "Sending/Receiving NewOrderSingle/ExecutionReports on ThreadedSocket";
-  report( testSendOnThreadedSocket( count, port ), count );
+    std::cout << "Sending/Receiving NewOrderSingle/ExecutionReports on ThreadedSocket";
+    report( testSendOnThreadedSocket( count, port ), count );
+  }
+  catch( std::exception const& e )
+  {
+    std::cerr << e.what() << std::endl;
+  }
 
   return 0;
 }

--- a/src/pt.cpp
+++ b/src/pt.cpp
@@ -19,6 +19,7 @@
 **
 ****************************************************************************/
 
+#include "FixFields.h"
 #ifdef _MSC_VER
 #pragma warning( disable : 4503 4355 4786 )
 #include "stdafx.h"
@@ -642,6 +643,8 @@ long testValidateNewOrderSingle( int count )
   message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
   message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
   message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
+  message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 
   FIX::DataDictionary dataDictionary;
   count = count - 1;
@@ -667,6 +670,8 @@ long testValidateDictNewOrderSingle( int count )
   message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
   message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
   message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
+  message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 
   count = count - 1;
 
@@ -696,6 +701,12 @@ long testValidateQuoteRequest( int count )
     message.addGroup( noRelatedSym );
   }
 
+  message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
+  message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
+  message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
+  message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
+
   FIX::DataDictionary dataDictionary;
   count = count - 1;
 
@@ -724,6 +735,12 @@ long testValidateDictQuoteRequest( int count )
     noRelatedSym.set( FIX::OrdType(FIX::OrdType_MARKET) );
     message.addGroup( noRelatedSym );
   }
+
+  message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
+  message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
+  message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
+  message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 
   count = count - 1;
 

--- a/src/pt.cpp
+++ b/src/pt.cpp
@@ -111,7 +111,7 @@ int main( int argc, char** argv )
       std::cout << "usage: "
       << argv[ 0 ]
       << " -p port -c count" << std::endl;
-      return 1;
+      return EXIT_FAILURE;
     }
   }
 
@@ -197,9 +197,10 @@ int main( int argc, char** argv )
   catch( std::exception const& e )
   {
     std::cerr << e.what() << std::endl;
+    return EXIT_FAILURE;
   }
 
-  return 0;
+  return EXIT_SUCCESS;
 }
 
 void report( long time, int count )

--- a/src/pt.cpp
+++ b/src/pt.cpp
@@ -651,6 +651,7 @@ long testValidateNewOrderSingle( int count )
   message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
   message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
   message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::SendingTime( ) );
   message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
   message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 
@@ -678,6 +679,7 @@ long testValidateDictNewOrderSingle( int count )
   message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
   message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
   message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::SendingTime( ) );
   message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
   message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 
@@ -712,6 +714,8 @@ long testValidateQuoteRequest( int count )
   message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
   message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
   message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::SendingTime( ) );
+  message.getHeader().set( FIX::SendingTime( ) );
   message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
   message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 
@@ -747,6 +751,7 @@ long testValidateDictQuoteRequest( int count )
   message.getHeader().set( FIX::SenderCompID( "SENDER" ) );
   message.getHeader().set( FIX::TargetCompID( "TARGET" ) );
   message.getHeader().set( FIX::MsgSeqNum( 1 ) );
+  message.getHeader().set( FIX::SendingTime( ) );
   message.getHeader().set( FIX::BodyLength( message.calculateLength() ) );
   message.getTrailer().set( FIX::CheckSum( message.checkSum() ));
 


### PR DESCRIPTION
Validation in performance tests were failing because we now properly validate the presence of header and trailer fields