### PR TITLE
SharedArray: crash on arm64

### DIFF
--- a/src/C++/SharedArray.h
+++ b/src/C++/SharedArray.h
@@ -192,6 +192,7 @@ namespace FIX
     shared_array(const shared_array& rhs)
     : m_size(rhs.m_size)
     , m_buffer(rhs.m_buffer)
+    , m_pCtr(rhs.m_pCtr)
     {
       rhs.attach();
     }

--- a/src/C++/SharedArray.h
+++ b/src/C++/SharedArray.h
@@ -294,7 +294,7 @@ namespace FIX
         m_size = 0;
 
         //explicitly call destructor for the counter object
-        tmpCounter->~std::atomic<long>();
+        tmpCounter->~atomic<long>();
 
         std::free(tmpBuff);
       }


### PR DESCRIPTION
List of changes:
1. Call destructor without namespace (as at https://github.com/quickfix/quickfix/blob/master/src/C%2B%2B/SharedArray.h#L172 ) - it causes a compilation error in gcc-12 and clang-15;
2. Correct copy constructor: if `m_pCtr` is left uninitialized, `release()` will crash because of accessing `m_pCtr` in `decrement_reference_count()`.