### PR TITLE
Handle ResendRequest: update target MsgSeqNum regardless of message persisting

### DIFF
--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -398,10 +398,11 @@ void Session::nextResendRequest( const Message& resendRequest, const UtcTimeStam
     if( endSeqNo > next )
       endSeqNo = EndSeqNo(next);
     generateSequenceReset( beginSeqNo, endSeqNo );
-    return;
   }
-
-  generateRetransmits( beginSeqNo.getValue(), endSeqNo.getValue() );
+  else
+  {
+    generateRetransmits( beginSeqNo.getValue(), endSeqNo.getValue() );
+  }
 
   MsgSeqNum msgSeqNum(0);
   resendRequest.getHeader().getField( msgSeqNum );

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -1332,7 +1332,7 @@ TEST_CASE_METHOD(initiatorFixture, "InitiatorSessionTestCase")
     object->next(resendReq, now);
 
     CHECK(5 == object->getExpectedSenderNum());
-    CHECK(2 == object->getExpectedTargetNum());
+    CHECK(3 == object->getExpectedTargetNum());
   }
 
   SECTION("disconnect_ResetOnDisconnect") 


### PR DESCRIPTION
Current behaviour: QuickFIX increments expected target MsgSeqNum only if persisting is enabled.
Correct behaviour (I think): expected target MsgSeqNum should be incremented on each received correct message.

Corresponding code from other FIX implementations:
- QuickFIX/j: No return statement in case of disabled persisting: https://github.com/quickfix-j/quickfixj/blob/master/quickfixj-core/src/main/java/quickfix/Session.java#L1374
- QuickFIX/go: https://github.com/quickfixgo/quickfix/blob/main/in_session.go#L213