### PR TITLE
Fixing the sorting order of trailer's FIELD::SignatureLength

### DIFF
--- a/src/C++/MessageSorters.h
+++ b/src/C++/MessageSorters.h
@@ -74,9 +74,10 @@ struct trailer_order
   static bool compare( const int x, const int y )
   {
     if ( x == FIELD::CheckSum ) return false;
-    else
-      if ( y == FIELD::CheckSum ) return true;
-      else return x < y;
+    else if ( y == FIELD::CheckSum ) return true;
+    else if ( x == FIELD::SignatureLength ) return true;
+    else if ( y == FIELD::SignatureLength ) return false;
+    else return x < y;
   }
 };
 

--- a/src/C++/MessageSorters.h
+++ b/src/C++/MessageSorters.h
@@ -75,7 +75,7 @@ struct trailer_order
   {
     if ( x == FIELD::CheckSum ) return false;
     else if ( y == FIELD::CheckSum ) return true;
-    else if ( x == FIELD::SignatureLength ) return true;
+    else if ( x == FIELD::SignatureLength ) return y != FIELD::SignatureLength;
     else if ( y == FIELD::SignatureLength ) return false;
     else return x < y;
   }

--- a/src/C++/test/MessageSortersTestCase.cpp
+++ b/src/C++/test/MessageSortersTestCase.cpp
@@ -97,6 +97,16 @@ TEST_CASE("MessageSortersTestCase")
 
     CHECK( !trailer_order::compare(FIELD::Signature, FIELD::SignatureLength) );
     CHECK( trailer_order::compare(FIELD::SignatureLength, FIELD::Signature) );
+    CHECK( trailer_order::compare(FIELD::Signature - 1, FIELD::Signature) );
+    CHECK( trailer_order::compare(FIELD::Signature, FIELD::Signature + 1) );
+    CHECK( !trailer_order::compare(FIELD::Signature + 1, FIELD::Signature) );
+    CHECK( !trailer_order::compare(FIELD::Signature, FIELD::Signature - 1) );
+    CHECK( !trailer_order::compare(FIELD::Signature, FIELD::Signature) );
+    CHECK( !trailer_order::compare(FIELD::SignatureLength - 1, FIELD::SignatureLength) );
+    CHECK( trailer_order::compare(FIELD::SignatureLength, FIELD::SignatureLength + 1) );
+    CHECK( !trailer_order::compare(FIELD::SignatureLength + 1, FIELD::SignatureLength) );
+    CHECK( trailer_order::compare(FIELD::SignatureLength, FIELD::SignatureLength - 1) );
+    CHECK( !trailer_order::compare(FIELD::SignatureLength, FIELD::SignatureLength) );
   }
 
   SECTION("normalOrder")

--- a/src/C++/test/MessageSortersTestCase.cpp
+++ b/src/C++/test/MessageSortersTestCase.cpp
@@ -86,6 +86,17 @@ TEST_CASE("MessageSortersTestCase")
     CHECK( trailer_order::compare(0, FIELD::CheckSum) );
     CHECK( trailer_order::compare(1, FIELD::CheckSum) );
     CHECK( trailer_order::compare(100, FIELD::CheckSum) );
+
+    CHECK( trailer_order::compare(FIELD::SignatureLength, 0) );
+    CHECK( trailer_order::compare(FIELD::SignatureLength, 1) );
+    CHECK( trailer_order::compare(FIELD::SignatureLength, 100) );
+
+    CHECK( !trailer_order::compare(0, FIELD::SignatureLength) );
+    CHECK( !trailer_order::compare(1, FIELD::SignatureLength) );
+    CHECK( !trailer_order::compare(100, FIELD::SignatureLength) );
+
+    CHECK( !trailer_order::compare(FIELD::Signature, FIELD::SignatureLength) );
+    CHECK( trailer_order::compare(FIELD::SignatureLength, FIELD::Signature) );
   }
 
   SECTION("normalOrder")


### PR DESCRIPTION
At the current moment, all trailer fields are sorted by their id (the less id, the less position). Signature is a DATA field but in contrary to all other DATA fields, its length field is not 1 less that the DATA field id but larger (93 vs. 89). Hence, SignatureLength is put after Signature by FieldMap::addField. On the other hand, Message::extractField is used to process fields one-by-one through the coming message. Thus, SignatureLength is never found because it is not processed yet because it comes after Signature. Missing DATA length field is treated as an error now so a Signature field always leads to an error in message processing.
The suggested fix puts SignatureLength as the first field in the trailer.
No attempt to define specific comparison rules between Signature and SignatureLength has been done to avoid potential transitivity complications (Signature=89<90, 90<SignatureLength=93, SignatureLength=93<Signature=89).