### PR TITLE
FieldConvertors: avoid undefined behaviour on signed negation

### DIFF
--- a/src/C++/FieldConvertors.h
+++ b/src/C++/FieldConvertors.h
@@ -257,7 +257,7 @@ struct IntTConvertor
     
     PRAGMA_PUSH( 4146 );
     if( isNegative )
-      x = -static_cast<T>(x);
+      x = -x;
     PRAGMA_POP;
 
     result = x;


### PR DESCRIPTION
Existing code contains an undefined behaviour because `unsigned x` is casted to `T = signed`, then negated (undefined behaviour) and then implicitly casted back to `unsigned` (line 260).
This PR removes an undefined behaviour of negation of signed int, replacing with defined behaviour of unsigned negation.

The bug can be reproduced with gcc-14 (arm64):
```
FieldConvertorsTestCase.cpp:390: FAILED:
  CHECK( MIN_INT == IntConvertor::convert( "-2147483648" ) )
with expansion:
  -2147483648 == -2147483648
```

From C++ standard:
```
[expr.unary.op]
The negative of an unsigned quantity is computed by subtracting its value from 2^n, where n is the number of bits in the promoted operand.
```

@pps314159 May you please check, is MSVC warning suppression still required?