### PR TITLE
Add support of TLS 1.3 (and add TLSCipherSuites setting)

### DIFF
--- a/src/C++/SessionSettings.h
+++ b/src/C++/SessionSettings.h
@@ -185,6 +185,9 @@ const char VERIFY_LEVEL[] = "CertificateVerifyLevel";
 */
 const char SSL_PROTOCOL[] = "SSLProtocol";
 /*
+# DISCLAIMER: This setting only work for TLSv1.2 and below
+# see: https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_cipher_list.html
+#
 # This complex directive uses a colon-separated cipher-spec string consisting
 # of OpenSSL cipher specifications to configure the Cipher Suite the client is
 # permitted to negotiate in the SSL handshake phase. Notice that this directive
@@ -214,6 +217,22 @@ const char SSL_PROTOCOL[] = "SSLProtocol";
 # Example: RC4+RSA:+HIGH:
 */
 const char SSL_CIPHER_SUITE[] = "SSLCipherSuite";
+/*
+# DISCLAIMER: This setting only work for TLSv1.3 and upper
+# see: https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_ciphersuites.html
+#
+# This is a simple colon (":") separated list of TLSv1.3 ciphersuite names in
+# order of preference. Valid TLSv1.3 ciphersuite names are:
+#   TLS_AES_128_GCM_SHA256
+#   TLS_AES_256_GCM_SHA384
+#   TLS_CHACHA20_POLY1305_SHA256
+#   TLS_AES_128_CCM_SHA256
+#   TLS_AES_128_CCM_8_SHA256
+#
+# An empty list is permissible. The default value for the this setting is:
+# "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+*/
+const char TLS_CIPHER_SUITES[] = "TLSCipherSuites";
 
 
 /// Container for setting dictionaries mapped to sessions.

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -1075,6 +1075,13 @@ long protocolOptions(const char *opt)
         thisopt = SSL_PROTOCOL_TLSV1_2;
         w += 7 /* strlen("TLSv1_2") */;
       }
+#if (OPENSSL_VERSION_NUMBER >= 0x1010100FL)
+      else if (!strncasecmp(w, "TLSv1_3", 7 /* strlen("TLSv1_3") */))
+      {
+        thisopt = SSL_PROTOCOL_TLSV1_3;
+        w += 7 /* strlen("TLSv1_3") */;
+      }
+#endif
       else if (!strncasecmp(w, "TLSv1", 5 /* strlen("TLSv1") */))
       {
         thisopt = SSL_PROTOCOL_TLSV1;
@@ -1119,6 +1126,10 @@ void setCtxOptions(SSL_CTX *ctx, long options)
     SSL_CTX_set_options(ctx, SSL_OP_NO_TLSv1_1);
   if (!(options & SSL_PROTOCOL_TLSV1_2))
     SSL_CTX_set_options(ctx, SSL_OP_NO_TLSv1_2);
+#if (OPENSSL_VERSION_NUMBER >= 0x1010100FL)
+  if (!(options & SSL_PROTOCOL_TLSV1_3))
+    SSL_CTX_set_options(ctx, SSL_OP_NO_TLSv1_3);
+#endif
 }
 
 int enable_DH_ECDH(SSL_CTX *ctx, const char *certFile)
@@ -1224,6 +1235,28 @@ SSL_CTX *createSSLContext(bool server, const SessionSettings &settings,
       SSL_CTX_free(ctx);
       return 0;
     }
+  }
+
+  if (settings.get().has(TLSCipherSuites))
+  {
+    std::string strCipherSuites = settings.get().getString(TLSCipherSuites);
+
+#if (OPENSSL_VERSION_NUMBER >= 0x1010100FL)
+    if (!strCipherSuites.empty() &&
+        !SSL_CTX_set_ciphersuites(ctx, strCipherSuites.c_str()))
+    {
+      errStr.append("Unable to configure permitted TLS ciphersuites");
+      SSL_CTX_free(ctx);
+      return 0;
+    }
+#else
+    if (!strCipherSuites.empty())
+    {
+      errStr.append("Unable to configure TLS ciphersuites (OpenSSl < 1.1.1)");
+      SSL_CTX_free(ctx);
+      return 0;
+    }
+#endif
   }
 
   return ctx;
