### PR TITLE
FieldConvertors: warning caused by signed integer overflow

### DIFF
--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -249,10 +249,8 @@ struct IntTConvertor
 
     if( isNegative )
     {
-      PRAGMA_PUSH( 4146 );
-      if( nx > typename std::make_unsigned<T>::type( -VALUE_MIN ) )
+      if( nx > UNSIGNED_VALUE_OF( VALUE_MIN ) )
         return false; // overflow
-      PRAGMA_POP;
     }
     else if ( nx > VALUE_MAX )
       return false; // overflow


### PR DESCRIPTION
clang prints warning:
```
./FieldConvertors.h:253:54: warning: overflow in expression; result is -2147483648 with type 'int' [-Winteger-overflow]
  253 |       if( nx > typename std::make_unsigned<T>::type( -VALUE_MIN ) )
./FieldConvertors.h:253:54: warning: overflow in expression; result is -9223372036854775808 with type 'long' [-Winteger-overflow]
  253 |       if( nx > typename std::make_unsigned<T>::type( -VALUE_MIN ) )
```

Current PR performs casting signed to unsigned and then negation. It is defined behaviour:
```
[conv.integral]
If the destination type is unsigned, the resulting value is the least unsigned integer congruent to the source
integer (modulo 2^n where n is the number of bits used to represent the unsigned type). [ Note: In a two’s
complement representation, this conversion is conceptual and there is no change in the bit pattern (if there
is no truncation). — end note ]

[expr.unary.op]
The negative of an unsigned quantity is computed by subtracting its value from 2^n, where n is the number of bits in the promoted operand.
```

So, now warning disabling is not required.
