### PR TITLE
Replace deprecated sprintf with snprintf in pugixml.cpp

### DIFF
--- a/src/C++/pugixml.cpp
+++ b/src/C++/pugixml.cpp
@@ -3653,15 +3653,15 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, int value)
 	{
 		char buf[128];
-		sprintf(buf, "%d", value);
-	
-		return set_value_buffer(dest, header, header_mask, buf);
+        snprintf(buf, sizeof(buf), "%d", value);
+
+        return set_value_buffer(dest, header, header_mask, buf);
 	}
 
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, unsigned int value)
 	{
 		char buf[128];
-		sprintf(buf, "%u", value);
+        snprintf(buf, sizeof(buf), "%u", value);
 
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -3669,7 +3669,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, double value)
 	{
 		char buf[128];
-		sprintf(buf, "%g", value);
+        snprintf(buf, sizeof(buf), "%g", value);
 
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -3683,7 +3683,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, long long value)
 	{
 		char buf[128];
-		sprintf(buf, "%lld", value);
+        snprintf(buf, sizeof(buf), "%lld", value);
 	
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -3691,7 +3691,7 @@ PUGI__NS_BEGIN
 	PUGI__FN bool set_value_convert(char_t*& dest, uintptr_t& header, uintptr_t header_mask, unsigned long long value)
 	{
 		char buf[128];
-		sprintf(buf, "%llu", value);
+		snprintf(buf, sizeof(buf), "%llu", value);
 	
 		return set_value_buffer(dest, header, header_mask, buf);
 	}
@@ -6840,7 +6840,7 @@ PUGI__NS_BEGIN
 	PUGI__FN void convert_number_to_mantissa_exponent(double value, char* buffer, size_t buffer_size, char** out_mantissa, int* out_exponent)
 	{
 		// get a scientific notation value with IEEE DBL_DIG decimals
-		sprintf(buffer, "%.*e", DBL_DIG, value);
+		snprintf(buffer, sizeof(buffer), "%.*e", DBL_DIG, value);
 		assert(strlen(buffer) < buffer_size);
 		(void)!buffer_size;
 


### PR DESCRIPTION
- Replaced multiple instances of deprecated 'sprintf' function with the safer 'snprintf' alternative in pugixml.cpp.
- The change eliminates compiler warnings and improves code security by preventing potential buffer overflows.

Warnings Addressed:
- pugixml.cpp:3656
- pugixml.cpp:3664
- pugixml.cpp:3672
- pugixml.cpp:3686
- pugixml.cpp:3694
- pugixml.cpp:6843