### PR TITLE
Fix AC_CHECK_HEADERS warning for autotools build

### DIFF
--- a/m4/ax_lib_ssl.m4
+++ b/m4/ax_lib_ssl.m4
@@ -33,7 +33,7 @@ then
   CPPFLAGS="$CPPFLAGS -I$with_openssl/include"
   LDFLAGS="$LDFLAGS -L$with_openssl/lib"
   # Check for OpenSSL headers
-	AC_CHECK_HEADERS([$with_openssl/include/openssl/ssl.h],,AC_MSG_ERROR([Unable to find the OpenSSL headers]))
+	AC_CHECK_HEADER([$with_openssl/include/openssl/ssl.h],,AC_MSG_ERROR([Unable to find the OpenSSL headers]))
 	# Check for OpenSSL library
   LIBS_SAVED="$LIBS"
 	LIBS="$LIBS_SAVED -lssl -lcrypto"

--- a/src/C++/test/UtilityTestCase.cpp
+++ b/src/C++/test/UtilityTestCase.cpp
@@ -207,7 +207,7 @@ TEST_CASE("UtilityTests")
 
   SECTION("socketPeername_SocketDoesNotExist_SocketNameUnknown")
   {
-    CHECK(std::string_view("UNKNOWN") == socket_peername(1000));
+    CHECK(std::string("UNKNOWN") == socket_peername(1000));
   }
 
   SECTION("spawnThread_True")


### PR DESCRIPTION
Environment: Ubuntu 20.04, autoreconf (GNU Autoconf) 2.71
./bootstrap script produces warning:

`+ autoreconf -i -Wall
configure.ac:34: warning: AC_CHECK_HEADERS("$with_openssl/include/openssl/ssl.h"): you should use literals
./lib/autoconf/headers.m4:217: AC_CHECK_HEADERS is expanded from...
`
The proposed patch fixes that warning.