### PR TITLE
Providing a session option to completely disable incoming message validation.

### DIFF
--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -39,13 +39,13 @@
 namespace FIX
 {
 DataDictionary::DataDictionary()
-: m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
+: m_hasVersion( false ), m_suppressAllFieldsChecking( false ), m_checkFieldsOutOfOrder( true ),
   m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ), m_storeMsgFieldsOrder(false)
 {}
 
 DataDictionary::DataDictionary( std::istream& stream, bool preserveMsgFldsOrder )
 EXCEPT ( ConfigError )
-: m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
+: m_hasVersion( false ), m_suppressAllFieldsChecking( false ), m_checkFieldsOutOfOrder( true ),
   m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ), m_storeMsgFieldsOrder(preserveMsgFldsOrder)
 {
   readFromStream( stream );
@@ -53,7 +53,7 @@ EXCEPT ( ConfigError )
 
 DataDictionary::DataDictionary( const std::string& url, bool preserveMsgFldsOrder )
 EXCEPT ( ConfigError )
-: m_hasVersion( false ), m_checkFieldsOutOfOrder( true ),
+: m_hasVersion( false ), m_suppressAllFieldsChecking( false ), m_checkFieldsOutOfOrder( true ),
   m_checkFieldsHaveValues( true ), m_checkUserDefinedFields( true ), m_allowUnknownMessageFields( false ), m_storeMsgFieldsOrder(preserveMsgFldsOrder), m_orderedFieldsArray(0)
 {
   readFromURL( url );
@@ -80,6 +80,7 @@ DataDictionary::~DataDictionary()
 DataDictionary& DataDictionary::operator=( const DataDictionary& rhs )
 {
   m_hasVersion = rhs.m_hasVersion;
+  m_suppressAllFieldsChecking = rhs.m_suppressAllFieldsChecking;
   m_checkFieldsOutOfOrder = rhs.m_checkFieldsOutOfOrder;
   m_checkFieldsHaveValues = rhs.m_checkFieldsHaveValues;
   m_storeMsgFieldsOrder = rhs.m_storeMsgFieldsOrder;
@@ -136,6 +137,10 @@ EXCEPT ( FIX::Exception )
       throw UnsupportedVersion();
     }
   }
+
+  if( (pSessionDD !=0 && pSessionDD->m_suppressAllFieldsChecking) || 
+      (pAppDD != 0 && pAppDD->m_suppressAllFieldsChecking) )
+      return;
 
   int field = 0;
   if( (pSessionDD !=0 && pSessionDD->m_checkFieldsOutOfOrder) || 

--- a/src/C++/DataDictionary.h
+++ b/src/C++/DataDictionary.h
@@ -365,6 +365,8 @@ public:
           || i->second == TYPE::MultipleStringValue );
   }
 
+  void suppressAllFieldsChecking( bool value )
+  { m_suppressAllFieldsChecking = value; }
   void checkFieldsOutOfOrder( bool value )
   { m_checkFieldsOutOfOrder = value; }
   void checkFieldsHaveValues( bool value )
@@ -595,6 +597,7 @@ private:
   TYPE::Type XMLTypeToType( const std::string& xmlType ) const;
 
   bool m_hasVersion;
+  bool m_suppressAllFieldsChecking;
   bool m_checkFieldsOutOfOrder;
   bool m_checkFieldsHaveValues;
   bool m_checkUserDefinedFields;

--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -229,6 +229,8 @@ std::shared_ptr<DataDictionary> SessionFactory::createDataDictionary(const Sessi
 
   std::shared_ptr<DataDictionary> pCopyOfDD = std::shared_ptr<DataDictionary>(new DataDictionary(*pDD));
 
+  if( settings.has( VALIDATE_SUPPRESS ) )
+    pCopyOfDD->suppressAllFieldsChecking( settings.getBool( VALIDATE_SUPPRESS ) );
   if( settings.has( VALIDATE_FIELDS_OUT_OF_ORDER ) )
     pCopyOfDD->checkFieldsOutOfOrder( settings.getBool( VALIDATE_FIELDS_OUT_OF_ORDER ) );
   if( settings.has( VALIDATE_FIELDS_HAVE_VALUES ) )

--- a/src/C++/SessionSettings.h
+++ b/src/C++/SessionSettings.h
@@ -69,6 +69,7 @@ const char SOCKET_NODELAY[] = "SocketNodelay";
 const char SOCKET_SEND_BUFFER_SIZE[] = "SocketSendBufferSize";
 const char SOCKET_RECEIVE_BUFFER_SIZE[] = "SocketReceiveBufferSize";
 const char RECONNECT_INTERVAL[] = "ReconnectInterval";
+const char VALIDATE_SUPPRESS[] = "ValidateSuppress";
 const char VALIDATE_LENGTH_AND_CHECKSUM[] = "ValidateLengthAndChecksum";
 const char VALIDATE_FIELDS_OUT_OF_ORDER[] = "ValidateFieldsOutOfOrder";
 const char VALIDATE_FIELDS_HAVE_VALUES[] = "ValidateFieldsHaveValues";


### PR DESCRIPTION
src/C++/DataDictionary.h
src/C++/DataDictionary.cpp
src/C++/SessionSettings.h
src/C++/SessionFactory.cpp 

A new boolean flag (m_suppressAllFieldsChecking) has been added to FIX::DataDictionary. If the flag is set, DataDictionary::validate() only checks for a valid message type and then immediately returns. There exist historic FIX protocol implementations that may violate many field rules yet these protocols need to be supported. Making these checks more granular is unlikely reasonable: some validations that have no control are scattered in the code while all these granular control efforts would be relevant for few legacy systems only.