### PR TITLE
Fix using buffer size instead of pointer size

### DIFF
--- a/src/C++/pugixml.cpp
+++ b/src/C++/pugixml.cpp
@@ -6840,7 +6840,7 @@ PUGI__NS_BEGIN
 	PUGI__FN void convert_number_to_mantissa_exponent(double value, char* buffer, size_t buffer_size, char** out_mantissa, int* out_exponent)
 	{
 		// get a scientific notation value with IEEE DBL_DIG decimals
-		snprintf(buffer, sizeof(buffer), "%.*e", DBL_DIG, value);
+		snprintf(buffer, buffer_size, "%.*e", DBL_DIG, value);
 		assert(strlen(buffer) < buffer_size);
 		(void)!buffer_size;
 


### PR DESCRIPTION
This PR addresses issue #575 :
snprintf in pugixml incorrectly used sizeof(buffer) that is the pointer size. Corrected to use the already present buffer_size.
This is likely a slight copy paste error, as other snprintfs had a local buffer of char array, where the sizeof(buffer) work correctly.

As I am a newcomer to the project, any reviews appreciated! 