### PR TITLE
Only reset state on session construction

### DIFF
--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -73,7 +73,7 @@ Session::Session( Application& application,
     m_state.log( m_pLogFactory->create( m_sessionID ) );
 
   if( !checkSessionTime(UtcTimeStamp()) )
-    reset();
+    m_state.reset();
 
   addSession( *this );
   m_application.onCreate( m_sessionID );


### PR DESCRIPTION
On construction, state needs to be reset if we are outside of the session time. However calling the reset method on session also calls disconnect and attempts to login. Instead we must only reset the state without additional side effects.