### PR TITLE
Enable extendable FIX::FileStore.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ option(HAVE_POSTGRESQL "Build with PostgreSQL")
 option(HAVE_PYTHON "Build with default Python version")
 option(HAVE_PYTHON3 "Build with default Python3 version")
 
+# add option to build with extendable FIX::FileStore
+option(QUICKFIX_EXTEND_FILE_STORE, "Build with overridable FileStore::setSeqNum()")
+
 # add option to build shared or static
 option(QUICKFIX_SHARED_LIBS "Build using shared libraries" ON)
 # add option to build other targets

--- a/src/C++/FileStore.h
+++ b/src/C++/FileStore.h
@@ -99,6 +99,11 @@ public:
   void reset( const UtcTimeStamp& now ) EXCEPT ( IOException );
   void refresh() EXCEPT ( IOException );
 
+#if defined( QUICKFIX_EXTEND_FILE_STORE )
+protected:
+  virtual void setSeqNum();
+#endif
+
 private:
 #ifdef _MSC_VER
   typedef std::pair<int, std::size_t> OffsetSize;
@@ -110,7 +115,9 @@ private:
   void open( bool deleteFile );
   void populateCache();
   bool readFromFile( int offset, int size, std::string& msg );
+#if !defined( QUICKFIX_EXTEND_FILE_STORE )
   void setSeqNum();
+#endif
   void setSession();
 
   bool get( int, std::string& ) const EXCEPT ( IOException );


### PR DESCRIPTION
There are situations when the sequence numbers has to be stored in extra locations. Overriding of the original FIX::FileStore::setSeqNum() makes this extension possible and declaring of this function as 'protected' permits calling the original function form the overriding one.
This change has been done optional (-DQUICKFIX_EXTEND_FILE_STORE)  to not break encapsulation ('private' FIX::FileStore::setSeqNum()) and to avoid extra cost of a virtual function call if not necessary.