### PR TITLE
Fix cmake SQL store never build

### DIFF
--- a/cmake/QuickfixPrebuildSetup.cmake
+++ b/cmake/QuickfixPrebuildSetup.cmake
@@ -109,3 +109,9 @@ COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/src/C++/fixt11 
 COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_SOURCE_DIR}/include/quickfix/wx
 COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/src/C++/fixt11 ${PROJECT_SOURCE_DIR}/include/quickfix/wx/
 )
+
+if (EXISTS ${PROJECT_SOURCE_DIR}/src/C++/Allocator.h)
+add_custom_target(QUICKFIX_ALLOCATOR_HEADERS_COPY ALL
+COMMAND ${CMAKE_COMMAND} -E copy_if_different ${PROJECT_SOURCE_DIR}/src/C++/Allocator.h ${PROJECT_SOURCE_DIR}/include/quickfix/Allocator.h
+)
+endif()

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -3,5 +3,7 @@
 
 #cmakedefine HAVE_CXX17
 #cmakedefine HAVE_STD_SHARED_PTR
+#cmakedefine HAVE_MYSQL
+#cmakedefine HAVE_POSTGRESQL
 
 #endif

--- a/src/C++/MySQLLog.cpp
+++ b/src/C++/MySQLLog.cpp
@@ -229,7 +229,7 @@ void MySQLLog::backup()
 
 void MySQLLog::insert( const std::string& table, const std::string value )
 {
-  UtcTimeStamp time;
+  UtcTimeStamp time = UtcTimeStamp::now();
   int year, month, day, hour, minute, second, millis;
   time.getYMD( year, month, day );
   time.getHMS( hour, minute, second, millis );

--- a/src/C++/PostgreSQLLog.cpp
+++ b/src/C++/PostgreSQLLog.cpp
@@ -230,7 +230,7 @@ void PostgreSQLLog::backup()
 
 void PostgreSQLLog::insert( const std::string& table, const std::string value )
 {
-  UtcTimeStamp time;
+  UtcTimeStamp time = UtcTimeStamp::now();
   int year, month, day, hour, minute, second, millis;
   time.getYMD( year, month, day );
   time.getHMS( hour, minute, second, millis );


### PR DESCRIPTION
Without this change, `HAVE_*SQL` compile definition are never passed to C/C++ code when building with cmake.

You can check it with following command:

```sh
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DHAVE_SSL=ON -DHAVE_MYSQL=ON -DHAVE_POSTGRESQL=ON ..
make -j32

strings src/C++/libquickfix.so | grep MySQLStoreFactory
```

Without the fix:

```
❯ strings src/C++/libquickfix.so | grep MySQLStoreFactory | wc -l                                                                      
0
```

With the fix:

```
❯ strings src/C++/libquickfix.so | grep MySQLStoreFactory | wc -l
47
```

I also fix various deprecation warning / example build error.
