### PR TITLE
Small fixes, customizations and extension.

### DIFF
--- a/src/C++/Application.h
+++ b/src/C++/Application.h
@@ -40,6 +40,15 @@ namespace FIX
  * The various MessageCracker classes can be used to parse the generic message
  * structure into specific %FIX messages.
  */
+
+#if defined(QUICKFIX_THROWS_IGNORE_MESSAGE)
+#  define QUICKFIX_APP_FROM_ADMIN_EXCEPT EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon, IgnoreMessage )
+#  define QUICKFIX_APP_FROM_APP_EXCEPT   EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType, IgnoreMessage )
+#else
+#  define QUICKFIX_APP_FROM_ADMIN_EXCEPT EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon )
+#  define QUICKFIX_APP_FROM_APP_EXCEPT   EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType )
+#endif // QUICKFIX_THROWS_IGNORE_MESSAGE
+
 class Application
 {
 public:
@@ -57,10 +66,10 @@ public:
   EXCEPT ( DoNotSend ) = 0;
   /// Notification of admin message being received from target
   virtual void fromAdmin( const Message&, const SessionID& )
-  EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon ) = 0;
+  QUICKFIX_APP_FROM_ADMIN_EXCEPT = 0;
   /// Notification of app message being received from target
   virtual void fromApp( const Message&, const SessionID& )
-  EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType ) = 0;
+  QUICKFIX_APP_FROM_APP_EXCEPT = 0;
 };
 
 /**
@@ -90,10 +99,10 @@ public:
   EXCEPT ( DoNotSend )
   { Locker l( m_mutex ); app().toApp( message, sessionID ); }
   void fromAdmin( const Message& message, const SessionID& sessionID )
-  EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon )
+  QUICKFIX_APP_FROM_ADMIN_EXCEPT
   { Locker l( m_mutex ); app().fromAdmin( message, sessionID ); }
   void fromApp( const Message& message, const SessionID& sessionID )
-  EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType )
+  QUICKFIX_APP_FROM_APP_EXCEPT
   { Locker l( m_mutex ); app().fromApp( message, sessionID ); }
 
   Mutex m_mutex;
@@ -117,9 +126,9 @@ class NullApplication : public Application
   void toApp( Message&, const SessionID& )
   EXCEPT ( DoNotSend ) {}
   void fromAdmin( const Message&, const SessionID& )
-  EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, RejectLogon ) {}
+  QUICKFIX_APP_FROM_ADMIN_EXCEPT {}
   void fromApp( const Message&, const SessionID& )
-  EXCEPT ( FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType ) {}
+  QUICKFIX_APP_FROM_APP_EXCEPT {}
 };
 /*! @} */
 }

--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -39,13 +39,13 @@
 namespace FIX
 {
 DataDictionary::DataDictionary()
-: m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
+: m_hasVersion( false ), m_suppressAllFieldsChecking( false ), m_checkFieldsOutOfOrder( true ),
   m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ), m_storeMsgFieldsOrder(false)
 {}
 
 DataDictionary::DataDictionary( std::istream& stream, bool preserveMsgFldsOrder )
 EXCEPT ( ConfigError )
-: m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
+: m_hasVersion( false ), m_suppressAllFieldsChecking( false ), m_checkFieldsOutOfOrder( true ),
   m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ), m_storeMsgFieldsOrder(preserveMsgFldsOrder)
 {
   readFromStream( stream );
@@ -53,7 +53,7 @@ EXCEPT ( ConfigError )
 
 DataDictionary::DataDictionary( const std::string& url, bool preserveMsgFldsOrder )
 EXCEPT ( ConfigError )
-: m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
+: m_hasVersion( false ), m_suppressAllFieldsChecking( false ), m_checkFieldsOutOfOrder( true ),
   m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ), m_storeMsgFieldsOrder(preserveMsgFldsOrder), m_orderedFieldsArray(0)
 {
   readFromURL( url );
@@ -80,6 +80,7 @@ DataDictionary::~DataDictionary()
 DataDictionary& DataDictionary::operator=( const DataDictionary& rhs )
 {
   m_hasVersion = rhs.m_hasVersion;
+  m_suppressAllFieldsChecking = rhs.m_suppressAllFieldsChecking;
   m_checkFieldsOutOfOrder = rhs.m_checkFieldsOutOfOrder;
   m_checkFieldsHaveValues = rhs.m_checkFieldsHaveValues;
   m_storeMsgFieldsOrder = rhs.m_storeMsgFieldsOrder;
@@ -136,6 +137,10 @@ EXCEPT ( FIX::Exception )
       throw UnsupportedVersion();
     }
   }
