### PR TITLE
Fix build with HAVE_SSL

### DIFF
--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -5,5 +5,6 @@
 #cmakedefine HAVE_STD_SHARED_PTR
 #cmakedefine HAVE_MYSQL
 #cmakedefine HAVE_POSTGRESQL
+#cmakedefine HAVE_SSL 1
 
 #endif

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -1159,9 +1159,9 @@ SSL_CTX *createSSLContext(bool server, const SessionSettings &settings,
     }
   }
 
-  if (settings.get().has(TLSCipherSuites))
+  if (settings.get().has(TLS_CIPHER_SUITES))
   {
-    std::string strCipherSuites = settings.get().getString(TLSCipherSuites);
+    std::string strCipherSuites = settings.get().getString(TLS_CIPHER_SUITES);
 
 #if (OPENSSL_VERSION_NUMBER >= 0x1010100FL)
     if (!strCipherSuites.empty() &&

--- a/src/C++/UtilitySSL.h
+++ b/src/C++/UtilitySSL.h
@@ -234,6 +234,7 @@ int setSocketNonBlocking(socket_handle pSocket);
 #   define SSL_PROTOCOL_ALL                                                        \
       (SSL_PROTOCOL_SSLV2 | SSL_PROTOCOL_SSLV3 | SSL_PROTOCOL_TLSV1 |              \
        SSL_PROTOCOL_TLSV1_1 | SSL_PROTOCOL_TLSV1_2)
+#endif
 
 typedef enum {
   SSL_CLIENT_VERIFY_NONE = 0,


### PR DESCRIPTION
Add a missing `#endif` in `UtilitySSL.h`,
Fix a typo in `UtilitySSL.cpp` -- `TLSCipherSuites` -> `TLS_CIPHER_SUITES`

Add the `HAVE_SSL` macro to `cmake_config.h.in`, as without this, no cmake build ever has SSL support.