### PR TITLE
Allow opening log file in another application when quickfix is running

### DIFF
--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -526,12 +526,10 @@ void file_mkdir( const char* path )
 
 FILE* file_fopen( const char* path, const char* mode )
 {
-#if( _MSC_VER >= 1400 )
-  FILE* result = 0;
-  fopen_s( &result, path, mode );
-  return result;
+#ifdef _MSC_VER
+  return _fsopen(path, mode, _SH_DENYWR);
 #else
-  return fopen( path, mode );
+  return fopen(path, mode);
 #endif
 }
 


### PR DESCRIPTION
We monitor fix session logs during the Quickfix run and cannot open the file *.body for the C++ version of Quickfix on Windows. Because the file is locked.
We do not have the same problems with the .NET version of Quickfix.

The fix allows you to view the file during the Quickfix run.