+
+  if( (pSessionDD !=0 && pSessionDD->m_suppressAllFieldsChecking) || 
+      (pAppDD != 0 && pAppDD->m_suppressAllFieldsChecking) )
+      return;
 
   int field = 0;
   if( (pSessionDD !=0 && pSessionDD->m_checkFieldsOutOfOrder) || 

--- a/src/C++/DataDictionary.h
+++ b/src/C++/DataDictionary.h
@@ -365,6 +365,8 @@ public:
           || i->second == TYPE::MultipleStringValue );
   }
 
+  void suppressAllFieldsChecking( bool value )
+  { m_suppressAllFieldsChecking = value; }
   void checkFieldsOutOfOrder( bool value )
   { m_checkFieldsOutOfOrder = value; }
   void checkFieldsHaveValues( bool value )
@@ -587,6 +589,7 @@ private:
   TYPE::Type XMLTypeToType( const std::string& xmlType ) const;
 
   bool m_hasVersion;
+  bool m_suppressAllFieldsChecking;
   bool m_checkFieldsOutOfOrder;
   bool m_checkFieldsHaveValues;
   bool m_checkUserDefinedFields;

--- a/src/C++/Exceptions.h
+++ b/src/C++/Exceptions.h
@@ -83,6 +83,15 @@ struct InvalidMessage : public Exception
     : Exception( "Invalid message", what ) {}
 };
 
+#if defined(QUICKFIX_THROWS_IGNORE_MESSAGE)
+/// A message to be ignored
+struct IgnoreMessage : public Exception
+{
+  IgnoreMessage( const std::string& what = "" )
+    : Exception( "Message to ignore", what ) {}
+};
+#endif // QUICKFIX_THROWS_IGNORE_MESSAGE
+
 /// %Application is not configured correctly
 struct ConfigError : public Exception
 {
@@ -277,7 +286,7 @@ struct SocketSendFailed : public SocketException
 /// Socket recv operation failed
 struct SocketRecvFailed : public SocketException
 {
-  SocketRecvFailed( ssize_t size )
+  SocketRecvFailed( quickfix_ssize_t size )
     : SocketException( size == 0 ? "Connection reset by peer." : size < 0 ? errorToWhat() : "Success." ) {}
   SocketRecvFailed( const std::string& what )
     : SocketException( what ) {}

--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -419,6 +419,29 @@ public:
     { return getValue(); }
 };
 
+// A generic template-based int type could be created and a field specialization
+// could be declared for any specific intN_t but this does not go well with SWIG.
+//
+/// Field that contains a 64-bit integer value
+class Int64Field : public FieldBase
+{
+public:
+  explicit Int64Field( int field, int64_t data )
+: FieldBase( field, Int64Convertor::convert( data ) ) {}
+  Int64Field( int field )
+: FieldBase( field, "" ) {}
+
+  void setValue( int64_t value )
+    { setString( Int64Convertor::convert( value ) ); }
+  int64_t getValue() const EXCEPT ( IncorrectDataFormat )
+    { try
+      { return Int64Convertor::convert( getString() ); }
+      catch( FieldConvertError& )
+      { throw IncorrectDataFormat( getTag(), getString() ); } }
+  operator int64_t() const
+    { return getValue(); }
+};
+
 /// Field that contains a boolean value
 class BoolField : public FieldBase
 {
@@ -601,6 +624,8 @@ DEFINE_FIELD_TIMECLASS_NUM(NAME, TOK, TYPE, DEPRECATED_FIELD::NAME)
   DEFINE_FIELD_CLASS(NAME, Price, FIX::PRICE)
 #define DEFINE_INT( NAME ) \
   DEFINE_FIELD_CLASS(NAME, Int, FIX::INT)
+#define DEFINE_INT64( NAME ) \
+  DEFINE_FIELD_CLASS(NAME, Int64, FIX::INT64)
 #define DEFINE_AMT( NAME ) \
   DEFINE_FIELD_CLASS(NAME, Amt, FIX::AMT)
 #define DEFINE_QTY( NAME ) \

--- a/src/C++/FieldTypes.h
+++ b/src/C++/FieldTypes.h
@@ -881,6 +881,7 @@ typedef std::string STRING;
 typedef char CHAR;
 typedef double PRICE;
 typedef int INT;
+typedef int64_t INT64;
 typedef double AMT;
 typedef double QTY;
 typedef std::string CURRENCY;

--- a/src/C++/FileStore.h
+++ b/src/C++/FileStore.h
@@ -99,6 +99,11 @@ public:
   void reset() EXCEPT ( IOException );
   void refresh() EXCEPT ( IOException );
 
+#if defined( QUICKFIX_EXTEND_FILE_STORE )
+protected:
+  virtual void setSeqNum();
+#endif
+
 private:
 #ifdef _MSC_VER
   typedef std::pair < int, int > OffsetSize;
@@ -110,7 +115,9 @@ private:
   void open( bool deleteFile );
   void populateCache();
   bool readFromFile( int offset, int size, std::string& msg );
+#if !defined( QUICKFIX_EXTEND_FILE_STORE )
   void setSeqNum();
+#endif
   void setSession();
 
   bool get( int, std::string& ) const EXCEPT ( IOException );

--- a/src/C++/HttpConnection.cpp
+++ b/src/C++/HttpConnection.cpp
@@ -66,7 +66,7 @@ bool HttpConnection::read()
     if( result > 0 ) // Something to read
     {
       // We can read without blocking
-      ssize_t size = socket_recv( m_socket, m_buffer, sizeof(m_buffer) );
+      quickfix_ssize_t size = socket_recv( m_socket, m_buffer, sizeof(m_buffer) );
       if ( size <= 0 ) { throw SocketRecvFailed( size ); }
       m_parser.addToStream( m_buffer, size );
     }

--- a/src/C++/SSLSocketAcceptor.cpp
+++ b/src/C++/SSLSocketAcceptor.cpp
@@ -301,7 +301,7 @@ bool SSLSocketAcceptor::onPoll()
     }
   }
 
