### PR TITLE
Tests: DataDictionaryTestCase warning, SessionTestCase null pointer dereference

### DIFF
--- a/src/C++/test/DataDictionaryTestCase.cpp
+++ b/src/C++/test/DataDictionaryTestCase.cpp
@@ -161,7 +161,7 @@ TEST_CASE("DataDictionaryTests")
     object.addGroup( "A", 200, 201, group2 );
     object.addGroup( "A", 300, 301, group3 );
 
-    int delim;
+    int delim = 0;
     const DataDictionary* pDD = 0;
 
     CHECK( object.getGroup( "A", 100, delim, pDD ) );
@@ -846,7 +846,7 @@ TEST_CASE("DataDictionaryTests")
 
     DataDictionary copy = object;
     TYPE::Type type;
-    int delim;
+    int delim = 0;
 
     CHECK( BeginString_FIX40 == object.getVersion() );
     CHECK( copy.isMsgType( MsgType_NewOrderSingle ) );

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -1101,7 +1101,7 @@ TEST_CASE_METHOD(sessionFixture, "SessionTestCase")
     Session sessionObject = Session( [this](){ return now; }, *this, factory, sessionIDCustom, providerCustom,
         sessionTimeCustom, 1, &fileLogFactory);
 
-    Log* log = object->getLog();
+    Log* log = sessionObject.getLog();
     CHECK(log != nullptr);
   }
 


### PR DESCRIPTION
This PR resolves warning:
```
In constructor ‘Catch::BinaryExpr<LhsT, RhsT>::BinaryExpr(bool, LhsT, Catch::StringRef, RhsT) [with LhsT = int; RhsT = int]’,
    inlined from ‘std::enable_if_t<((bool)std::conjunction<Catch::Detail::is_eq_comparable<LhsT, RhsT, void>, std::is_arithmetic<RhsT> >::value), Catch::BinaryExpr<LhsT, RhsT> > Catch::operator==(ExprLhs<LhsT>&&, RhsT) [with RhsT = int; LhsT = int]’ at catch_amalgamated.hpp:5576:9,
    inlined from ‘void CATCH2_INTERNAL_TEST_0()’ at DataDictionaryTestCase.cpp:168:5:
catch_amalgamated.hpp:5446:13: warning: ‘delim’ may be used uninitialized [-Wmaybe-uninitialized]
 5446 |             m_rhs( rhs )
      |             ^~~~~~~~~~~~
DataDictionaryTestCase.cpp: In function ‘void CATCH2_INTERNAL_TEST_0()’:
DataDictionaryTestCase.cpp:164:9: note: ‘delim’ was declared here
  164 |     int delim;
```

And test with null pointer dereference:
```
SessionTestCase.cpp:1086: FAILED:
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal
```
This SIGSEGV is usually not happening, because `Session::getLog()` performs only arithmetical operations with pointer in optimized build.