@@ -1387,7 +1420,7 @@ bool loadSSLCert(SSL_CTX *ctx, bool server, const SessionSettings &settings,
       return false;
     }
     break;
-    
+
   case SSL_ALGO_EC:
     log->onEvent("Configuring EC client private key");
     if (SSL_CTX_use_PrivateKey(ctx, privateKey) <= 0)

--- a/src/C++/UtilitySSL.h
+++ b/src/C++/UtilitySSL.h
@@ -228,9 +228,15 @@ int setSocketNonBlocking(socket_handle pSocket);
 #define SSL_PROTOCOL_TLSV1 (1 << 2)
 #define SSL_PROTOCOL_TLSV1_1 (1 << 3)
 #define SSL_PROTOCOL_TLSV1_2 (1 << 4)
-#define SSL_PROTOCOL_ALL                                                       \
-  (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 |              \
-   SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2)
+#if (OPENSSL_VERSION_NUMBER >= 0x1010100FL)
+#   define SSL_PROTOCOL_TLSV1_3 (1 << 5)
+#   define SSL_PROTOCOL_ALL                                                        \
+      (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 |              \
+       SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2 | SSL_PROTOCOL_TLSV1_3)
+#else
+#   define SSL_PROTOCOL_ALL                                                        \
+      (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 |              \
+       SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2)
 
 typedef enum {
   SSL_CLIENT_VERIFY_NONE = 0,


### PR DESCRIPTION
Hello,

TLS 1.3 is officially supported by OpenSSL [since the version 1.1.1 (11 Sep 2018)](https://www.openssl.org/news/openssl-1.1.1-notes.html). The support of this new protocol comes with a new OpenSSL API to set the ciphers.

There is now two functions that are available that can be used to set the ciphers.
* `SSL_CTX_set_cipher_list`: sets the list of available ciphers (TLSv1.2 and below). This function does not impact TLSv1.3 ciphersuites.
* `SSL_CTX_set_ciphersuites`: is used to configure the available TLSv1.3 ciphersuites (an mayber upper version of TLS too). 

I found the rationale of this new OpenSSL API in a GitHub comment here: https://github.com/openssl/openssl/issues/13704#issuecomment-748950174. It is stated the following:
* `[...] You cannot enable/disable TLSv1.3 ciphersuites via SSL_CTX_set_cipher_list(). [...]`
* `[...] We did at one point have a combined list which was fully visible through the API. Unfortunately this can cause significant problems for people upgrading from previous versions of OpenSSL. It is possible to write perfectly valid cipherlist strings that work just fine in OpenSSL versions prior to 1.1.1, but that silently disable all TLSv1.3 ciphersuites. So applications think they have all the benefits of TLSv1.3, but are in fact not using it. Therefore we made the decision to separate out the concepts at an API level, so that this is no longer possible. [...]`


Now that the new OpenSSL API is explained, there is some questions that arised in my mind regarding Quickfix (that mostly justifies the "Draft mode"):
* It seems we need to have two configurations fields to be able to set the ciphers. One for TLSv1.2 and below, and one for TLSv1.3 and upper.
* The name of the current setting is kind of confusing now. It is `SSLCipherSuite` but it actually uses  `SSL_CTX_set_cipher_list` in OpenSSL
* Quickfix should not uses deprecated versions of OpenSSL. The current LTS is 1.1.1, older versions are [deprecated](https://www.openssl.org/source/).


Now, about this PR:
* I have created a new setting called `TLSCipherSuites` that uses `SSL_CTX_set_ciphersuites`. I'm unsure about the name, but since the existing setting `SSLCipherSuite` is kind of confusing now, I don't have any other idea (unless we decide to deprecate  `SSLCipherSuite` by creating another setting `SSLCipherList`?)
* Since I didn't know if we want to drop the support of OpenSSL 1.1.0 and below, I used some preprocessor conditions to do so.
* I already use a simplified version of this PR in production, but I don't use the new setting TLSCipherSuites (I'm using the default ones), so it will need further testing if this design is approved.


I would like to have your insights on this @leleftheriades and @orenmnero.
I think Quickfix should have the support of TLS 1.3 in a upcoming release soon (it's not up to me to decide which one though). There is more and more brokers that support TLS 1.3 now.

Note: A SWIG generation should be done to expose the new setting.
