### PR TITLE
Refresh the Session state when new connection is established before the Session reset checks occur

### DIFF
--- a/src/C++/Session.h
+++ b/src/C++/Session.h
@@ -232,6 +232,8 @@ public:
 
   void setResponder( Responder* pR )
   {
+    if (m_refreshOnLogon)
+      refresh();
     if( !checkSessionTime(m_timestamper()) )
       reset();
     m_pResponder = pR;


### PR DESCRIPTION
Refresh the session when a new connection is established so that It won't be reseted [here](https://github.com/ilolis/quickfix/blob/d6d0f11a4024dcc296a2ccece9211fc7de54a5cb/src/C%2B%2B/Session.h#L237).

Fixes #540, so please feel free to read #540 for a more detailed description of the bug.