### PR TITLE
Refactor and modernize C++ log classes

### DIFF
--- a/src/C++/Log.cpp
+++ b/src/C++/Log.cpp
@@ -36,7 +36,7 @@ Log* ScreenLogFactory::create()
   return new ScreenLog( incoming, outgoing, event );
 }
 
-Log* ScreenLogFactory::create(const SessionID& sessionID )
+Log* ScreenLogFactory::create( const SessionID& sessionID )
 {
   Dictionary settings;
   if( m_settings.has(sessionID) ) 
@@ -47,7 +47,7 @@ Log* ScreenLogFactory::create(const SessionID& sessionID )
   return new ScreenLog( sessionID, incoming, outgoing, event );
 }
 
-void ScreenLogFactory::init(const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
+void ScreenLogFactory::init( const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
 {  
   if( m_useSettings )
   {
@@ -70,7 +70,7 @@ void ScreenLogFactory::init(const Dictionary& settings, bool& incoming, bool& ou
   }
 }
 
-void ScreenLogFactory::destroy(Log* pLog )
+void ScreenLogFactory::destroy( Log* pLog )
 {
   delete pLog;
 }

--- a/src/C++/Log.cpp
+++ b/src/C++/Log.cpp
@@ -29,16 +29,14 @@ namespace FIX
 {
 Mutex ScreenLog::s_mutex;
 
-
-    Log* ScreenLogFactory::create()
+Log* ScreenLogFactory::create()
 {
   bool incoming, outgoing, event;
   init( m_settings.get(), incoming, outgoing, event );
   return new ScreenLog( incoming, outgoing, event );
 }
 
-
-    Log* ScreenLogFactory::create(const SessionID& sessionID )
+Log* ScreenLogFactory::create(const SessionID& sessionID )
 {
   Dictionary settings;
   if( m_settings.has(sessionID) ) 
@@ -49,8 +47,7 @@ Mutex ScreenLog::s_mutex;
   return new ScreenLog( sessionID, incoming, outgoing, event );
 }
 
-
-    void ScreenLogFactory::init(const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
+void ScreenLogFactory::init(const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
 {  
   if( m_useSettings )
   {
@@ -73,8 +70,7 @@ Mutex ScreenLog::s_mutex;
   }
 }
 
-
-    void ScreenLogFactory::destroy(Log* pLog )
+void ScreenLogFactory::destroy(Log* pLog )
 {
   delete pLog;
 }

--- a/src/C++/Log.cpp
+++ b/src/C++/Log.cpp
@@ -47,7 +47,7 @@ Log* ScreenLogFactory::create( const SessionID& sessionID )
   return new ScreenLog( sessionID, incoming, outgoing, event );
 }
 
-void ScreenLogFactory::init( const Dictionary& settings, bool& incoming, bool& outgoing, bool& event )
+void ScreenLogFactory::init( const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
 {  
   if( m_useSettings )
   {

--- a/src/C++/Log.cpp
+++ b/src/C++/Log.cpp
@@ -73,14 +73,7 @@ Mutex ScreenLog::s_mutex;
   }
 }
 
-/**
- * @brief Destroy a Log object.
- *
- * This function destroys a Log object by deleting the dynamically allocated memory.
- *
- * @param pLog A pointer to the Log object to be destroyed.
- * @return None
- */
+
     void ScreenLogFactory::destroy(Log* pLog )
 {
   delete pLog;

--- a/src/C++/Log.cpp
+++ b/src/C++/Log.cpp
@@ -29,14 +29,16 @@ namespace FIX
 {
 Mutex ScreenLog::s_mutex;
 
-Log* ScreenLogFactory::create()
+
+    Log* ScreenLogFactory::create()
 {
   bool incoming, outgoing, event;
   init( m_settings.get(), incoming, outgoing, event );
   return new ScreenLog( incoming, outgoing, event );
 }
 
-Log* ScreenLogFactory::create( const SessionID& sessionID )
+
+    Log* ScreenLogFactory::create(const SessionID& sessionID )
 {
   Dictionary settings;
   if( m_settings.has(sessionID) ) 
@@ -47,7 +49,8 @@ Log* ScreenLogFactory::create( const SessionID& sessionID )
   return new ScreenLog( sessionID, incoming, outgoing, event );
 }
 
-void ScreenLogFactory::init( const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
+
+    void ScreenLogFactory::init(const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const
 {  
   if( m_useSettings )
   {
@@ -70,7 +73,15 @@ void ScreenLogFactory::init( const Dictionary& settings, bool& incoming, bool& o
   }
 }
 
-void ScreenLogFactory::destroy( Log* pLog )
+/**
+ * @brief Destroy a Log object.
+ *
+ * This function destroys a Log object by deleting the dynamically allocated memory.
+ *
+ * @param pLog A pointer to the Log object to be destroyed.
+ * @return None
+ */
+    void ScreenLogFactory::destroy(Log* pLog )
 {
   delete pLog;
 }

--- a/src/C++/Log.h
+++ b/src/C++/Log.h
@@ -64,11 +64,45 @@ public:
   ScreenLogFactory( bool incoming, bool outgoing, bool event )
 : m_incoming( incoming ), m_outgoing( outgoing ), m_event( event ), m_useSettings( false ) {}
 
+  /**
+  * \brief Create a new instance of the ScreenLog class.
+  *
+  * This function initializes the incoming, outgoing, and event variables based on the
+  * settings provided. It then creates a new instance of the ScreenLog class with the
+  * initialized variables and returns a pointer to it.
+  *
+  * \return A pointer to the created ScreenLog object.
+  */
   Log* create() override ;
+   /**
+  * Creates a `Log` object for the given session ID.
+  * @param sessionID The session ID.
+  * @return A pointer to the created `Log` object.
+  */
   Log* create( const SessionID& ) override;
+  /**
+  * @brief Destroy a Log object.
+  *
+  * This function destroys a Log object by deleting the dynamically allocated memory.
+  *
+  * @param pLog A pointer to the Log object to be destroyed.
+  * @return None
+  */
   void destroy( Log* log ) override;
 
 private:
+ /**
+ * @brief Initializes the screen logging settings.
+ *
+ * This function initializes the screen logging settings based on the provided dictionary.
+ * If m_useSettings is true, the settings from the dictionary are used to set the values of the incoming, outgoing, and event parameters.
+ * If m_useSettings is false, the values of incoming, outgoing, and event are set to the values of m_incoming, m_outgoing, and m_event respectively.
+ *
+ * @param settings The dictionary containing the screen logging settings.
+ * @param incoming A boolean reference to store the value of whether to show incoming log events.
+ * @param outgoing A boolean reference to store the value of whether to show outgoing log events.
+ * @param event A boolean reference to store the value of whether to show event log events.
+ */
   void init( const Dictionary& settings, bool& incoming, bool& outgoing, bool& event ) const;
 
   bool m_incoming{};
@@ -130,7 +164,15 @@ public:
   void clear() override {}
   void backup() override {}
 
-  void onIncoming( const std::string& value ) override
+    /**
+     * @brief Handles incoming messages.
+     *
+     * This function is called when an incoming message is received.
+     * It locks a mutex, retrieves the current timestamp, and prints the incoming message to the standard output.
+     *
+     * @param[in] value The incoming message.
+     */
+    void onIncoming(const std::string& value ) override
   {
     if ( !m_incoming ) return ;
     Locker l( s_mutex );
@@ -141,7 +183,18 @@ public:
               << "  (" << replaceSOHWithPipe(value) << ")" << std::endl;
   }
 
-  void onOutgoing( const std::string& value ) override
+    /**
+     * @brief Handles outgoing messages.
+     *
+     * This function is called when an outgoing message is sent. It prints the outgoing message to the standard output.
+     * The method first checks if outgoing logging is enabled. If not, it returns without performing any action.
+     * It locks a mutex to ensure thread safety, retrieves the current timestamp, and prints the outgoing message to the standard output.
+     *
+     * @param[in] value The outgoing message.
+     *
+     * @return void
+     */
+    void onOutgoing(const std::string& value ) override
   {
     if ( !m_outgoing ) return ;
     Locker l( s_mutex );
@@ -152,7 +205,18 @@ public:
               << "  (" << replaceSOHWithPipe(value) << ")" << std::endl;
   }
 
-  void onEvent( const std::string& value ) override
+    /**
+     * Handles an event by printing the event details to the standard output.
+     *
+     * This function first checks if the m_event flag is set to true. If not,
+     * it returns without performing any action.
+     * It then locks a mutex to ensure thread safety, retrieves the current timestamp,
+     * and prints the event details to the standard output.
+     *
+     * @param[in] value The event details.
+     * @return void
+     */
+    void onEvent(const std::string& value ) override
   {
     if ( !m_event ) return ;
     Locker l( s_mutex );
@@ -164,7 +228,13 @@ public:
   }
 
 private:
-  static std::string replaceSOHWithPipe( std::string value )
+    /**
+     * Replaces all occurrences of Start Of Header (SOH) character ('\001') in a given string with a pipe ('|') character.
+     *
+     * @param value The input string.
+     * @return The modified string with SOH replaced by pipe character.
+     */
+    static std::string replaceSOHWithPipe(std::string value )
   {
     std::replace( value.begin(), value.end(), '\001', '|');
     return value;


### PR DESCRIPTION
This commit modernizes the C++ logging classes by making use of the 'default' keyword for destructors, adopting the explicit keyword, improving the precision of the 'override' keyword, and optimizing memory usage through the use of 'std::move()'. The addition of preprocessor definitions in 'config.h' further improves the code's platform compatibility.