### PR TITLE
Adding Int64Field.

### DIFF
--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -419,6 +419,30 @@ public:
     { return getValue(); }
 };
 
+// A generic template-based int field type would be more elegant; a specific field
+// specialization could be declared for any required intN_t but this does not go
+// well with SWIG (it looks breaking the inheritance chain on a template).
+//
+/// Field that contains a 64-bit integer value
+class Int64Field : public FieldBase
+{
+public:
+  explicit Int64Field( int field, int64_t data )
+: FieldBase( field, Int64Convertor::convert( data ) ) {}
+  Int64Field( int field )
+: FieldBase( field, "" ) {}
+
+  void setValue( int64_t value )
+    { setString( Int64Convertor::convert( value ) ); }
+  int64_t getValue() const EXCEPT ( IncorrectDataFormat )
+    { try
+      { return Int64Convertor::convert( getString() ); }
+      catch( FieldConvertError& )
+      { throw IncorrectDataFormat( getTag(), getString() ); } }
+  operator int64_t() const
+    { return getValue(); }
+};
+
 /// Field that contains a boolean value
 class BoolField : public FieldBase
 {
@@ -616,6 +640,8 @@ DEFINE_FIELD_TIMECLASS_NUM(NAME, TOK, TYPE, DEPRECATED_FIELD::NAME)
   DEFINE_FIELD_CLASS(NAME, Price, FIX::PRICE)
 #define DEFINE_INT( NAME ) \
   DEFINE_TRIVIAL_FIELD_CLASS(NAME, Int, FIX::INT)
+#define DEFINE_INT64( NAME ) \
+  DEFINE_TRIVIAL_FIELD_CLASS(NAME, Int64, FIX::INT64)
 #define DEFINE_AMT( NAME ) \
   DEFINE_FIELD_CLASS(NAME, Amt, FIX::AMT)
 #define DEFINE_QTY( NAME ) \

--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -22,10 +22,6 @@
 #ifndef FIX_FIELDCONVERTORS_H
 #define FIX_FIELDCONVERTORS_H
 
-#ifdef _MSC_VER
-#pragma warning( disable: 4146 )
-#endif
-
 #include "FieldTypes.h"
 #include "Exceptions.h"
 #include "Utility.h"
@@ -42,16 +38,37 @@ namespace FIX
 {
 
 typedef int signed_int;
+typedef int64_t signed_int64;
 typedef unsigned int unsigned_int;
+typedef uint64_t unsigned_int64;
 
-#define UNSIGNED_VALUE_OF( x ) ( ( x < 0 ) ? -unsigned_int(x) : unsigned_int(x) )
+#ifdef _MSC_VER
+#  define PRAGMA_PUSH( x )                      \
+   __pragma( warning( push ) )                  \
+   __pragma( warning( disable: x ) ) 
+#  define PRAGMA_POP                            \
+   __pragma( warning( pop ) )
+#else
+#  define PRAGMA_PUSH( x )
+#  define PRAGMA_POP
+#endif
+
+template<typename T>
+inline typename std::make_unsigned<T>::type _UNSIGNED_VALUE_OF( const T x )
+{ return x < 0 ? -( typename std::make_unsigned<T>::type )( x ) : ( typename std::make_unsigned<T>::type )( x ); }
+
+#define UNSIGNED_VALUE_OF( x )   \
+  PRAGMA_PUSH( 4146 )            \
+  _UNSIGNED_VALUE_OF( x )        \
+  PRAGMA_POP
 
 #define IS_SPACE( x ) ( x == ' ' )
 #define IS_DIGIT( x ) ( unsigned_int( x - '0' ) < 10 )
 
-inline int number_of_symbols_in( const signed_int value )
+template<typename T>
+inline int number_of_symbols_in( const T value )
 {
-  unsigned_int number = UNSIGNED_VALUE_OF( value );
+  typename std::make_unsigned<T>::type number = UNSIGNED_VALUE_OF( value );
 
   int symbols = 0;
 
@@ -97,12 +114,13 @@ static const char digit_pairs[201] = {
   "90919293949596979899"
 };
 
-inline char* integer_to_string( char* buf, const size_t len, signed_int t )
+template<typename T>
+inline char* integer_to_string( char* buf, const size_t len, const T t )
 {
   const bool isNegative = t < 0;
   char* p = buf + len;
 
-  unsigned_int number = UNSIGNED_VALUE_OF( t );
+  typename std::make_unsigned<T>::type number = UNSIGNED_VALUE_OF( t );
 
   while( number > 99 )
   {
@@ -129,8 +147,9 @@ inline char* integer_to_string( char* buf, const size_t len, signed_int t )
   return p;
 }
 
+template<typename T>
 inline char* integer_to_string_padded
-( char* buf, const size_t len, signed_int t,
+( char* buf, const size_t len, const T t,
   const char paddingChar = '0')
 {
   char* p = integer_to_string( buf, len, t );
@@ -186,18 +205,23 @@ struct EmptyConvertor
 
 typedef EmptyConvertor StringConvertor;
 
-/// Converts integer to/from a string
-struct IntConvertor
+/// Converts integers to/from a string
+template <typename T>
+struct IntTConvertor
 {
-  static const signed_int VALUE_MIN = (std::numeric_limits<signed_int>::min)();
-  static const signed_int VALUE_MAX = (std::numeric_limits<signed_int>::max)();
-  static const signed_int OVERFLOW_MAX = VALUE_MAX / 10;
+  static_assert(std::is_integral<T>::value, "An integer type is required.");
 
-  static std::string convert( signed_int value )
+  typedef T value_type;
+  
+  static const T VALUE_MIN = (std::numeric_limits<T>::min)();
+  static const T VALUE_MAX = (std::numeric_limits<T>::max)();
+  static const T OVERFLOW_MAX = VALUE_MAX / 10;
+
+  static std::string convert( T value )
   {
     // buffer is big enough for significant digits and extra digit,
     // minus and null
-    char buffer[std::numeric_limits<signed_int>::digits10 + 2];
+    char buffer[std::numeric_limits<T>::digits10 + 2];
     const char* const start
       = integer_to_string( buffer, sizeof (buffer), value );
     return std::string( start, buffer + sizeof (buffer) - start );
@@ -206,12 +230,15 @@ struct IntConvertor
   static bool convert(     
     std::string::const_iterator str, 
     std::string::const_iterator end, 
-    signed_int& result )
+    T& result )
   {
     bool isNegative = false;
-    signed_int x = 0;
+    typename std::make_unsigned<T>::type x = 0, nx = 0;
 
     if( str == end )
+      return false;
+
+    if( *str == '-' && std::is_unsigned<T>::value )
       return false;
 
     if( *str == '-' )
@@ -223,35 +250,54 @@ struct IntConvertor
 
     do
     {
-      if( x < 0 || x > OVERFLOW_MAX ) return false; // overflow
-      const unsigned_int c = *str - '0';
+      if( x > OVERFLOW_MAX ) return false; // overflow
+      const unsigned char c = *str - '0';
       if( c > 9 ) return false;
-      x = 10 * x + c;
-      if( x < 0 && ( !isNegative || x != VALUE_MIN )) return false; // overflow
+      nx = 10 * x + c;
+      if( nx < x ) return false; // overflow
+      x = nx;
     } while ( ++str != end );
 
     if( isNegative )
-      x = -unsigned_int(x);
+    {
+      PRAGMA_PUSH( 4146 );
+      if( nx > typename std::make_unsigned<T>::type( -VALUE_MIN ) )
+        return false; // overflow
+      PRAGMA_POP;
+    }
+    else if ( nx > VALUE_MAX )
+      return false; // overflow
+    
+    PRAGMA_PUSH( 4146 );
+    if( isNegative )
+      x = -static_cast<T>(x);
+    PRAGMA_POP;
 
     result = x;
     return true;
   }
 
-  static bool convert( const std::string& value, signed_int& result )
+  static bool convert( const std::string& value, T& result )
   {
     return convert( value.begin(), value.end(), result );
   }
 
-  static signed_int convert( const std::string& value )
+  static T convert( const std::string& value )
   EXCEPT ( FieldConvertError )
   {
-    signed_int result = 0;
+    T result = 0;
     if( !convert( value.begin(), value.end(), result ) )
       throw FieldConvertError(value);
     else
       return result;
   }
 };
+
+/// Converts integer to/from a string
+typedef IntTConvertor<signed_int>   IntConvertor;
+
+/// Converts 64-bit integer to/from a string
+typedef IntTConvertor<signed_int64> Int64Convertor;
 
 /// Converts checksum to/from a string
 struct CheckSumConvertor
@@ -718,6 +764,7 @@ typedef StringConvertor STRING_CONVERTOR;
 typedef CharConvertor CHAR_CONVERTOR;
 typedef DoubleConvertor PRICE_CONVERTOR;
 typedef IntConvertor INT_CONVERTOR;
+typedef Int64Convertor INT64_CONVERTOR;
 typedef DoubleConvertor AMT_CONVERTOR;
 typedef DoubleConvertor QTY_CONVERTOR;
 typedef StringConvertor CURRENCY_CONVERTOR;
@@ -750,5 +797,8 @@ typedef StringConvertor XID_CONVERTOR;
 typedef StringConvertor XIDREF_CONVERTOR;
 typedef CheckSumConvertor CHECKSUM_CONVERTOR;
 }
+
+#undef PRAGMA_POP
+#undef PRAGMA_PUSH
 
 #endif //FIX_FIELDCONVERTORS_H

--- a/src/C++/FieldTypes.h
+++ b/src/C++/FieldTypes.h
@@ -886,6 +886,7 @@ typedef std::string STRING;
 typedef char CHAR;
 typedef double PRICE;
 typedef int INT;
+typedef int64_t INT64;
 typedef double AMT;
 typedef double QTY;
 typedef std::string CURRENCY;

--- a/src/C++/test/FieldConvertorsTestCase.cpp
+++ b/src/C++/test/FieldConvertorsTestCase.cpp
@@ -145,6 +145,494 @@ TEST(integerConvertFrom)
   CHECK_THROW( IntConvertor::convert( "+200" ), FieldConvertError );
 }
 
+namespace
+{
+  typedef IntTConvertor<int8_t>   Int8Convertor;
+  typedef IntTConvertor<int16_t>  Int16Convertor;
+  typedef IntTConvertor<int32_t>  Int32Convertor;
+  typedef IntTConvertor<int64_t>  Int64Convertor;
+
+  typedef IntTConvertor<uint8_t>  UInt8Convertor;
+  typedef IntTConvertor<uint16_t> UInt16Convertor;
+  typedef IntTConvertor<uint32_t> UInt32Convertor;
+  typedef IntTConvertor<uint64_t> UInt64Convertor;
+}
+
+#if defined( max )
+#  undef max
+#endif
+#if defined( min )
+#  undef min
+#endif
+
+TEST(int8_integerConvertTo)
+{
+  CHECK_EQUAL( "0", Int8Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", Int8Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", Int8Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", Int8Convertor::convert( 100 ) );
+  CHECK_EQUAL( "126", Int8Convertor::convert( 126 ) );
+  CHECK_EQUAL( "127", Int8Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_THROW( Int8Convertor::convert( "128" ), FieldConvertError );
+
+  CHECK_EQUAL( "-1", Int8Convertor::convert( -1 ) );
+  CHECK_EQUAL( "-12", Int8Convertor::convert( -12 ) );
+  CHECK_EQUAL( "-100", Int8Convertor::convert( -100 ) );
+  CHECK_EQUAL( "-127", Int8Convertor::convert( -127 ) );
+  CHECK_EQUAL( "-128", Int8Convertor::convert( std::numeric_limits<int8_t>::min() ) );
+  CHECK_THROW( Int8Convertor::convert( "-129" ), FieldConvertError );
+
+  CHECK_THROW( Int8Convertor::convert( "-" ), FieldConvertError );
+}
+
+TEST(int8_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, Int8Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, Int8Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, Int8Convertor::convert( "12" ) );
+  CHECK_EQUAL( 13, Int8Convertor::convert( "13" ) );
+  CHECK_EQUAL( 100, Int8Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), Int8Convertor::convert( "127" ) );
+  CHECK_THROW( Int8Convertor::convert( "128" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int8Convertor::convert( "130" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int8Convertor::convert( "999" ), FieldConvertError ); // overflow
+  
+  CHECK_EQUAL( -1, Int8Convertor::convert( "-1" ) );
+  CHECK_EQUAL( -12, Int8Convertor::convert( "-12" ) );
+  CHECK_EQUAL( -13, Int8Convertor::convert( "-13" ) );
+  CHECK_EQUAL( -100, Int8Convertor::convert( "-100" ) );
+  CHECK_EQUAL( -127, Int8Convertor::convert( "-127" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::min(), Int8Convertor::convert( "-128" ) );
+  CHECK_THROW( Int8Convertor::convert( "-129" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int8Convertor::convert( "-130" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int8Convertor::convert( "-999" ), FieldConvertError ); // overflow
+
+  CHECK_THROW( Int8Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( Int8Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( Int8Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( Int8Convertor::convert( "+200" ), FieldConvertError );
+}
+
+TEST(int16_integerConvertTo)
+{
+  CHECK_EQUAL( "0", Int16Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", Int16Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", Int16Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", Int16Convertor::convert( 100 ) );
+  CHECK_EQUAL( "127", Int16Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_EQUAL( "128", Int16Convertor::convert( 128 ) );
+  CHECK_EQUAL( "1234", Int16Convertor::convert( 1234 ) );
+  CHECK_EQUAL( "12345", Int16Convertor::convert( 12345 ) );
+  CHECK_EQUAL( "32767", Int16Convertor::convert( std::numeric_limits<int16_t>::max() ) );
+  CHECK_THROW( Int16Convertor::convert( "32768" ), FieldConvertError );
+
+  CHECK_EQUAL( "-1", Int16Convertor::convert( -1 ) );
+  CHECK_EQUAL( "-12", Int16Convertor::convert( -12 ) );
+  CHECK_EQUAL( "-100", Int16Convertor::convert( -100 ) );
+  CHECK_EQUAL( "-128", Int16Convertor::convert( std::numeric_limits<int8_t>::min() ) );
+  CHECK_EQUAL( "-129", Int16Convertor::convert( -129 ) );
+  CHECK_EQUAL( "-1234", Int16Convertor::convert( -1234 ) );
+  CHECK_EQUAL( "-12345", Int16Convertor::convert( -12345 ) );
+  CHECK_EQUAL( "-32767", Int16Convertor::convert( -32767 ) );
+  CHECK_EQUAL( "-32768", Int16Convertor::convert( std::numeric_limits<int16_t>::min() ) );
+  CHECK_THROW( Int16Convertor::convert( "-32769" ), FieldConvertError );
+
+  CHECK_THROW( Int16Convertor::convert( "-" ), FieldConvertError );
+}
+
+TEST(int16_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, Int16Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, Int16Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, Int16Convertor::convert( "12" ) );
+  CHECK_EQUAL( 100, Int16Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), Int16Convertor::convert( "127" ) );
+  CHECK_EQUAL( 128, Int16Convertor::convert( "128" ) );
+  CHECK_EQUAL( 130, Int16Convertor::convert( "130" ) );
+  CHECK_EQUAL( 999, Int16Convertor::convert( "999" ) );
+  CHECK_EQUAL( 1234, Int16Convertor::convert( "1234" ) );
+  CHECK_EQUAL( 3277, Int16Convertor::convert( "3277" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::max(), Int16Convertor::convert( "32767" ) );
+  CHECK_THROW( Int16Convertor::convert( "32768" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int16Convertor::convert( "32770" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int16Convertor::convert( "99999" ), FieldConvertError ); // overflow
+
+  CHECK_EQUAL( -1, Int16Convertor::convert( "-1" ) );
+  CHECK_EQUAL( -12, Int16Convertor::convert( "-12" ) );
+  CHECK_EQUAL( -100, Int16Convertor::convert( "-100" ) );
+  CHECK_EQUAL( -127, Int16Convertor::convert( "-127" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::min(), Int16Convertor::convert( "-128" ) );
+  CHECK_EQUAL( -129, Int16Convertor::convert( "-129" ) );
+  CHECK_EQUAL( -130, Int16Convertor::convert( "-130" ) );
+  CHECK_EQUAL( -999, Int16Convertor::convert( "-999" ) );
+  CHECK_EQUAL( -1234, Int16Convertor::convert( "-1234" ) );
+  CHECK_EQUAL( -32767, Int16Convertor::convert( "-32767" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::min(), Int16Convertor::convert( "-32768" ) );
+  CHECK_THROW( Int16Convertor::convert( "-32769" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int16Convertor::convert( "-32770" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int16Convertor::convert( "-99999" ), FieldConvertError ); // overflow
+
+  CHECK_THROW( Int16Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( Int16Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( Int16Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( Int16Convertor::convert( "+200" ), FieldConvertError );
+}
+
+TEST(int64_integerConvertTo)
+{
+  CHECK_EQUAL( "0", Int64Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", Int64Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", Int64Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", Int64Convertor::convert( 100 ) );
+  CHECK_EQUAL( "127", Int64Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_EQUAL( "128", Int64Convertor::convert( 128 ) );
+  CHECK_EQUAL( "1234", Int64Convertor::convert( 1234 ) );
+  CHECK_EQUAL( "12345", Int64Convertor::convert( 12345 ) );
+  CHECK_EQUAL( "32767", Int64Convertor::convert( std::numeric_limits<int16_t>::max() ) );
+  CHECK_EQUAL( "32768", Int64Convertor::convert( 32768 ) );
+  CHECK_EQUAL( "123456", Int64Convertor::convert( 123456 ) );
+  CHECK_EQUAL( "1234567", Int64Convertor::convert( 1234567 ) );
+  CHECK_EQUAL( "12345678", Int64Convertor::convert( 12345678 ) );
+  CHECK_EQUAL( "123456789", Int64Convertor::convert( 123456789 ) );
+  CHECK_EQUAL( "2147483647", Int64Convertor::convert( MAX_INT ) );
+  CHECK_EQUAL( "2147483648", Int64Convertor::convert( 2147483648 ) );
+  CHECK_EQUAL( "12345678912", Int64Convertor::convert( 12345678912LL ) );
+  CHECK_EQUAL( "123456789123", Int64Convertor::convert( 123456789123LL ) );
+  CHECK_EQUAL( "1234567891234", Int64Convertor::convert( 1234567891234LL ) );
+  CHECK_EQUAL( "12345678912345", Int64Convertor::convert( 12345678912345LL ) );
+  CHECK_EQUAL( "123456789123456", Int64Convertor::convert( 123456789123456LL ) );
+  CHECK_EQUAL( "1234567891234567", Int64Convertor::convert( 1234567891234567LL ) );
+  CHECK_EQUAL( "12345678912345678", Int64Convertor::convert( 12345678912345678LL ) );
+  CHECK_EQUAL( "123456789123456789", Int64Convertor::convert( 123456789123456789LL ) );
+  CHECK_EQUAL( "1234567891234567891", Int64Convertor::convert( 1234567891234567891LL ) );
+  CHECK_EQUAL( "9223372036854775807", Int64Convertor::convert( std::numeric_limits<int64_t>::max() ) );
+  CHECK_THROW( Int64Convertor::convert( "9223372036854775808" ), FieldConvertError );
+  
+  CHECK_EQUAL( "-1", Int64Convertor::convert( -1 ) );
+  CHECK_EQUAL( "-12", Int64Convertor::convert( -12 ) );
+  CHECK_EQUAL( "-100", Int64Convertor::convert( -100 ) );
+  CHECK_EQUAL( "-128", Int64Convertor::convert( std::numeric_limits<int8_t>::min() ) );
+  CHECK_EQUAL( "-129", Int64Convertor::convert( -129 ) );
+  CHECK_EQUAL( "-1234", Int64Convertor::convert( -1234 ) );
+  CHECK_EQUAL( "-12345", Int64Convertor::convert( -12345 ) );
+  CHECK_EQUAL( "-32768", Int64Convertor::convert( std::numeric_limits<int16_t>::min() ) );
+  CHECK_EQUAL( "-32769", Int64Convertor::convert( -32769 ) );
+  CHECK_EQUAL( "-123456", Int64Convertor::convert( -123456 ) );
+  CHECK_EQUAL( "-1234567", Int64Convertor::convert( -1234567 ) );
+  CHECK_EQUAL( "-12345678", Int64Convertor::convert( -12345678 ) );
+  CHECK_EQUAL( "-123456789", Int64Convertor::convert( -123456789 ) );
+  CHECK_EQUAL( "-2147483647", Int64Convertor::convert( -2147483647 ) );
+  CHECK_EQUAL( "-2147483648", Int64Convertor::convert( MIN_INT ) );
+  CHECK_EQUAL( "-2147483649", Int64Convertor::convert( -2147483649LL ) );
+  CHECK_EQUAL( "-12345678912", Int64Convertor::convert( -12345678912LL ) );
+  CHECK_EQUAL( "-123456789123", Int64Convertor::convert( -123456789123LL ) );
+  CHECK_EQUAL( "-1234567891234", Int64Convertor::convert( -1234567891234LL ) );
+  CHECK_EQUAL( "-12345678912345", Int64Convertor::convert( -12345678912345LL ) );
+  CHECK_EQUAL( "-123456789123456", Int64Convertor::convert( -123456789123456LL ) );
+  CHECK_EQUAL( "-1234567891234567", Int64Convertor::convert( -1234567891234567LL ) );
+  CHECK_EQUAL( "-12345678912345678", Int64Convertor::convert( -12345678912345678LL ) );
+  CHECK_EQUAL( "-123456789123456789", Int64Convertor::convert( -123456789123456789LL ) );
+  CHECK_EQUAL( "-1234567891234567891", Int64Convertor::convert( -1234567891234567891LL ) );
+  CHECK_EQUAL( "-9223372036854775807", Int64Convertor::convert( -9223372036854775807 ) );
+  CHECK_EQUAL( "-9223372036854775808", Int64Convertor::convert( std::numeric_limits<int64_t>::min() ) );
+  CHECK_THROW( Int64Convertor::convert( "-9223372036854775809" ), FieldConvertError );
+
+  CHECK_THROW( Int64Convertor::convert( "-" ), FieldConvertError );
+}
+
+TEST(int64_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, Int64Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, Int64Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, Int64Convertor::convert( "12" ) );
+  CHECK_EQUAL( 100, Int64Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), Int64Convertor::convert( "127" ) );
+  CHECK_EQUAL( 128, Int64Convertor::convert( "128" ) );
+  CHECK_EQUAL( 130, Int64Convertor::convert( "130" ) );
+  CHECK_EQUAL( 999, Int64Convertor::convert( "999" ) );
+  CHECK_EQUAL( 1234, Int64Convertor::convert( "1234" ) );
+  CHECK_EQUAL( 3277, Int64Convertor::convert( "3277" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::max(), Int64Convertor::convert( "32767" ) );
+  CHECK_EQUAL( 32768, Int64Convertor::convert( "32768" ) );
+  CHECK_EQUAL( 32770, Int64Convertor::convert( "32770" ) );
+  CHECK_EQUAL( 99999, Int64Convertor::convert( "99999" ) );
+  CHECK_EQUAL( 214748365, Int64Convertor::convert( "214748365" ) );
+  CHECK_EQUAL( MAX_INT, Int64Convertor::convert( "2147483647" ) );
+  CHECK_EQUAL( 2147483648LL, Int64Convertor::convert( "2147483648" ) );
+  CHECK_EQUAL( 2147483650LL, Int64Convertor::convert( "2147483650" ) );
+  CHECK_EQUAL( 9999999999LL, Int64Convertor::convert( "9999999999" ) );
+  CHECK_EQUAL( 922337203685477581LL, Int64Convertor::convert( "922337203685477581" ) );
+  CHECK_EQUAL( std::numeric_limits<int64_t>::max(), Int64Convertor::convert( "9223372036854775807" ) );
+  CHECK_THROW( Int64Convertor::convert( "9223372036854775808" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int64Convertor::convert( "9223372036854775810" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int64Convertor::convert( "9999999999999999999" ), FieldConvertError ); // overflow
+  
+  CHECK_EQUAL( -1, Int64Convertor::convert( "-1" ) );
+  CHECK_EQUAL( -12, Int64Convertor::convert( "-12" ) );
+  CHECK_EQUAL( -100, Int64Convertor::convert( "-100" ) );
+  CHECK_EQUAL( -127, Int64Convertor::convert( "-127" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::min(), Int64Convertor::convert( "-128" ) );
+  CHECK_EQUAL( -129, Int64Convertor::convert( "-129" ) );
+  CHECK_EQUAL( -130, Int64Convertor::convert( "-130" ) );
+  CHECK_EQUAL( -999, Int64Convertor::convert( "-999" ) );
+  CHECK_EQUAL( -1234, Int64Convertor::convert( "-1234" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::min(), Int64Convertor::convert( "-32768" ) );
+  CHECK_EQUAL( -32769, Int64Convertor::convert( "-32769" ) );
+  CHECK_EQUAL( -32770, Int64Convertor::convert( "-32770" ) );
+  CHECK_EQUAL( -99999, Int64Convertor::convert( "-99999" ) );
+  CHECK_EQUAL( -214748365LL, Int64Convertor::convert( "-214748365" ) );
+  CHECK_EQUAL( -2147483647LL, Int64Convertor::convert( "-2147483647" ) );
+  CHECK_EQUAL( MIN_INT, Int64Convertor::convert( "-2147483648" ) );
+  CHECK_EQUAL( -2147483649LL, Int64Convertor::convert( "-2147483649" ) );
+  CHECK_EQUAL( -2147483650LL, Int64Convertor::convert( "-2147483650" ) );
+  CHECK_EQUAL( -9999999999LL, Int64Convertor::convert( "-9999999999" ) );
+  CHECK_EQUAL( -922337203685477581LL, Int64Convertor::convert( "-922337203685477581" ) );
+  CHECK_EQUAL( std::numeric_limits<int64_t>::min(), Int64Convertor::convert( "-9223372036854775808" ) );
+  CHECK_THROW( Int64Convertor::convert( "-9223372036854775809" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int64Convertor::convert( "-9223372036854775810" ), FieldConvertError ); // overflow
+  CHECK_THROW( Int64Convertor::convert( "-9999999999999999999" ), FieldConvertError ); // overflow
+  
+  CHECK_THROW( Int64Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( Int64Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( Int64Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( Int64Convertor::convert( "+200" ), FieldConvertError );
+}
+
+TEST(uint8_integerConvertTo)
+{
+  CHECK_EQUAL( "0", UInt8Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", UInt8Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", UInt8Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", UInt8Convertor::convert( 100 ) );
+  CHECK_EQUAL( "126", UInt8Convertor::convert( 126 ) );
+  CHECK_EQUAL( "127", UInt8Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_EQUAL( "128", UInt8Convertor::convert( 128 ) );
+  CHECK_EQUAL( "255", UInt8Convertor::convert( 255 ) );
+  CHECK_THROW( UInt8Convertor::convert( "256" ), FieldConvertError );
+
+  CHECK_THROW( UInt8Convertor::convert( "-" ), FieldConvertError );
+  CHECK_THROW( UInt8Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint8_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, UInt8Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, UInt8Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, UInt8Convertor::convert( "12" ) );
+  CHECK_EQUAL( 13, UInt8Convertor::convert( "13" ) );
+  CHECK_EQUAL( 100, UInt8Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), UInt8Convertor::convert( "127" ) );
+  CHECK_EQUAL( 128, UInt8Convertor::convert( "128" ) );
+  CHECK_EQUAL( 130, UInt8Convertor::convert( "130" ) );
+  CHECK_EQUAL( 254, UInt8Convertor::convert( "254" ) );
+  CHECK_EQUAL( std::numeric_limits<uint8_t>::max(), UInt8Convertor::convert( "255" ) );
+  CHECK_THROW( UInt8Convertor::convert( "256" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt8Convertor::convert( "258" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt8Convertor::convert( "999" ), FieldConvertError ); // overflow
+  
+  CHECK_THROW( UInt8Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( UInt8Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( UInt8Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( UInt8Convertor::convert( "+200" ), FieldConvertError );
+  CHECK_THROW( UInt8Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint16_integerConvertTo)
+{
+  CHECK_EQUAL( "0", UInt16Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", UInt16Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", UInt16Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", UInt16Convertor::convert( 100 ) );
+  CHECK_EQUAL( "127", UInt16Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_EQUAL( "128", UInt16Convertor::convert( 128 ) );
+  CHECK_EQUAL( "1234", UInt16Convertor::convert( 1234 ) );
+  CHECK_EQUAL( "12345", UInt16Convertor::convert( 12345 ) );
+  CHECK_EQUAL( "32767", UInt16Convertor::convert( std::numeric_limits<int16_t>::max() ) );
+  CHECK_EQUAL( "32768", UInt16Convertor::convert( 32768 ) );
+  CHECK_EQUAL( "65535", UInt16Convertor::convert( std::numeric_limits<uint16_t>::max() ) );
+  CHECK_THROW( UInt16Convertor::convert( "65536" ), FieldConvertError );
+
+  CHECK_THROW( UInt16Convertor::convert( "-" ), FieldConvertError );
+  CHECK_THROW( UInt16Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint16_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, UInt16Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, UInt16Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, UInt16Convertor::convert( "12" ) );
+  CHECK_EQUAL( 100, UInt16Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), UInt16Convertor::convert( "127" ) );
+  CHECK_EQUAL( 128, UInt16Convertor::convert( "128" ) );
+  CHECK_EQUAL( 254, UInt16Convertor::convert( "254" ) );
+  CHECK_EQUAL( std::numeric_limits<uint8_t>::max(), UInt16Convertor::convert( "255" ) );
+  CHECK_EQUAL( 256, UInt16Convertor::convert( "256" ) );
+  CHECK_EQUAL( 258, UInt16Convertor::convert( "258" ) );
+  CHECK_EQUAL( 999, UInt16Convertor::convert( "999" ) );
+  CHECK_EQUAL( 1234, UInt16Convertor::convert( "1234" ) );
+  CHECK_EQUAL( 3277, UInt16Convertor::convert( "3277" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::max(), UInt16Convertor::convert( "32767" ) );
+  CHECK_EQUAL( 32768, UInt16Convertor::convert( "32768" ) );
+  CHECK_EQUAL( 32770, UInt16Convertor::convert( "32770" ) );
+  CHECK_EQUAL( 6556, UInt16Convertor::convert( "6556" ) );
+  CHECK_EQUAL( std::numeric_limits<uint16_t>::max(), UInt16Convertor::convert( "65535" ) );
+  CHECK_THROW( UInt16Convertor::convert( "65536" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt16Convertor::convert( "65538" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt16Convertor::convert( "99999" ), FieldConvertError ); // overflow
+
+  CHECK_THROW( UInt16Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( UInt16Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( UInt16Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( UInt16Convertor::convert( "+200" ), FieldConvertError );
+  CHECK_THROW( UInt16Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint32_integerConvertTo)
+{
+  CHECK_EQUAL( "0", UInt32Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", UInt32Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", UInt32Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", UInt32Convertor::convert( 100 ) );
+  CHECK_EQUAL( "127", UInt32Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_EQUAL( "128", UInt32Convertor::convert( 128 ) );
+  CHECK_EQUAL( "1234", UInt32Convertor::convert( 1234 ) );
+  CHECK_EQUAL( "12345", UInt32Convertor::convert( 12345 ) );
+  CHECK_EQUAL( "32767", UInt32Convertor::convert( std::numeric_limits<int16_t>::max() ) );
+  CHECK_EQUAL( "32768", UInt32Convertor::convert( 32768 ) );
+  CHECK_EQUAL( "123456", UInt32Convertor::convert( 123456 ) );
+  CHECK_EQUAL( "1234567", UInt32Convertor::convert( 1234567 ) );
+  CHECK_EQUAL( "12345678", UInt32Convertor::convert( 12345678 ) );
+  CHECK_EQUAL( "123456789", UInt32Convertor::convert( 123456789 ) );
+  CHECK_EQUAL( "2147483647", UInt32Convertor::convert( MAX_INT ) );
+  CHECK_EQUAL( "2147483648", UInt32Convertor::convert( 2147483648UL ) );
+  CHECK_EQUAL( "4294967295", UInt32Convertor::convert( 4294967295UL ) );
+  CHECK_THROW( UInt32Convertor::convert( "4294967296" ), FieldConvertError );
+
+  CHECK_THROW( UInt32Convertor::convert( "-" ), FieldConvertError );
+  CHECK_THROW( UInt32Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint32_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, UInt32Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, UInt32Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, UInt32Convertor::convert( "12" ) );
+  CHECK_EQUAL( 100, UInt32Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), UInt32Convertor::convert( "127" ) );
+  CHECK_EQUAL( 128, UInt32Convertor::convert( "128" ) );
+  CHECK_EQUAL( 254, UInt32Convertor::convert( "254" ) );
+  CHECK_EQUAL( std::numeric_limits<uint8_t>::max(), UInt32Convertor::convert( "255" ) );
+  CHECK_EQUAL( 256, UInt32Convertor::convert( "256" ) );
+  CHECK_EQUAL( 258, UInt32Convertor::convert( "258" ) );
+  CHECK_EQUAL( 999, UInt32Convertor::convert( "999" ) );
+  CHECK_EQUAL( 1234, UInt32Convertor::convert( "1234" ) );
+  CHECK_EQUAL( 3277, UInt32Convertor::convert( "3277" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::max(), UInt32Convertor::convert( "32767" ) );
+  CHECK_EQUAL( 32768, UInt32Convertor::convert( "32768" ) );
+  CHECK_EQUAL( 32770, UInt32Convertor::convert( "32770" ) );
+  CHECK_EQUAL( 6556, UInt32Convertor::convert( "6556" ) );
+  CHECK_EQUAL( std::numeric_limits<uint16_t>::max(), UInt32Convertor::convert( "65535" ) );
+  CHECK_EQUAL( 65536, UInt32Convertor::convert( "65536" ) ); // overflow
+  CHECK_EQUAL( 65538, UInt32Convertor::convert( "65538" ) ); // overflow
+  CHECK_EQUAL( 99999, UInt32Convertor::convert( "99999" ) );
+  CHECK_EQUAL( 214748365, UInt32Convertor::convert( "214748365" ) );
+  CHECK_EQUAL( MAX_INT, UInt32Convertor::convert( "2147483647" ) );
+  CHECK_EQUAL( 2147483648UL, UInt32Convertor::convert( "2147483648" ) );
+  CHECK_EQUAL( 2147483650UL, UInt32Convertor::convert( "2147483650" ) );
+  CHECK_EQUAL( 429496730UL, UInt32Convertor::convert( "429496730" ) );
+  CHECK_EQUAL( std::numeric_limits<uint32_t>::max(), UInt32Convertor::convert( "4294967295" ) );
+  CHECK_THROW( UInt32Convertor::convert( "4294967296" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt32Convertor::convert( "4294967297" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt32Convertor::convert( "9999999999" ), FieldConvertError ); // overflow
+
+  CHECK_THROW( UInt32Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( UInt32Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( UInt32Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( UInt32Convertor::convert( "+200" ), FieldConvertError );
+  CHECK_THROW( UInt32Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint64_integerConvertTo)
+{
+  CHECK_EQUAL( "0", UInt64Convertor::convert( 0 ) );
+  CHECK_EQUAL( "1", UInt64Convertor::convert( 1 ) );
+  CHECK_EQUAL( "12", UInt64Convertor::convert( 12 ) );
+  CHECK_EQUAL( "100", UInt64Convertor::convert( 100 ) );
+  CHECK_EQUAL( "127", UInt64Convertor::convert( std::numeric_limits<int8_t>::max() ) );
+  CHECK_EQUAL( "128", UInt64Convertor::convert( 128 ) );
+  CHECK_EQUAL( "1234", UInt64Convertor::convert( 1234 ) );
+  CHECK_EQUAL( "12345", UInt64Convertor::convert( 12345 ) );
+  CHECK_EQUAL( "32767", UInt64Convertor::convert( std::numeric_limits<int16_t>::max() ) );
+  CHECK_EQUAL( "32768", UInt64Convertor::convert( 32768 ) );
+  CHECK_EQUAL( "123456", UInt64Convertor::convert( 123456 ) );
+  CHECK_EQUAL( "1234567", UInt64Convertor::convert( 1234567 ) );
+  CHECK_EQUAL( "12345678", UInt64Convertor::convert( 12345678 ) );
+  CHECK_EQUAL( "123456789", UInt64Convertor::convert( 123456789 ) );
+  CHECK_EQUAL( "2147483647", UInt64Convertor::convert( MAX_INT ) );
+  CHECK_EQUAL( "2147483648", UInt64Convertor::convert( 2147483648 ) );
+  CHECK_EQUAL( "12345678912", UInt64Convertor::convert( 12345678912LL ) );
+  CHECK_EQUAL( "123456789123", UInt64Convertor::convert( 123456789123LL ) );
+  CHECK_EQUAL( "1234567891234", UInt64Convertor::convert( 1234567891234LL ) );
+  CHECK_EQUAL( "12345678912345", UInt64Convertor::convert( 12345678912345LL ) );
+  CHECK_EQUAL( "123456789123456", UInt64Convertor::convert( 123456789123456LL ) );
+  CHECK_EQUAL( "1234567891234567", UInt64Convertor::convert( 1234567891234567LL ) );
+  CHECK_EQUAL( "12345678912345678", UInt64Convertor::convert( 12345678912345678LL ) );
+  CHECK_EQUAL( "123456789123456789", UInt64Convertor::convert( 123456789123456789LL ) );
+  CHECK_EQUAL( "1234567891234567891", UInt64Convertor::convert( 1234567891234567891ULL ) );
+  CHECK_EQUAL( "9223372036854775807", UInt64Convertor::convert( std::numeric_limits<int64_t>::max() ) );
+  CHECK_EQUAL( "9223372036854775808", UInt64Convertor::convert( 9223372036854775808ULL ) );
+  CHECK_EQUAL( "18446744073709551615", UInt64Convertor::convert( std::numeric_limits<uint64_t>::max() ) );
+  CHECK_THROW( UInt64Convertor::convert( "18446744073709551616" ), FieldConvertError );
+
+  CHECK_THROW( UInt64Convertor::convert( "-" ), FieldConvertError );
+  CHECK_THROW( UInt64Convertor::convert( "-1" ), FieldConvertError );
+}
+
+TEST(uint64_integerConvertFrom)
+{
+  CHECK_EQUAL( 0, UInt64Convertor::convert( "0" ) );
+  CHECK_EQUAL( 1, UInt64Convertor::convert( "1" ) );
+  CHECK_EQUAL( 12, UInt64Convertor::convert( "12" ) );
+  CHECK_EQUAL( 100, UInt64Convertor::convert( "100" ) );
+  CHECK_EQUAL( std::numeric_limits<int8_t>::max(), UInt64Convertor::convert( "127" ) );
+  CHECK_EQUAL( 128, UInt64Convertor::convert( "128" ) );
+  CHECK_EQUAL( 254, UInt64Convertor::convert( "254" ) );
+  CHECK_EQUAL( std::numeric_limits<uint8_t>::max(), UInt64Convertor::convert( "255" ) );
+  CHECK_EQUAL( 256, UInt64Convertor::convert( "256" ) );
+  CHECK_EQUAL( 258, UInt64Convertor::convert( "258" ) );
+  CHECK_EQUAL( 999, UInt64Convertor::convert( "999" ) );
+  CHECK_EQUAL( 1234, UInt64Convertor::convert( "1234" ) );
+  CHECK_EQUAL( 3277, UInt64Convertor::convert( "3277" ) );
+  CHECK_EQUAL( std::numeric_limits<int16_t>::max(), UInt64Convertor::convert( "32767" ) );
+  CHECK_EQUAL( 32768, UInt64Convertor::convert( "32768" ) );
+  CHECK_EQUAL( 32770, UInt64Convertor::convert( "32770" ) );
+  CHECK_EQUAL( 6556, UInt64Convertor::convert( "6556" ) );
+  CHECK_EQUAL( std::numeric_limits<uint16_t>::max(), UInt64Convertor::convert( "65535" ) );
+  CHECK_EQUAL( 65536, UInt64Convertor::convert( "65536" ) ); // overflow
+  CHECK_EQUAL( 65538, UInt64Convertor::convert( "65538" ) ); // overflow
+  CHECK_EQUAL( 99999, UInt64Convertor::convert( "99999" ) );
+  CHECK_EQUAL( 214748365, UInt64Convertor::convert( "214748365" ) );
+  CHECK_EQUAL( MAX_INT, UInt64Convertor::convert( "2147483647" ) );
+  CHECK_EQUAL( 2147483648ULL, UInt64Convertor::convert( "2147483648" ) );
+  CHECK_EQUAL( 2147483650ULL, UInt64Convertor::convert( "2147483650" ) );
+  CHECK_EQUAL( 429496730ULL, UInt64Convertor::convert( "429496730" ) );
+  CHECK_EQUAL( std::numeric_limits<uint32_t>::max(), UInt64Convertor::convert( "4294967295" ) );
+  CHECK_EQUAL( 4294967296ULL, UInt64Convertor::convert( "4294967296" ) );
+  CHECK_EQUAL( 4294967297ULL, UInt64Convertor::convert( "4294967297" ) );
+  CHECK_EQUAL( 429496730ULL, UInt64Convertor::convert( "429496730" ) );
+  CHECK_EQUAL( 9999999999ULL, UInt64Convertor::convert( "9999999999" ) );
+  CHECK_EQUAL( std::numeric_limits<uint64_t>::max(), UInt64Convertor::convert( "18446744073709551615" ) );
+  CHECK_THROW( UInt64Convertor::convert( "18446744073709551616" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt64Convertor::convert( "18446744073709551617" ), FieldConvertError ); // overflow
+  CHECK_THROW( UInt64Convertor::convert( "99999999999999999999" ), FieldConvertError ); // overflow
+  
+  CHECK_THROW( UInt64Convertor::convert( "" ), FieldConvertError );
+  CHECK_THROW( UInt64Convertor::convert( "abc" ), FieldConvertError );
+  CHECK_THROW( UInt64Convertor::convert( "123.4" ), FieldConvertError );
+  CHECK_THROW( UInt64Convertor::convert( "+200" ), FieldConvertError );
+  CHECK_THROW( UInt64Convertor::convert( "-1" ), FieldConvertError );
+}
+
 TEST(doubleConvertTo)
 {
   CHECK_EQUAL( "45.32", DoubleConvertor::convert( 45.32 ) );

--- a/src/python/quickfix.py
+++ b/src/python/quickfix.py
@@ -942,6 +942,22 @@ class IntField(FieldBase):
 
 # Register IntField in _quickfix:
 _quickfix.IntField_swigregister(IntField)
+class Int64Field(FieldBase):
+    thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
+    __repr__ = _swig_repr
+
+    def __init__(self, *args):
+        _quickfix.Int64Field_swiginit(self, _quickfix.new_Int64Field(*args))
+
+    def setValue(self, value):
+        return _quickfix.Int64Field_setValue(self, value)
+
+    def getValue(self):
+        return _quickfix.Int64Field_getValue(self)
+    __swig_destroy__ = _quickfix.delete_Int64Field
+
+# Register Int64Field in _quickfix:
+_quickfix.Int64Field_swigregister(Int64Field)
 class BoolField(FieldBase):
     thisown = property(lambda x: x.this.own(), lambda x, v: x.this.own(v), doc="The membership flag")
     __repr__ = _swig_repr

--- a/src/ruby/QuickfixRuby.cpp
+++ b/src/ruby/QuickfixRuby.cpp
@@ -2222,137 +2222,138 @@ namespace Swig {
 #define SWIGTYPE_p_FIX__IncorrectMessageStructure swig_types[39]
 #define SWIGTYPE_p_FIX__IncorrectTagValue swig_types[40]
 #define SWIGTYPE_p_FIX__Initiator swig_types[41]
-#define SWIGTYPE_p_FIX__IntField swig_types[42]
-#define SWIGTYPE_p_FIX__InvalidMessage swig_types[43]
-#define SWIGTYPE_p_FIX__InvalidMessageType swig_types[44]
-#define SWIGTYPE_p_FIX__InvalidTagNumber swig_types[45]
-#define SWIGTYPE_p_FIX__LocalDate swig_types[46]
-#define SWIGTYPE_p_FIX__LocalTimeOnly swig_types[47]
-#define SWIGTYPE_p_FIX__LocalTimeStamp swig_types[48]
-#define SWIGTYPE_p_FIX__Log swig_types[49]
-#define SWIGTYPE_p_FIX__LogFactory swig_types[50]
-#define SWIGTYPE_p_FIX__MemoryStore swig_types[51]
-#define SWIGTYPE_p_FIX__MemoryStoreFactory swig_types[52]
-#define SWIGTYPE_p_FIX__Message swig_types[53]
-#define SWIGTYPE_p_FIX__MessageParseError swig_types[54]
-#define SWIGTYPE_p_FIX__MessageStore swig_types[55]
-#define SWIGTYPE_p_FIX__MessageStoreExceptionWrapper swig_types[56]
-#define SWIGTYPE_p_FIX__MessageStoreFactory swig_types[57]
-#define SWIGTYPE_p_FIX__MessageStoreFactoryExceptionWrapper swig_types[58]
-#define SWIGTYPE_p_FIX__MySQLConnection swig_types[59]
-#define SWIGTYPE_p_FIX__MySQLLog swig_types[60]
-#define SWIGTYPE_p_FIX__MySQLLogFactory swig_types[61]
-#define SWIGTYPE_p_FIX__MySQLQuery swig_types[62]
-#define SWIGTYPE_p_FIX__MySQLStore swig_types[63]
-#define SWIGTYPE_p_FIX__MySQLStoreFactory swig_types[64]
-#define SWIGTYPE_p_FIX__NoTagValue swig_types[65]
-#define SWIGTYPE_p_FIX__NullApplication swig_types[66]
-#define SWIGTYPE_p_FIX__NullLog swig_types[67]
-#define SWIGTYPE_p_FIX__PostgreSQLConnection swig_types[68]
-#define SWIGTYPE_p_FIX__PostgreSQLLog swig_types[69]
-#define SWIGTYPE_p_FIX__PostgreSQLLogFactory swig_types[70]
-#define SWIGTYPE_p_FIX__PostgreSQLQuery swig_types[71]
-#define SWIGTYPE_p_FIX__PostgreSQLStore swig_types[72]
-#define SWIGTYPE_p_FIX__PostgreSQLStoreFactory swig_types[73]
-#define SWIGTYPE_p_FIX__RejectLogon swig_types[74]
-#define SWIGTYPE_p_FIX__RepeatedTag swig_types[75]
-#define SWIGTYPE_p_FIX__RepeatingGroupCountMismatch swig_types[76]
-#define SWIGTYPE_p_FIX__RequiredTagMissing swig_types[77]
-#define SWIGTYPE_p_FIX__RuntimeError swig_types[78]
-#define SWIGTYPE_p_FIX__SSLSocketAcceptor swig_types[79]
-#define SWIGTYPE_p_FIX__SSLSocketInitiator swig_types[80]
-#define SWIGTYPE_p_FIX__ScreenLog swig_types[81]
-#define SWIGTYPE_p_FIX__ScreenLogFactory swig_types[82]
-#define SWIGTYPE_p_FIX__SenderCompID swig_types[83]
-#define SWIGTYPE_p_FIX__Session swig_types[84]
-#define SWIGTYPE_p_FIX__SessionID swig_types[85]
-#define SWIGTYPE_p_FIX__SessionNotFound swig_types[86]
-#define SWIGTYPE_p_FIX__SessionSettings swig_types[87]
-#define SWIGTYPE_p_FIX__SocketAcceptor swig_types[88]
-#define SWIGTYPE_p_FIX__SocketCloseFailed swig_types[89]
-#define SWIGTYPE_p_FIX__SocketException swig_types[90]
-#define SWIGTYPE_p_FIX__SocketInitiator swig_types[91]
-#define SWIGTYPE_p_FIX__SocketRecvFailed swig_types[92]
-#define SWIGTYPE_p_FIX__SocketSendFailed swig_types[93]
-#define SWIGTYPE_p_FIX__StringField swig_types[94]
-#define SWIGTYPE_p_FIX__SynchronizedApplication swig_types[95]
-#define SWIGTYPE_p_FIX__TYPE__Type swig_types[96]
-#define SWIGTYPE_p_FIX__TagNotDefinedForMessage swig_types[97]
-#define SWIGTYPE_p_FIX__TagOutOfOrder swig_types[98]
-#define SWIGTYPE_p_FIX__TargetCompID swig_types[99]
-#define SWIGTYPE_p_FIX__Trailer swig_types[100]
-#define SWIGTYPE_p_FIX__UnsupportedMessageType swig_types[101]
-#define SWIGTYPE_p_FIX__UnsupportedVersion swig_types[102]
-#define SWIGTYPE_p_FIX__UtcDate swig_types[103]
-#define SWIGTYPE_p_FIX__UtcDateField swig_types[104]
-#define SWIGTYPE_p_FIX__UtcTimeOnly swig_types[105]
-#define SWIGTYPE_p_FIX__UtcTimeOnlyField swig_types[106]
-#define SWIGTYPE_p_FIX__UtcTimeStamp swig_types[107]
-#define SWIGTYPE_p_FIX__UtcTimeStampField swig_types[108]
-#define SWIGTYPE_p_Fields swig_types[109]
-#define SWIGTYPE_p_Group swig_types[110]
-#define SWIGTYPE_p_Groups swig_types[111]
-#define SWIGTYPE_p_IntArray swig_types[112]
-#define SWIGTYPE_p_IntField swig_types[113]
-#define SWIGTYPE_p_Log swig_types[114]
-#define SWIGTYPE_p_LogFactory swig_types[115]
-#define SWIGTYPE_p_MYSQL swig_types[116]
-#define SWIGTYPE_p_MessageStore swig_types[117]
-#define SWIGTYPE_p_MessageStoreFactory swig_types[118]
-#define SWIGTYPE_p_MsgType swig_types[119]
-#define SWIGTYPE_p_Mutex swig_types[120]
-#define SWIGTYPE_p_PGconn swig_types[121]
-#define SWIGTYPE_p_RSA swig_types[122]
-#define SWIGTYPE_p_Responder swig_types[123]
-#define SWIGTYPE_p_SessionID swig_types[124]
-#define SWIGTYPE_p_SessionToPort swig_types[125]
-#define SWIGTYPE_p_StringField swig_types[126]
-#define SWIGTYPE_p_TimeRange swig_types[127]
-#define SWIGTYPE_p_UtcDateField swig_types[128]
-#define SWIGTYPE_p_X509 swig_types[129]
-#define SWIGTYPE_p_allocator_type swig_types[130]
-#define SWIGTYPE_p_bool swig_types[131]
-#define SWIGTYPE_p_char swig_types[132]
-#define SWIGTYPE_p_const_iterator swig_types[133]
-#define SWIGTYPE_p_difference_type swig_types[134]
-#define SWIGTYPE_p_double swig_types[135]
-#define SWIGTYPE_p_g_const_iterator swig_types[136]
-#define SWIGTYPE_p_g_iterator swig_types[137]
-#define SWIGTYPE_p_g_value_type swig_types[138]
-#define SWIGTYPE_p_int swig_types[139]
-#define SWIGTYPE_p_int64_t swig_types[140]
-#define SWIGTYPE_p_iterator swig_types[141]
-#define SWIGTYPE_p_key_type swig_types[142]
-#define SWIGTYPE_p_message_order swig_types[143]
-#define SWIGTYPE_p_p_FIX__DataDictionary swig_types[144]
-#define SWIGTYPE_p_size_type swig_types[145]
-#define SWIGTYPE_p_ssize_t swig_types[146]
-#define SWIGTYPE_p_std__functionT_FIX__UtcTimeStamp_fF_t swig_types[147]
-#define SWIGTYPE_p_std__istream swig_types[148]
-#define SWIGTYPE_p_std__lessT_FIX__SessionID_t swig_types[149]
-#define SWIGTYPE_p_std__logic_error swig_types[150]
-#define SWIGTYPE_p_std__mapT_FIX__SessionID_uint16_t_t swig_types[151]
-#define SWIGTYPE_p_std__mapT_int_std__vectorT_FIX__FieldMap_p_t_std__lessT_int_t_ALLOCATORT_std__pairT_int_const_std__vectorT_FIX__FieldMap_p_t_t_t_t swig_types[152]
-#define SWIGTYPE_p_std__mapT_int_std__vectorT_FIX__FieldMap_p_t_std__lessT_int_t_ALLOCATORT_std__pairT_int_const_std__vectorT_FIX__FieldMap_p_t_t_t_t__const_iterator swig_types[153]
-#define SWIGTYPE_p_std__mapT_int_std__vectorT_FIX__FieldMap_p_t_std__lessT_int_t_ALLOCATORT_std__pairT_int_const_std__vectorT_FIX__FieldMap_p_t_t_t_t__iterator swig_types[154]
-#define SWIGTYPE_p_std__mapT_std__string_std__string_t__const_iterator swig_types[155]
-#define SWIGTYPE_p_std__ostream swig_types[156]
-#define SWIGTYPE_p_std__setT_FIX__SessionID_std__lessT_FIX__SessionID_t_std__allocatorT_FIX__SessionID_t_t swig_types[157]
-#define SWIGTYPE_p_std__string swig_types[158]
-#define SWIGTYPE_p_std__string__size_type swig_types[159]
-#define SWIGTYPE_p_std__unique_ptrT_FIX__DatabaseConnectionPoolT_FIX__MySQLConnection_t_t swig_types[160]
-#define SWIGTYPE_p_std__unique_ptrT_FIX__DatabaseConnectionPoolT_FIX__PostgreSQLConnection_t_t swig_types[161]
-#define SWIGTYPE_p_std__vectorT_FIX__FieldBase_ALLOCATORT_FIX__FieldBase_t_t__const_iterator swig_types[162]
-#define SWIGTYPE_p_std__vectorT_FIX__FieldBase_ALLOCATORT_FIX__FieldBase_t_t__iterator swig_types[163]
-#define SWIGTYPE_p_std__vectorT_std__string_t swig_types[164]
-#define SWIGTYPE_p_swig__ConstIterator swig_types[165]
-#define SWIGTYPE_p_swig__GC_VALUE swig_types[166]
-#define SWIGTYPE_p_swig__Iterator swig_types[167]
-#define SWIGTYPE_p_tm swig_types[168]
-#define SWIGTYPE_p_value_type swig_types[169]
-#define SWIGTYPE_p_void swig_types[170]
-static swig_type_info *swig_types[172];
-static swig_module_info swig_module = {swig_types, 171, 0, 0, 0, 0};
+#define SWIGTYPE_p_FIX__Int64Field swig_types[42]
+#define SWIGTYPE_p_FIX__IntField swig_types[43]
+#define SWIGTYPE_p_FIX__InvalidMessage swig_types[44]
+#define SWIGTYPE_p_FIX__InvalidMessageType swig_types[45]
+#define SWIGTYPE_p_FIX__InvalidTagNumber swig_types[46]
+#define SWIGTYPE_p_FIX__LocalDate swig_types[47]
+#define SWIGTYPE_p_FIX__LocalTimeOnly swig_types[48]
+#define SWIGTYPE_p_FIX__LocalTimeStamp swig_types[49]
+#define SWIGTYPE_p_FIX__Log swig_types[50]
+#define SWIGTYPE_p_FIX__LogFactory swig_types[51]
+#define SWIGTYPE_p_FIX__MemoryStore swig_types[52]
+#define SWIGTYPE_p_FIX__MemoryStoreFactory swig_types[53]
+#define SWIGTYPE_p_FIX__Message swig_types[54]
+#define SWIGTYPE_p_FIX__MessageParseError swig_types[55]
+#define SWIGTYPE_p_FIX__MessageStore swig_types[56]
+#define SWIGTYPE_p_FIX__MessageStoreExceptionWrapper swig_types[57]
+#define SWIGTYPE_p_FIX__MessageStoreFactory swig_types[58]
+#define SWIGTYPE_p_FIX__MessageStoreFactoryExceptionWrapper swig_types[59]
+#define SWIGTYPE_p_FIX__MySQLConnection swig_types[60]
+#define SWIGTYPE_p_FIX__MySQLLog swig_types[61]
+#define SWIGTYPE_p_FIX__MySQLLogFactory swig_types[62]
+#define SWIGTYPE_p_FIX__MySQLQuery swig_types[63]
+#define SWIGTYPE_p_FIX__MySQLStore swig_types[64]
+#define SWIGTYPE_p_FIX__MySQLStoreFactory swig_types[65]
+#define SWIGTYPE_p_FIX__NoTagValue swig_types[66]
+#define SWIGTYPE_p_FIX__NullApplication swig_types[67]
+#define SWIGTYPE_p_FIX__NullLog swig_types[68]
+#define SWIGTYPE_p_FIX__PostgreSQLConnection swig_types[69]
+#define SWIGTYPE_p_FIX__PostgreSQLLog swig_types[70]
+#define SWIGTYPE_p_FIX__PostgreSQLLogFactory swig_types[71]
+#define SWIGTYPE_p_FIX__PostgreSQLQuery swig_types[72]
+#define SWIGTYPE_p_FIX__PostgreSQLStore swig_types[73]
+#define SWIGTYPE_p_FIX__PostgreSQLStoreFactory swig_types[74]
+#define SWIGTYPE_p_FIX__RejectLogon swig_types[75]
+#define SWIGTYPE_p_FIX__RepeatedTag swig_types[76]
+#define SWIGTYPE_p_FIX__RepeatingGroupCountMismatch swig_types[77]
+#define SWIGTYPE_p_FIX__RequiredTagMissing swig_types[78]
+#define SWIGTYPE_p_FIX__RuntimeError swig_types[79]
+#define SWIGTYPE_p_FIX__SSLSocketAcceptor swig_types[80]
+#define SWIGTYPE_p_FIX__SSLSocketInitiator swig_types[81]
+#define SWIGTYPE_p_FIX__ScreenLog swig_types[82]
+#define SWIGTYPE_p_FIX__ScreenLogFactory swig_types[83]
+#define SWIGTYPE_p_FIX__SenderCompID swig_types[84]
+#define SWIGTYPE_p_FIX__Session swig_types[85]
+#define SWIGTYPE_p_FIX__SessionID swig_types[86]
+#define SWIGTYPE_p_FIX__SessionNotFound swig_types[87]
+#define SWIGTYPE_p_FIX__SessionSettings swig_types[88]
+#define SWIGTYPE_p_FIX__SocketAcceptor swig_types[89]
+#define SWIGTYPE_p_FIX__SocketCloseFailed swig_types[90]
+#define SWIGTYPE_p_FIX__SocketException swig_types[91]
+#define SWIGTYPE_p_FIX__SocketInitiator swig_types[92]
+#define SWIGTYPE_p_FIX__SocketRecvFailed swig_types[93]
+#define SWIGTYPE_p_FIX__SocketSendFailed swig_types[94]
+#define SWIGTYPE_p_FIX__StringField swig_types[95]
+#define SWIGTYPE_p_FIX__SynchronizedApplication swig_types[96]
+#define SWIGTYPE_p_FIX__TYPE__Type swig_types[97]
+#define SWIGTYPE_p_FIX__TagNotDefinedForMessage swig_types[98]
+#define SWIGTYPE_p_FIX__TagOutOfOrder swig_types[99]
+#define SWIGTYPE_p_FIX__TargetCompID swig_types[100]
+#define SWIGTYPE_p_FIX__Trailer swig_types[101]
+#define SWIGTYPE_p_FIX__UnsupportedMessageType swig_types[102]
+#define SWIGTYPE_p_FIX__UnsupportedVersion swig_types[103]
+#define SWIGTYPE_p_FIX__UtcDate swig_types[104]
+#define SWIGTYPE_p_FIX__UtcDateField swig_types[105]
+#define SWIGTYPE_p_FIX__UtcTimeOnly swig_types[106]
+#define SWIGTYPE_p_FIX__UtcTimeOnlyField swig_types[107]
+#define SWIGTYPE_p_FIX__UtcTimeStamp swig_types[108]
+#define SWIGTYPE_p_FIX__UtcTimeStampField swig_types[109]
+#define SWIGTYPE_p_Fields swig_types[110]
+#define SWIGTYPE_p_Group swig_types[111]
+#define SWIGTYPE_p_Groups swig_types[112]
+#define SWIGTYPE_p_IntArray swig_types[113]
+#define SWIGTYPE_p_IntField swig_types[114]
+#define SWIGTYPE_p_Log swig_types[115]
+#define SWIGTYPE_p_LogFactory swig_types[116]
+#define SWIGTYPE_p_MYSQL swig_types[117]
+#define SWIGTYPE_p_MessageStore swig_types[118]
+#define SWIGTYPE_p_MessageStoreFactory swig_types[119]
+#define SWIGTYPE_p_MsgType swig_types[120]
+#define SWIGTYPE_p_Mutex swig_types[121]
+#define SWIGTYPE_p_PGconn swig_types[122]
+#define SWIGTYPE_p_RSA swig_types[123]
+#define SWIGTYPE_p_Responder swig_types[124]
+#define SWIGTYPE_p_SessionID swig_types[125]
+#define SWIGTYPE_p_SessionToPort swig_types[126]
+#define SWIGTYPE_p_StringField swig_types[127]
+#define SWIGTYPE_p_TimeRange swig_types[128]
+#define SWIGTYPE_p_UtcDateField swig_types[129]
+#define SWIGTYPE_p_X509 swig_types[130]
+#define SWIGTYPE_p_allocator_type swig_types[131]
+#define SWIGTYPE_p_bool swig_types[132]
+#define SWIGTYPE_p_char swig_types[133]
+#define SWIGTYPE_p_const_iterator swig_types[134]
+#define SWIGTYPE_p_difference_type swig_types[135]
+#define SWIGTYPE_p_double swig_types[136]
+#define SWIGTYPE_p_g_const_iterator swig_types[137]
+#define SWIGTYPE_p_g_iterator swig_types[138]
+#define SWIGTYPE_p_g_value_type swig_types[139]
+#define SWIGTYPE_p_int swig_types[140]
+#define SWIGTYPE_p_int64_t swig_types[141]
+#define SWIGTYPE_p_iterator swig_types[142]
+#define SWIGTYPE_p_key_type swig_types[143]
+#define SWIGTYPE_p_message_order swig_types[144]
+#define SWIGTYPE_p_p_FIX__DataDictionary swig_types[145]
+#define SWIGTYPE_p_size_type swig_types[146]
+#define SWIGTYPE_p_ssize_t swig_types[147]
+#define SWIGTYPE_p_std__functionT_FIX__UtcTimeStamp_fF_t swig_types[148]
+#define SWIGTYPE_p_std__istream swig_types[149]
+#define SWIGTYPE_p_std__lessT_FIX__SessionID_t swig_types[150]
+#define SWIGTYPE_p_std__logic_error swig_types[151]
+#define SWIGTYPE_p_std__mapT_FIX__SessionID_uint16_t_t swig_types[152]
+#define SWIGTYPE_p_std__mapT_int_std__vectorT_FIX__FieldMap_p_t_std__lessT_int_t_ALLOCATORT_std__pairT_int_const_std__vectorT_FIX__FieldMap_p_t_t_t_t swig_types[153]
+#define SWIGTYPE_p_std__mapT_int_std__vectorT_FIX__FieldMap_p_t_std__lessT_int_t_ALLOCATORT_std__pairT_int_const_std__vectorT_FIX__FieldMap_p_t_t_t_t__const_iterator swig_types[154]
+#define SWIGTYPE_p_std__mapT_int_std__vectorT_FIX__FieldMap_p_t_std__lessT_int_t_ALLOCATORT_std__pairT_int_const_std__vectorT_FIX__FieldMap_p_t_t_t_t__iterator swig_types[155]
+#define SWIGTYPE_p_std__mapT_std__string_std__string_t__const_iterator swig_types[156]
+#define SWIGTYPE_p_std__ostream swig_types[157]
+#define SWIGTYPE_p_std__setT_FIX__SessionID_std__lessT_FIX__SessionID_t_std__allocatorT_FIX__SessionID_t_t swig_types[158]
+#define SWIGTYPE_p_std__string swig_types[159]
+#define SWIGTYPE_p_std__string__size_type swig_types[160]
+#define SWIGTYPE_p_std__unique_ptrT_FIX__DatabaseConnectionPoolT_FIX__MySQLConnection_t_t swig_types[161]
+#define SWIGTYPE_p_std__unique_ptrT_FIX__DatabaseConnectionPoolT_FIX__PostgreSQLConnection_t_t swig_types[162]
+#define SWIGTYPE_p_std__vectorT_FIX__FieldBase_ALLOCATORT_FIX__FieldBase_t_t__const_iterator swig_types[163]
+#define SWIGTYPE_p_std__vectorT_FIX__FieldBase_ALLOCATORT_FIX__FieldBase_t_t__iterator swig_types[164]
+#define SWIGTYPE_p_std__vectorT_std__string_t swig_types[165]
+#define SWIGTYPE_p_swig__ConstIterator swig_types[166]
+#define SWIGTYPE_p_swig__GC_VALUE swig_types[167]
+#define SWIGTYPE_p_swig__Iterator swig_types[168]
+#define SWIGTYPE_p_tm swig_types[169]
+#define SWIGTYPE_p_value_type swig_types[170]
+#define SWIGTYPE_p_void swig_types[171]
+static swig_type_info *swig_types[173];
+static swig_module_info swig_module = {swig_types, 172, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -25841,6 +25842,239 @@ fail:
 SWIGINTERN void
 free_FIX_IntField(void *self) {
     FIX::IntField *arg1 = (FIX::IntField *)self;
+    delete arg1;
+}
+
+static swig_class SwigClassInt64Field;
+
+SWIGINTERN VALUE
+_wrap_new_Int64Field__SWIG_0(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int64_t arg2 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  const char *classname SWIGUNUSED = "Quickfix::Int64Field";
+  FIX::Int64Field *result = 0 ;
+  
+  if ((argc < 2) || (argc > 2)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 2)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","Int64Field", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  {
+    res2 = SWIG_ConvertPtr(argv[1], &argp2, SWIGTYPE_p_int64_t,  0 );
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "int64_t","Int64Field", 2, argv[1] )); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "int64_t","Int64Field", 2, argv[1]));
+    } else {
+      arg2 = *(reinterpret_cast< int64_t * >(argp2));
+    }
+  }
+  {
+    if(tryRubyException([&]() mutable 
+        {
+      result = (FIX::Int64Field *)new FIX::Int64Field(arg1,arg2);
+          DATA_PTR(self) = result;
+          return self;
+        fail:
+          return Qnil;
+        }) == Qnil) 
+    {
+      SWIG_fail;
+    }
+  }
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+#ifdef HAVE_RB_DEFINE_ALLOC_FUNC
+_wrap_Int64Field_allocate(VALUE self)
+#else
+_wrap_Int64Field_allocate(int argc, VALUE *argv, VALUE self)
+#endif
+{
+  VALUE vresult = SWIG_NewClassInstance(self, SWIGTYPE_p_FIX__Int64Field);
+#ifndef HAVE_RB_DEFINE_ALLOC_FUNC
+  rb_obj_call_init(vresult, argc, argv);
+#endif
+  return vresult;
+}
+
+
+SWIGINTERN VALUE
+_wrap_new_Int64Field__SWIG_1(int argc, VALUE *argv, VALUE self) {
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  const char *classname SWIGUNUSED = "Quickfix::Int64Field";
+  FIX::Int64Field *result = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  ecode1 = SWIG_AsVal_int(argv[0], &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), Ruby_Format_TypeError( "", "int","Int64Field", 1, argv[0] ));
+  } 
+  arg1 = static_cast< int >(val1);
+  {
+    if(tryRubyException([&]() mutable 
+        {
+      result = (FIX::Int64Field *)new FIX::Int64Field(arg1);
+          DATA_PTR(self) = result;
+          return self;
+        fail:
+          return Qnil;
+        }) == Qnil) 
+    {
+      SWIG_fail;
+    }
+  }
+  return self;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE _wrap_new_Int64Field(int nargs, VALUE *args, VALUE self) {
+  int argc;
+  VALUE argv[2];
+  int ii;
+  
+  argc = nargs;
+  if (argc > 2) SWIG_fail;
+  for (ii = 0; (ii < argc); ++ii) {
+    argv[ii] = args[ii];
+  }
+  if (argc == 1) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Int64Field__SWIG_1(nargs, args, self);
+    }
+  }
+  if (argc == 2) {
+    int _v = 0;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      void *vptr = 0;
+      int res = SWIG_ConvertPtr(argv[1], &vptr, SWIGTYPE_p_int64_t, SWIG_POINTER_NO_NULL);
+      _v = SWIG_CheckState(res);
+      if (_v) {
+        return _wrap_new_Int64Field__SWIG_0(nargs, args, self);
+      }
+    }
+  }
+  
+fail:
+  Ruby_Format_OverloadedError( argc, 2, "Int64Field.new", 
+    "    Int64Field.new(int field, int64_t data)\n"
+    "    Int64Field.new(int field)\n");
+  
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Int64Field_setValue(int argc, VALUE *argv, VALUE self) {
+  FIX::Int64Field *arg1 = (FIX::Int64Field *) 0 ;
+  int64_t arg2 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  void *argp2 ;
+  int res2 = 0 ;
+  
+  if ((argc < 1) || (argc > 1)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 1)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_FIX__Int64Field, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "FIX::Int64Field *","setValue", 1, self )); 
+  }
+  arg1 = reinterpret_cast< FIX::Int64Field * >(argp1);
+  {
+    res2 = SWIG_ConvertPtr(argv[0], &argp2, SWIGTYPE_p_int64_t,  0 );
+    if (!SWIG_IsOK(res2)) {
+      SWIG_exception_fail(SWIG_ArgError(res2), Ruby_Format_TypeError( "", "int64_t","setValue", 2, argv[0] )); 
+    }  
+    if (!argp2) {
+      SWIG_exception_fail(SWIG_ValueError, Ruby_Format_TypeError("invalid null reference ", "int64_t","setValue", 2, argv[0]));
+    } else {
+      arg2 = *(reinterpret_cast< int64_t * >(argp2));
+    }
+  }
+  {
+    if(tryRubyException([&]() mutable 
+        {
+      (arg1)->setValue(arg2);
+          return self;
+        fail:
+          return Qnil;
+        }) == Qnil) 
+    {
+      SWIG_fail;
+    }
+  }
+  return Qnil;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN VALUE
+_wrap_Int64Field_getValue(int argc, VALUE *argv, VALUE self) {
+  FIX::Int64Field *arg1 = (FIX::Int64Field *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  int64_t result;
+  VALUE vresult = Qnil;
+  
+  if ((argc < 0) || (argc > 0)) {
+    rb_raise(rb_eArgError, "wrong # of arguments(%d for 0)",argc); SWIG_fail;
+  }
+  res1 = SWIG_ConvertPtr(self, &argp1,SWIGTYPE_p_FIX__Int64Field, 0 |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), Ruby_Format_TypeError( "", "FIX::Int64Field const *","getValue", 1, self )); 
+  }
+  arg1 = reinterpret_cast< FIX::Int64Field * >(argp1);
+  {
+    if(tryRubyException([&]() mutable 
+        {
+      result = ((FIX::Int64Field const *)arg1)->getValue();
+          return self;
+        fail:
+          return Qnil;
+        }) == Qnil) 
+    {
+      SWIG_fail;
+    }
+  }
+  vresult = SWIG_NewPointerObj((new int64_t(result)), SWIGTYPE_p_int64_t, SWIG_POINTER_OWN |  0 );
+  return vresult;
+fail:
+  return Qnil;
+}
+
+
+SWIGINTERN void
+free_FIX_Int64Field(void *self) {
+    FIX::Int64Field *arg1 = (FIX::Int64Field *)self;
     delete arg1;
 }
 
@@ -117654,6 +117888,9 @@ static void *_p_FIX__CheckSumFieldTo_p_FIX__FieldBase(void *x, int *SWIGUNUSEDPA
 static void *_p_FIX__DoubleFieldTo_p_FIX__FieldBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((FIX::FieldBase *)  ((FIX::DoubleField *) x));
 }
+static void *_p_FIX__Int64FieldTo_p_FIX__FieldBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
+    return (void *)((FIX::FieldBase *)  ((FIX::Int64Field *) x));
+}
 static void *_p_FIX__IntFieldTo_p_FIX__FieldBase(void *x, int *SWIGUNUSEDPARM(newmemory)) {
     return (void *)((FIX::FieldBase *)  ((FIX::IntField *) x));
 }
@@ -117897,6 +118134,7 @@ static swig_type_info _swigt__p_FIX__IncorrectDataFormat = {"_p_FIX__IncorrectDa
 static swig_type_info _swigt__p_FIX__IncorrectMessageStructure = {"_p_FIX__IncorrectMessageStructure", "FIX::IncorrectMessageStructure *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FIX__IncorrectTagValue = {"_p_FIX__IncorrectTagValue", "FIX::IncorrectTagValue *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FIX__Initiator = {"_p_FIX__Initiator", "FIX::Initiator *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_FIX__Int64Field = {"_p_FIX__Int64Field", "FIX::Int64Field *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FIX__IntField = {"_p_FIX__IntField", "FIX::LengthField *|FIX::NumInGroupField *|FIX::SeqNumField *|FIX::TagNumField *|FIX::IntField *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FIX__InvalidMessage = {"_p_FIX__InvalidMessage", "FIX::InvalidMessage *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_FIX__InvalidMessageType = {"_p_FIX__InvalidMessageType", "FIX::InvalidMessageType *", 0, 0, (void*)0, 0};
@@ -117995,7 +118233,7 @@ static swig_type_info _swigt__p_g_const_iterator = {"_p_g_const_iterator", "g_co
 static swig_type_info _swigt__p_g_iterator = {"_p_g_iterator", "g_iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_g_value_type = {"_p_g_value_type", "g_value_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_int = {"_p_int", "FIX::INT *|FIX::LENGTH *|FIX::NUMINGROUP *|FIX::SEQNUM *|FIX::TAGNUM *|int *", 0, 0, (void*)0, 0};
-static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "int64_t *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_int64_t = {"_p_int64_t", "FIX::INT64 *|int64_t *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_iterator = {"_p_iterator", "iterator *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_key_type = {"_p_key_type", "key_type *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_message_order = {"_p_message_order", "message_order *", 0, 0, (void*)0, 0};
@@ -118070,6 +118308,7 @@ static swig_type_info *swig_type_initial[] = {
   &_swigt__p_FIX__IncorrectMessageStructure,
   &_swigt__p_FIX__IncorrectTagValue,
   &_swigt__p_FIX__Initiator,
+  &_swigt__p_FIX__Int64Field,
   &_swigt__p_FIX__IntField,
   &_swigt__p_FIX__InvalidMessage,
   &_swigt__p_FIX__InvalidMessageType,
@@ -118228,7 +118467,7 @@ static swig_cast_info _swigc__p_FIX__DoNotSend[] = {  {&_swigt__p_FIX__DoNotSend
 static swig_cast_info _swigc__p_FIX__DoubleField[] = {  {&_swigt__p_FIX__DoubleField, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__DuplicateFieldNumber[] = {  {&_swigt__p_FIX__DuplicateFieldNumber, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__Exception[] = {  {&_swigt__p_FIX__Exception, 0, 0, 0},  {&_swigt__p_FIX__ConfigError, _p_FIX__ConfigErrorTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__DataDictionaryNotFound, _p_FIX__DataDictionaryNotFoundTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__DoNotSend, _p_FIX__DoNotSendTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__DuplicateFieldNumber, _p_FIX__DuplicateFieldNumberTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__FieldConvertError, _p_FIX__FieldConvertErrorTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__FieldNotFound, _p_FIX__FieldNotFoundTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__IOException, _p_FIX__IOExceptionTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__IncorrectDataFormat, _p_FIX__IncorrectDataFormatTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__IncorrectMessageStructure, _p_FIX__IncorrectMessageStructureTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__IncorrectTagValue, _p_FIX__IncorrectTagValueTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__InvalidMessage, _p_FIX__InvalidMessageTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__InvalidMessageType, _p_FIX__InvalidMessageTypeTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__InvalidTagNumber, _p_FIX__InvalidTagNumberTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__MessageParseError, _p_FIX__MessageParseErrorTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__NoTagValue, _p_FIX__NoTagValueTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__RejectLogon, _p_FIX__RejectLogonTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__RepeatedTag, _p_FIX__RepeatedTagTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__RepeatingGroupCountMismatch, _p_FIX__RepeatingGroupCountMismatchTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__RequiredTagMissing, _p_FIX__RequiredTagMissingTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__RuntimeError, _p_FIX__RuntimeErrorTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__SessionNotFound, _p_FIX__SessionNotFoundTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__SocketCloseFailed, _p_FIX__SocketCloseFailedTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__SocketException, _p_FIX__SocketExceptionTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__SocketRecvFailed, _p_FIX__SocketRecvFailedTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__SocketSendFailed, _p_FIX__SocketSendFailedTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__TagNotDefinedForMessage, _p_FIX__TagNotDefinedForMessageTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__TagOutOfOrder, _p_FIX__TagOutOfOrderTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__UnsupportedMessageType, _p_FIX__UnsupportedMessageTypeTo_p_FIX__Exception, 0, 0},  {&_swigt__p_FIX__UnsupportedVersion, _p_FIX__UnsupportedVersionTo_p_FIX__Exception, 0, 0},{0, 0, 0, 0}};
-static swig_cast_info _swigc__p_FIX__FieldBase[] = {  {&_swigt__p_FIX__FieldBase, 0, 0, 0},  {&_swigt__p_FIX__BeginString, _p_FIX__BeginStringTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__BoolField, _p_FIX__BoolFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__CharField, _p_FIX__CharFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__CheckSumField, _p_FIX__CheckSumFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__DoubleField, _p_FIX__DoubleFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__IntField, _p_FIX__IntFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__SenderCompID, _p_FIX__SenderCompIDTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__StringField, _p_FIX__StringFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__TargetCompID, _p_FIX__TargetCompIDTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__UtcDateField, _p_FIX__UtcDateFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__UtcTimeOnlyField, _p_FIX__UtcTimeOnlyFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__UtcTimeStampField, _p_FIX__UtcTimeStampFieldTo_p_FIX__FieldBase, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_FIX__FieldBase[] = {  {&_swigt__p_FIX__FieldBase, 0, 0, 0},  {&_swigt__p_FIX__BeginString, _p_FIX__BeginStringTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__BoolField, _p_FIX__BoolFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__CharField, _p_FIX__CharFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__CheckSumField, _p_FIX__CheckSumFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__DoubleField, _p_FIX__DoubleFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__Int64Field, _p_FIX__Int64FieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__IntField, _p_FIX__IntFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__SenderCompID, _p_FIX__SenderCompIDTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__StringField, _p_FIX__StringFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__TargetCompID, _p_FIX__TargetCompIDTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__UtcDateField, _p_FIX__UtcDateFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__UtcTimeOnlyField, _p_FIX__UtcTimeOnlyFieldTo_p_FIX__FieldBase, 0, 0},  {&_swigt__p_FIX__UtcTimeStampField, _p_FIX__UtcTimeStampFieldTo_p_FIX__FieldBase, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__FieldConvertError[] = {  {&_swigt__p_FIX__FieldConvertError, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__FieldMap[] = {  {&_swigt__p_FIX__FieldMap, 0, 0, 0},  {&_swigt__p_FIX__Group, _p_FIX__GroupTo_p_FIX__FieldMap, 0, 0},  {&_swigt__p_FIX__Header, _p_FIX__HeaderTo_p_FIX__FieldMap, 0, 0},  {&_swigt__p_FIX__Message, _p_FIX__MessageTo_p_FIX__FieldMap, 0, 0},  {&_swigt__p_FIX__Trailer, _p_FIX__TrailerTo_p_FIX__FieldMap, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__FieldNotFound[] = {  {&_swigt__p_FIX__FieldNotFound, 0, 0, 0},{0, 0, 0, 0}};
@@ -118243,6 +118482,7 @@ static swig_cast_info _swigc__p_FIX__IncorrectDataFormat[] = {  {&_swigt__p_FIX_
 static swig_cast_info _swigc__p_FIX__IncorrectMessageStructure[] = {  {&_swigt__p_FIX__IncorrectMessageStructure, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__IncorrectTagValue[] = {  {&_swigt__p_FIX__IncorrectTagValue, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__Initiator[] = {  {&_swigt__p_FIX__Initiator, 0, 0, 0},  {&_swigt__p_FIX__SSLSocketInitiator, _p_FIX__SSLSocketInitiatorTo_p_FIX__Initiator, 0, 0},  {&_swigt__p_FIX__SocketInitiator, _p_FIX__SocketInitiatorTo_p_FIX__Initiator, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_FIX__Int64Field[] = {  {&_swigt__p_FIX__Int64Field, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__IntField[] = {  {&_swigt__p_FIX__IntField, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__InvalidMessage[] = {  {&_swigt__p_FIX__InvalidMessage, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_FIX__InvalidMessageType[] = {  {&_swigt__p_FIX__InvalidMessageType, 0, 0, 0},{0, 0, 0, 0}};
@@ -118416,6 +118656,7 @@ static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_FIX__IncorrectMessageStructure,
   _swigc__p_FIX__IncorrectTagValue,
   _swigc__p_FIX__Initiator,
+  _swigc__p_FIX__Int64Field,
   _swigc__p_FIX__IntField,
   _swigc__p_FIX__InvalidMessage,
   _swigc__p_FIX__InvalidMessageType,
@@ -119378,6 +119619,16 @@ SWIGEXPORT void Init_quickfix(void) {
   SwigClassIntField.mark = 0;
   SwigClassIntField.destroy = (void (*)(void *)) free_FIX_IntField;
   SwigClassIntField.trackObjects = 0;
+  
+  SwigClassInt64Field.klass = rb_define_class_under(mQuickfix, "Int64Field", ((swig_class *) SWIGTYPE_p_FIX__FieldBase->clientdata)->klass);
+  SWIG_TypeClientData(SWIGTYPE_p_FIX__Int64Field, (void *) &SwigClassInt64Field);
+  rb_define_alloc_func(SwigClassInt64Field.klass, _wrap_Int64Field_allocate);
+  rb_define_method(SwigClassInt64Field.klass, "initialize", VALUEFUNC(_wrap_new_Int64Field), -1);
+  rb_define_method(SwigClassInt64Field.klass, "setValue", VALUEFUNC(_wrap_Int64Field_setValue), -1);
+  rb_define_method(SwigClassInt64Field.klass, "getValue", VALUEFUNC(_wrap_Int64Field_getValue), -1);
+  SwigClassInt64Field.mark = 0;
+  SwigClassInt64Field.destroy = (void (*)(void *)) free_FIX_Int64Field;
+  SwigClassInt64Field.trackObjects = 0;
   
   SwigClassBoolField.klass = rb_define_class_under(mQuickfix, "BoolField", ((swig_class *) SWIGTYPE_p_FIX__FieldBase->clientdata)->klass);
   SWIG_TypeClientData(SWIGTYPE_p_FIX__BoolField, (void *) &SwigClassBoolField);


### PR DESCRIPTION
Adding a distinct Int64Field to ensure proper transfer of large integers whatever the platform is. Integer conversions has been implemented (src/C++/FieldConvertors.h) as a template to support multiple precisions (tests have been added for each potential case). For Windows, scope of pragma(warning(disable:4146)) has been reduced to the absolutely necessary minimum to avoid accidental masking of other potential issues to fix.