### PR TITLE
A session level configuration item 'AllowedRemoteAddresses' for acceptor

### DIFF
--- a/bin/cfg/executor.cfg
+++ b/bin/cfg/executor.cfg
@@ -45,6 +45,7 @@ SenderCompID=EXECUTOR
 TargetCompID=CLIENT1
 FileStorePath=store
 DataDictionary=../spec/FIX42.xml
+AllowedRemoteAddresses=127.0.0.1,127.0.0.2,127.0.0.3
 
 [SESSION]
 BeginString=FIX.4.2

--- a/src/C++/CMakeLists.txt
+++ b/src/C++/CMakeLists.txt
@@ -67,6 +67,7 @@ if (HAVE_SSL)
     ThreadedSSLSocketConnection.cpp
     ThreadedSSLSocketInitiator.cpp
     UtilitySSL.cpp)
+    add_definitions(-DHAVE_SSL=1)
 endif()
 
 if (WIN32)

--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -225,6 +225,13 @@ public:
   void setValidateLengthAndChecksum ( bool value )
     { m_validateLengthAndChecksum = value; }
 
+  const std::set<std::string>& getAllowedRemoteAddresses()
+    { return m_allowedRemoteAddresses; }
+  void setAllowedRemoteAddresses ( const std::set<std::string> &value )
+    { m_allowedRemoteAddresses = value; }
+  bool inAllowedRemoteAddresses ( const std::string &value )
+    { return ( m_allowedRemoteAddresses.cend() != m_allowedRemoteAddresses.find( value ) ); }
+
   void setResponder( Responder* pR )
   {
     if( !checkSessionTime(m_timestamper()) )
@@ -344,6 +351,7 @@ private:
   int m_timestampPrecision;
   bool m_persistMessages;
   bool m_validateLengthAndChecksum;
+  std::set<std::string> m_allowedRemoteAddresses;
 
   SessionState m_state;
   DataDictionaryProvider m_dataDictionaryProvider;

--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -198,6 +198,8 @@ Session* SessionFactory::create( const SessionID& sessionID,
     pSession->setPersistMessages( settings.getBool( PERSIST_MESSAGES ) );
   if ( settings.has( VALIDATE_LENGTH_AND_CHECKSUM ) )
     pSession->setValidateLengthAndChecksum( settings.getBool( VALIDATE_LENGTH_AND_CHECKSUM ) );
+  if ( settings.has( ALLOWED_REMOTE_ADDRESSES ) )
+    pSession->setAllowedRemoteAddresses( string_split( settings.getString( ALLOWED_REMOTE_ADDRESSES ), ',' ) );
    
   return pSession.release();
 }

--- a/src/C++/SessionSettings.h
+++ b/src/C++/SessionSettings.h
@@ -139,6 +139,7 @@ const char CERTIFICATE_AUTHORITIES_DIRECTORY[] = "CertificationAuthoritiesDirect
 const char CERTIFICATE_REVOCATION_LIST_FILE[] = "CertificateRevocationListFile";
 const char CERTIFICATE_REVOCATION_LIST_DIRECTORY[] = "CertificateRevocationListDirectory";
 const char CERTIFICATE_VERIFY_LEVEL[] = "CertificateVerifyLevel";
+const char ALLOWED_REMOTE_ADDRESSES[] = "AllowedRemoteAddresses";
 /*
 # This directive can be used to control the SSL protocol flavors the application
 # should use when establishing its environment.

--- a/src/C++/SocketConnection.cpp
+++ b/src/C++/SocketConnection.cpp
@@ -180,6 +180,15 @@ bool SocketConnection::read( SocketAcceptor& a, SocketServer& s )
         return false;
       }
 
+      std::string remote_address = socket_peername( m_socket );
+      if( !m_pSession->getAllowedRemoteAddresses().empty() &&
+          !m_pSession->inAllowedRemoteAddresses( remote_address ) )
+      {
+        m_pSession->getLog()->onEvent( "Deny connections to the acceptor from " + remote_address );
+        return false;
+      }
+      m_pSession->getLog()->onEvent( "Allows connections to the acceptor from " + remote_address );
+
       Session::registerSession( m_pSession->getSessionID() );
       return true;
     }

--- a/src/C++/ThreadedSocketConnection.cpp
+++ b/src/C++/ThreadedSocketConnection.cpp
@@ -222,6 +222,15 @@ bool ThreadedSocketConnection::setSession( const std::string& msg )
   if ( m_sessions.find(m_pSession->getSessionID()) == m_sessions.end() )
     return false;
 
+  std::string remote_address = socket_peername( m_socket );
+  if( !m_pSession->getAllowedRemoteAddresses().empty() &&
+      !m_pSession->inAllowedRemoteAddresses( remote_address ) )
+  {
+    m_pSession->getLog()->onEvent( "Deny connections to the acceptor from " + remote_address );
+    return false;
+  }
+  m_pSession->getLog()->onEvent( "Allows connections to the acceptor from " + remote_address );
+
   m_pSession->setResponder( this );
   return true;
 }

--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -160,6 +160,23 @@ std::string string_strip( const std::string& value )
   return std::string( value, startPos, endPos - startPos + 1 );
 }
 
+std::set<std::string> string_split( const std::string& value, const char delimiter )
+{
+  std::set<std::string> subStrings;
+  std::size_t start = 0;
+  for(std::size_t pos = 0; pos < value.size(); ++pos ) {
+    if( value[pos] == delimiter ) 
+    {
+      if( pos - start > 1 )
+        subStrings.insert( value.substr( start, pos-start ) );
+      start = pos+1;
+    }
+  }
+  if( start < value.size() )
+      subStrings.insert( value.substr( start, value.size() - start ) );
+  return subStrings;
+}
+
 void socket_init()
 {
 #ifdef _MSC_VER

--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -112,6 +112,7 @@
 
 #include <string>
 #include <cstring>
+#include <set>
 #include <cctype>
 #include <ctime>
 #include <cstdio>
@@ -147,6 +148,7 @@ char* string_concat(const char *a, ...);
 std::string string_toLower(const std::string& value);
 std::string string_toUpper(const std::string& value);
 std::string string_strip(const std::string& value);
+std::set<std::string> string_split(const std::string& value, const char delimiter);
 
 void socket_init();
 void socket_term();

--- a/src/C++/test/StringUtilitiesTestCase.cpp
+++ b/src/C++/test/StringUtilitiesTestCase.cpp
@@ -90,4 +90,19 @@ TEST_CASE("StringUtilitiesTests")
     object = "\t\n\r  strip this  \t\n\r";
     CHECK( "strip this" == string_strip(object) );
   }
+  
+  SECTION("split")
+  {
+    std::set<std::string> object = {};
+    CHECK( object == string_split("", ',') );
+    CHECK( object == string_split(",,,,,,,", ',') );
+    object = {"127.0.0.1"};
+    CHECK( object == string_split("127.0.0.1,", ',') );
+    CHECK( object == string_split("127.0.0.1", ',') );
+    CHECK( object == string_split("127.0.0.1,,,,", ',') );
+    CHECK( object == string_split("127.0.0.1,127.0.0.1,,,,,,127.0.0.1,127.0.0.1,127.0.0.1,", ',') );
+    object = {"127.0.0.1", "127.0.0.2"};
+    CHECK( object == string_split("127.0.0.1,127.0.0.2", ',') );
+    CHECK( object == string_split("127.0.0.1,127.0.0.1,127.0.0.1,127.0.0.1,127.0.0.2,127.0.0.2,127.0.0.2,", ',' ) );
+  }
 }


### PR DESCRIPTION
A new configuration item for Acceptor：

- ID: AllowedRemoteAddresses
- Description: List of remote IP addresses which are allowed to connect to this acceptor.
- Valid Values: comma-separated list of hostnames
- Default: empty, ie all remote addresses are allowed
- Example: AllowedRemoteAddresses=127.0.0.1,192.168.0.1

_Only valid for direct connections, ssl connections do not need to support this configuration._

By the way, update src/C++/CMakeLists.txt to support ssl.