-  m_pServer->block( *this, true, timeout );
+  m_pServer->block( *this, true );
   return true;
 }
 

--- a/src/C++/SSLSocketConnection.cpp
+++ b/src/C++/SSLSocketConnection.cpp
@@ -349,7 +349,7 @@ EXCEPT ( SocketRecvFailed )
   {
     pending = false;
     errno = 0;
-    ssize_t size = 0;
+    quickfix_ssize_t size = 0;
     int errCodeSSL = 0;
     ERR_clear_error();
 

--- a/src/C++/SSLSocketConnection.h
+++ b/src/C++/SSLSocketConnection.h
@@ -180,7 +180,7 @@ public:
   }
 
   int getSecondsFromHandshakeStart(time_t now) {
-    return now - m_handshakeStartTime;
+    return static_cast<int>(now - m_handshakeStartTime);
   }
 
   void onTimeout();

--- a/src/C++/SSLSocketInitiator.h
+++ b/src/C++/SSLSocketInitiator.h
@@ -165,7 +165,7 @@ private:
   void onInitialize( const SessionSettings& ) EXCEPT ( RuntimeError );
 
   void onStart();
-  bool onPoll( double timeout );
+  bool onPoll();
   void onStop();
 
   void doConnect( const SessionID&, const Dictionary& d );

