### PR TITLE
Add support for loongarch64

### DIFF
--- a/src/C++/double-conversion/utils.h
+++ b/src/C++/double-conversion/utils.h
@@ -63,6 +63,7 @@
 #if defined(_M_X64) || defined(__x86_64__) || \
     defined(__ARMEL__) || defined(__avr32__) || \
     defined(__hppa__) || defined(__ia64__) || \
+    defined(__loongarch64) || \
     defined(__mips__) || \
     defined(__powerpc__) || defined(__ppc__) || defined(__ppc64__) || \
     defined(_POWER) || defined(_ARCH_PPC) || defined(_ARCH_PPC64) || \


### PR DESCRIPTION
Compiling the quickfix failed for loong64 in the Debian Package Auto-Building environment.
The error log is as follows,
```
In file included from ./double-conversion/diy-fp.h:31,
                 from double-conversion/diy-fp.cc:29,
                 from FieldConvertors.cpp:37:
./double-conversion/utils.h:84:2: error: #error Target architecture was not detected as supported by Double-Conversion.
   84 | #error Target architecture was not detected as supported by Double-Conversion.
      |  ^~~~~
......
```

The Full log can be found at https://buildd.debian.org/status/logs.php?pkg=quickfix&ver=1.15.1%2Bdfsg-4.1&arch=loong64.

I have built successfully on my local ENV.
Please review.