### PR TITLE
Making ssize_t definition aligned with ssize_t type in Python 3.9

### DIFF
--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -29,7 +29,7 @@
 #ifdef _MSC_VER
 #  define PRAGMA_PUSH( x )                      \
    __pragma( warning( push ) )                  \
-   __pragma( warning( disable: x ) ) 
+   __pragma( warning( disable: x ) )
 #  define PRAGMA_POP                            \
    __pragma( warning( pop ) )
 #else
@@ -122,7 +122,11 @@ namespace FIX
 {
 #ifdef _MSC_VER
 typedef int socklen_t;
-typedef int ssize_t;
+#ifdef MS_WIN64
+typedef __int64 ssize_t;
+#else
+typedef _W64 int ssize_t;
+#endif
 typedef SOCKET socket_handle;
 #else
 typedef int socket_handle;


### PR DESCRIPTION
The existing type definition conflicts with Python39\include\pyconfig.h type definition for `ssize_t`, causing
`C2371: 'ssize_t': redefinition; different basic types`

I propose we use the same way of defining type for ssize_t as in pyconfig.h