--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -228,6 +228,8 @@ std::shared_ptr<DataDictionary> SessionFactory::createDataDictionary(const Sessi
 
   std::shared_ptr<DataDictionary> pCopyOfDD = std::shared_ptr<DataDictionary>(new DataDictionary(*pDD));
 
+  if( settings.has( VALIDATE_SUPPRESS ) )
+    pCopyOfDD->suppressAllFieldsChecking( settings.getBool( VALIDATE_SUPPRESS ) );
   if( settings.has( VALIDATE_FIELDS_OUT_OF_ORDER ) )
     pCopyOfDD->checkFieldsOutOfOrder( settings.getBool( VALIDATE_FIELDS_OUT_OF_ORDER ) );
   if( settings.has( VALIDATE_FIELDS_HAVE_VALUES ) )

--- a/src/C++/SessionSettings.h
+++ b/src/C++/SessionSettings.h
@@ -69,6 +69,7 @@ const char SOCKET_NODELAY[] = "SocketNodelay";
 const char SOCKET_SEND_BUFFER_SIZE[] = "SocketSendBufferSize";
 const char SOCKET_RECEIVE_BUFFER_SIZE[] = "SocketReceiveBufferSize";
 const char RECONNECT_INTERVAL[] = "ReconnectInterval";
+const char VALIDATE_SUPPRESS[] = "ValidateSuppress";
 const char VALIDATE_LENGTH_AND_CHECKSUM[] = "ValidateLengthAndChecksum";
 const char VALIDATE_FIELDS_OUT_OF_ORDER[] = "ValidateFieldsOutOfOrder";
 const char VALIDATE_FIELDS_HAVE_VALUES[] = "ValidateFieldsHaveValues";

--- a/src/C++/SocketConnection.h
+++ b/src/C++/SocketConnection.h
@@ -97,6 +97,8 @@ private:
   SocketMonitor* m_pMonitor;
   Mutex m_mutex;
   fd_set m_fds;
+  bool m_connected;
+  bool m_initiator;
 };
 }
 

--- a/src/C++/ThreadedSocketConnection.cpp
+++ b/src/C++/ThreadedSocketConnection.cpp
@@ -71,7 +71,7 @@ bool ThreadedSocketConnection::send( const std::string& msg )
   int totalSent = 0;
   while(totalSent < (int)msg.length())
   {
-    ssize_t sent = socket_send( m_socket, msg.c_str() + totalSent, msg.length() );
+    quickfix_ssize_t sent = socket_send( m_socket, msg.c_str() + totalSent, msg.length() );
     if(sent < 0) return false;
     totalSent += sent;
   }
@@ -107,7 +107,7 @@ bool ThreadedSocketConnection::read()
     if( result > 0 ) // Something to read
     {
       // We can read without blocking
-      ssize_t size = socket_recv( m_socket, m_buffer, sizeof(m_buffer) );
+      quickfix_ssize_t size = socket_recv( m_socket, m_buffer, sizeof(m_buffer) );
       if ( size <= 0 ) { throw SocketRecvFailed( size ); }
       m_parser.addToStream( m_buffer, size );
     }

--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -150,7 +150,19 @@ socket_handle socket_createConnector()
 int socket_connect(socket_handle socket, const char* address, int port )
 {
   const char* hostname = socket_hostname( address );
-  if( hostname == 0 ) return -1;
+  if( hostname == 0 )
+  {
+#ifdef _MSC_VER
+    // In a case of Windows + MSVC, select() does not fire a write event for
+    // a bare socket (no connection ever attempted). Therefore the later
+    // logic, which is based on unconditional continuation with select(),
+    // leads to a deadlock for the connecting session. So keep going ahead with
+    // a bad address.
+    hostname = address;
+#else
+    return -1;
+#endif
+  }
 
   sockaddr_in addr;
   addr.sin_family = PF_INET;
@@ -169,12 +181,12 @@ socket_handle socket_accept(socket_handle s )
   return accept( s, 0, 0 );
 }
 
-ssize_t socket_recv(socket_handle s, char* buf, size_t length )
+quickfix_ssize_t socket_recv(socket_handle s, char* buf, size_t length )
 {
   return recv( s, buf, length, 0 );
 }
 
-ssize_t socket_send(socket_handle s, const char* msg, size_t length )
+quickfix_ssize_t socket_send(socket_handle s, const char* msg, size_t length )
 {
   return send( s, msg, length, 0 );
 }

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -67,7 +67,7 @@
 #include <direct.h>
 #include <time.h>
 typedef int socklen_t;
-typedef int ssize_t;
+typedef SSIZE_T quickfix_ssize_t;
 typedef SOCKET socket_handle;
 #define INVALID_SOCKET_HANDLE INVALID_SOCKET
 #define BIND_SOCKET_ERROR SOCKET_ERROR
@@ -96,6 +96,7 @@ typedef SOCKET socket_handle;
 #include <time.h>
 #include <stdlib.h>
 typedef int socket_handle;
+typedef ssize_t quickfix_ssize_t;
 #define INVALID_SOCKET_HANDLE -1
 #define BIND_SOCKET_ERROR -1
 #define LISTEN_SOCKET_ERROR -1
@@ -128,8 +129,8 @@ socket_handle socket_createAcceptor( int port, bool reuse = false );
 socket_handle socket_createConnector();
 int socket_connect(socket_handle s, const char* address, int port );
 socket_handle socket_accept(socket_handle s );
-ssize_t socket_recv(socket_handle s, char* buf, size_t length );
-ssize_t socket_send(socket_handle s, const char* msg, size_t length );
+quickfix_ssize_t socket_recv(socket_handle s, char* buf, size_t length );
+quickfix_ssize_t socket_send(socket_handle s, const char* msg, size_t length );
 void socket_close(socket_handle s );
 std::string socket_get_last_error();
 bool socket_fionread(socket_handle s, int& bytes );

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -135,6 +135,10 @@
 
 #ifdef _MSC_VER
 
+#if !defined(snprintf)
+#define snprintf _snprintf
+#endif
+
 #if !defined(strcasecmp)
 #define strcasecmp _stricmp
 #endif

--- a/src/C++/UtilitySSL.h
+++ b/src/C++/UtilitySSL.h
@@ -136,8 +136,6 @@ namespace FIX
 
 #if defined(_MSC_VER)
 
-#define snprintf _snprintf
-
 static const char *WSAErrString(int code)
 /********************************************************************************
 * Translate WSA error code to message string (abreviated)
@@ -183,6 +181,7 @@ static const char *WSAErrString(int code)
   return "Unknown error code";
 }
 
+#undef  expand
 #define SLASH "\\"
 #define SUFFIX "*"
 

--- a/src/python/quickfix.i
+++ b/src/python/quickfix.i
@@ -179,6 +179,10 @@ def start(self):
         throw *((FIX::IncorrectTagValue*)result);
       } else if( SWIG_ConvertPtr(pvalue, &result, SWIGTYPE_p_FIX__RejectLogon, 0 ) != -1 ) {
         throw *((FIX::RejectLogon*)result);
+#ifdef QUICKFIX_THROWS_IGNORE_MESSAGE
+      } else if( SWIG_ConvertPtr(pvalue, &result, SWIGTYPE_p_FIX__IgnoreMessage, 0 ) != -1 ) {
+        throw *((FIX::IgnoreMessage*)result);
+#endif
       } else {
         PyErr_Restore( ptype, pvalue, ptraceback );
         PyErr_Print();
@@ -217,6 +221,10 @@ def start(self):
         throw *((FIX::IncorrectTagValue*)result);
       } else if( SWIG_ConvertPtr(pvalue, &result, SWIGTYPE_p_FIX__UnsupportedMessageType, 0 ) != -1 ) {
         throw *((FIX::UnsupportedMessageType*)result);
+#ifdef QUICKFIX_THROWS_IGNORE_MESSAGE
+      } else if( SWIG_ConvertPtr(pvalue, &result, SWIGTYPE_p_FIX__IgnoreMessage, 0 ) != -1 ) {
+        throw *((FIX::IgnoreMessage*)result);
+#endif
       } else {
         PyErr_Restore( ptype, pvalue, ptraceback );
         PyErr_Print();

--- a/src/python/quickfix.py
+++ b/src/python/quickfix.py
@@ -240,8 +240,8 @@ class FIXException(Exception):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
 
-    def __init__(self, t, d):
-        _quickfix.FIXException_swiginit(self, _quickfix.new_FIXException(t, d))
+    def __init__(self, type, detail):
+        _quickfix.FIXException_swiginit(self, _quickfix.new_FIXException(type, detail))
     __swig_destroy__ = _quickfix.delete_FIXException
     type = property(_quickfix.FIXException_type_get, _quickfix.FIXException_type_set)
     detail = property(_quickfix.FIXException_detail_get, _quickfix.FIXException_detail_set)
@@ -1024,6 +1024,23 @@ class IntField(FieldBase):
 # Register IntField in _quickfix:
 _quickfix.IntField_swigregister(IntField)
 
+class Int64Field(FieldBase):
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        _quickfix.Int64Field_swiginit(self, _quickfix.new_Int64Field(*args))
+
+    def setValue(self, value):
+        return _quickfix.Int64Field_setValue(self, value)
+
+    def getValue(self):
+        return _quickfix.Int64Field_getValue(self)
+    __swig_destroy__ = _quickfix.delete_Int64Field
+
+# Register Int64Field in _quickfix:
+_quickfix.Int64Field_swigregister(Int64Field)
+
 class BoolField(FieldBase):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
@@ -1188,6 +1205,9 @@ class FieldMap(object):
 
     def getGroupPtr(self, num, tag):
         return _quickfix.FieldMap_getGroupPtr(self, num, tag)
+
+    def groups(self):
+        return _quickfix.FieldMap_groups(self)
 
     def removeGroup(self, *args):
         return _quickfix.FieldMap_removeGroup(self, *args)
@@ -21725,6 +21745,7 @@ SOCKET_NODELAY = cvar.SOCKET_NODELAY
 SOCKET_SEND_BUFFER_SIZE = cvar.SOCKET_SEND_BUFFER_SIZE
 SOCKET_RECEIVE_BUFFER_SIZE = cvar.SOCKET_RECEIVE_BUFFER_SIZE
 RECONNECT_INTERVAL = cvar.RECONNECT_INTERVAL
+VALIDATE_SUPPRESS = cvar.VALIDATE_SUPPRESS
 VALIDATE_LENGTH_AND_CHECKSUM = cvar.VALIDATE_LENGTH_AND_CHECKSUM
 VALIDATE_FIELDS_OUT_OF_ORDER = cvar.VALIDATE_FIELDS_OUT_OF_ORDER
 VALIDATE_FIELDS_HAVE_VALUES = cvar.VALIDATE_FIELDS_HAVE_VALUES
@@ -22565,8 +22586,8 @@ class Initiator(object):
     def block(self):
         return _quickfix.Initiator_block(self)
 
-    def poll(self, timeout=0.0):
-        return _quickfix.Initiator_poll(self, timeout)
+    def poll(self):
+        return _quickfix.Initiator_poll(self)
 
     def stop(self, force=False):
         return _quickfix.Initiator_stop(self, force)
@@ -22629,8 +22650,8 @@ class Acceptor(object):
     def block(self):
         return _quickfix.Acceptor_block(self)
 
-    def poll(self, timeout=0.0):
-        return _quickfix.Acceptor_poll(self, timeout)
+    def poll(self):
+        return _quickfix.Acceptor_poll(self)
 
     def stop(self, force=False):
         return _quickfix.Acceptor_stop(self, force)
@@ -22792,6 +22813,9 @@ class DataDictionary(object):
     def isMultipleValueField(self, field):
         return _quickfix.DataDictionary_isMultipleValueField(self, field)
 
+    def suppressAllFieldsChecking(self, value):
+        return _quickfix.DataDictionary_suppressAllFieldsChecking(self, value)
+
     def checkFieldsOutOfOrder(self, value):
         return _quickfix.DataDictionary_checkFieldsOutOfOrder(self, value)
 
@@ -22862,19 +22886,22 @@ class SSLSocketAcceptorBase(Acceptor):
     def setPassword(self, pwd):
         return _quickfix.SSLSocketAcceptorBase_setPassword(self, pwd)
 
-    def passwordHandleCallback(self, buf, bufsize, verify, job):
-        return _quickfix.SSLSocketAcceptorBase_passwordHandleCallback(self, buf, bufsize, verify, job)
+    def passwordHandleCallback(self, buf, bufsize, verify):
+        return _quickfix.SSLSocketAcceptorBase_passwordHandleCallback(self, buf, bufsize, verify)
 
     @staticmethod
-    def passPhraseHandleCB(buf, bufsize, verify, job):
-        return _quickfix.SSLSocketAcceptorBase_passPhraseHandleCB(buf, bufsize, verify, job)
+    def passPhraseHandleCB(buf, bufsize, verify, instance):
+        return _quickfix.SSLSocketAcceptorBase_passPhraseHandleCB(buf, bufsize, verify, instance)
 
 # Register SSLSocketAcceptorBase in _quickfix:
 _quickfix.SSLSocketAcceptorBase_swigregister(SSLSocketAcceptorBase)
 
-def SSLSocketAcceptorBase_passPhraseHandleCB(buf, bufsize, verify, job):
-    return _quickfix.SSLSocketAcceptorBase_passPhraseHandleCB(buf, bufsize, verify, job)
+def SSLSocketAcceptorBase_passPhraseHandleCB(buf, bufsize, verify, instance):
+    return _quickfix.SSLSocketAcceptorBase_passPhraseHandleCB(buf, bufsize, verify, instance)
 
+SSL_HANDSHAKE_FAILED = _quickfix.SSL_HANDSHAKE_FAILED
+SSL_HANDSHAKE_SUCCEDED = _quickfix.SSL_HANDSHAKE_SUCCEDED
+SSL_HANDSHAKE_IN_PROGRESS = _quickfix.SSL_HANDSHAKE_IN_PROGRESS
 class SSLSocketInitiatorBase(Initiator):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr
@@ -22889,18 +22916,18 @@ class SSLSocketInitiatorBase(Initiator):
     def setCertAndKey(self, cert, key):
         return _quickfix.SSLSocketInitiatorBase_setCertAndKey(self, cert, key)
 
-    def passwordHandleCallback(self, buf, bufsize, verify, job):
-        return _quickfix.SSLSocketInitiatorBase_passwordHandleCallback(self, buf, bufsize, verify, job)
+    def passwordHandleCallback(self, buf, bufsize, verify):
+        return _quickfix.SSLSocketInitiatorBase_passwordHandleCallback(self, buf, bufsize, verify)
 
     @staticmethod
-    def passwordHandleCB(buf, bufsize, verify, job):
-        return _quickfix.SSLSocketInitiatorBase_passwordHandleCB(buf, bufsize, verify, job)
+    def passwordHandleCB(buf, bufsize, verify, instance):
+        return _quickfix.SSLSocketInitiatorBase_passwordHandleCB(buf, bufsize, verify, instance)
 
 # Register SSLSocketInitiatorBase in _quickfix:
 _quickfix.SSLSocketInitiatorBase_swigregister(SSLSocketInitiatorBase)
 
-def SSLSocketInitiatorBase_passwordHandleCB(buf, bufsize, verify, job):
-    return _quickfix.SSLSocketInitiatorBase_passwordHandleCB(buf, bufsize, verify, job)
+def SSLSocketInitiatorBase_passwordHandleCB(buf, bufsize, verify, instance):
+    return _quickfix.SSLSocketInitiatorBase_passwordHandleCB(buf, bufsize, verify, instance)
 
 class SSLSocketConnection(object):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
@@ -22925,14 +22952,29 @@ class SSLSocketConnection(object):
     def signal(self):
         return _quickfix.SSLSocketConnection_signal(self)
 
+    def subscribeToSocketWriteAvailableEvents(self):
+        return _quickfix.SSLSocketConnection_subscribeToSocketWriteAvailableEvents(self)
+
     def unsignal(self):
         return _quickfix.SSLSocketConnection_unsignal(self)
+
+    def setHandshakeStartTime(self, time):
+        return _quickfix.SSLSocketConnection_setHandshakeStartTime(self, time)
+
+    def getSecondsFromHandshakeStart(self, now):
+        return _quickfix.SSLSocketConnection_getSecondsFromHandshakeStart(self, now)
 
     def onTimeout(self):
         return _quickfix.SSLSocketConnection_onTimeout(self)
 
     def sslObject(self):
         return _quickfix.SSLSocketConnection_sslObject(self)
+
+    def didProcessQueueRequestToRead(self):
+        return _quickfix.SSLSocketConnection_didProcessQueueRequestToRead(self)
+
+    def didReadFromSocketRequestToWrite(self):
+        return _quickfix.SSLSocketConnection_didReadFromSocketRequestToWrite(self)
 
 # Register SSLSocketConnection in _quickfix:
 _quickfix.SSLSocketConnection_swigregister(SSLSocketConnection)

--- a/src/python/swig.sh
+++ b/src/python/swig.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# -DQUICKFIX_THROWS_IGNORE_MESSAGE
 swig -I../C++ -threads -D__cpp_noexcept_function_type -DHAVE_SSL=1 -python -c++ -o QuickfixPython.cpp quickfix.i
 cat quickfix_fields.py >> quickfix.py
 sed -i "s/object.__getattr__/object.__getattribute__/g" quickfix.py


### PR DESCRIPTION
New compilation macros to optionally extend the behavior:
- QUICKFIX_THROWS_IGNORE_MESSAGE
- QUICKFIX_EXTEND_FILE_STORE
- QUICKFIX_IDLE_DISCONNECTED_CLIENT_SESSION

See below for details. Some modifications are controlled by conditional compilation to:
- do not require people to modify their existing code if they do not need the optional extensions;
- avoid potential overhead in a case of added but not necessarily required functionality (like making some functions virtual).
- avoid potential changes in behavior if they are not required and not considered reasonable/safe enough.

--------------------------------------------------------------------------------
src/C++/Utility.h

A new type (quickfix_ssize_t) has been introduced for all compilers instead of ssize_t declaration for MSC. It is based on the corresponding native types (SSIZE_T for MSC and ssize_t for others). All (few) uses of ssize_t within the source code have been replaced to quickfix_ssize_t:
- src/C++/Exceptions.h
- src/C++/HttpConnection.cpp
- src/C++/SSLSocketConnection.cpp
- src/C++/SocketConnection.cpp
- src/C++/ThreadedSocketConnection.cpp
- src/C++/Utility.cpp

This is done because other 3rd-party packages (for example, Python) declare ssize_t type on their own and thus a very hard to resolve conflict is faced.

--------------------------------------------------------------------------------
src/C++/Exceptions.h
src/C++/Application.h

A new exception (IgnoreMessage) has been conditionally added. It's purpose is to terminate the message processing flow but without semantics of a real error if a specific protocol rules may require this. Depending on the condition, the exception specification in src/C++/Application.h can be defined differently now. The condition is controlled by definition of QUICKFIX_THROWS_IGNORE_MESSAGE macro during compilation.

-------------------------------------------------------------------------------
src/C++/Application.h

Exception specifications of selected methods have been updated to contain the newly added exception type (IgnoreMessage).

--------------------------------------------------------------------------------
src/C++/FieldTypes.h

A new distinct field type id (INT64) has been added.

--------------------------------------------------------------------------------
src/C++/Field.h

A new field type (Int64Field) has been added.

--------------------------------------------------------------------------------
src/C++/FieldConvertors.h

A new filed convertor (Int64Convertor) has been added. Corresponding unit tests have been added as well.

Disabling warning 4146 on Windows have been refactored to not affect the global scope but only required code blocks.

--------------------------------------------------------------------------------
src/C++/DataDictionary.h
src/C++/DataDictionary.cpp

A new boolean flag (m_suppressAllFieldsChecking) has been added to FIX::DataDictionary. If the flag is set, DataDictionary::validate() only checks for a valid message type and then immediately returns. There exist FIX protocol implementations that may violate many field rules historically yet these protocols need to be supported. Making these checks more granular is unlikely reasonable: some validations that have no control are scattered in the code while all these control efforts would be relevant only for few legacy systems.

--------------------------------------------------------------------------------
src/C++/UtilitySSL.h

Macro "expand" set undefined after it is used. Global use of such a commonly named macro can cause conflicts (for example, with boost/date_time/period.hpp).

--------------------------------------------------------------------------------
src/C++/UtilitySSL.h
src/C++/UtilitySSL.cpp

Definition of macro "snprintf" has been moved from the header file to the cpp file. This is the only source file it is used while this macro may conflict with another 3rd-party packages (e.g. newer versions of boost).

--------------------------------------------------------------------------------
src/C++/Utility.cpp

socket_connect()
In a case of Windows + MSVC, the function does not return -1 immediately in a case of unresolved host but continues with a connect() call to the bad host. A call to select() on Windows + MSVC does not fire a write event on a bare socket (no connection ever attempted) and thus the session gets stuck on never coming select() response.

--------------------------------------------------------------------------------
src/C++/FileStore.h

FIX::FileStore::setSeqNum() can be conditionally virtual and protected now. This can be helpful if store of the sequence numbers has to be extended with extra locations.

--------------------------------------------------------------------------------
src/C++/SocketConnection.{h,cpp}

A boolean members m_connected/m_initiator have been added. m_connected is initialized to 'true' and set to 'false' in FIX::SocketConnection::disconnect() if call to FIX::SocketMonitor::drop() returns 'true' (i.e. the connection socket is closed).

The added conditional behavior (QUICKFIX_IDLE_DISCONNECTED_CLIENT_SESSION) suggests skip calling to m_pSession->next() in SocketConnection::onTimeout() in a disconnected state if m_initiator is set to 'true'. For some applications, manipulating with a disconnected session can be hardly handled consistently.
