### PR TITLE
ReconnectInterval value in [SESSION] dominates the value in [DEFAULT]

### DIFF
--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -179,7 +179,7 @@ EXCEPT ( ConfigError )
 {
   const Dictionary& dict = s.get();
 
-  if( dict.has( RECONNECT_INTERVAL ) )
+  if( dict.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [DEFAULT]
     m_reconnectInterval = dict.getInt( RECONNECT_INTERVAL );
   if( dict.has( SOCKET_NODELAY ) )
     m_noDelay = dict.getBool( SOCKET_NODELAY );
@@ -290,10 +290,14 @@ void SSLSocketInitiator::doConnect( const SessionID& sessionID, const Dictionary
     Log* log = session->getLog();
 
     HostDetails host = m_hostDetailsProvider.getHost(sessionID, dictionary);
+    if( d.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [SESSION]
+      m_reconnectInterval = d.getInt( RECONNECT_INTERVAL );
 
     log->onEvent( "Connecting to " + host.address
                   + " on port " + IntConvertor::convert((unsigned short)host.port)
-                  + " (Source " + host.sourceAddress + ":" + IntConvertor::convert((unsigned short)host.sourcePort) + ")");
+                  + " (Source " + host.sourceAddress + ":" + IntConvertor::convert((unsigned short)host.sourcePort)
+                  + ") ReconnectInterval=" +
+                  IntConvertor::convert((int)m_reconnectInterval));
     socket_handle result = m_connector.connect( host.address, host.port, m_noDelay, m_sendBufSize, m_rcvBufSize, host.sourceAddress, host.sourcePort );
 
     log->onEvent("Socket created with handle:" + std::to_string(result));

--- a/src/C++/SocketInitiator.cpp
+++ b/src/C++/SocketInitiator.cpp
@@ -69,7 +69,7 @@ EXCEPT ( ConfigError )
 {
   const Dictionary& dict = s.get();
 
-  if( dict.has( RECONNECT_INTERVAL ) )
+  if( dict.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [DEFAULT]
     m_reconnectInterval = dict.getInt( RECONNECT_INTERVAL );
   if( dict.has( SOCKET_NODELAY ) )
     m_noDelay = dict.getBool( SOCKET_NODELAY );
@@ -139,8 +139,16 @@ void SocketInitiator::doConnect( const SessionID& s, const Dictionary& d )
     Log* log = session->getLog();
 
     HostDetails host = m_hostDetailsProvider.getHost( s, d);
+    if( d.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [SESSION]
+      m_reconnectInterval = d.getInt( RECONNECT_INTERVAL );
 
-    log->onEvent( "Connecting to " + host.address + " on port " + IntConvertor::convert((unsigned short)host.port) + " (Source " + host.sourceAddress + ":" + IntConvertor::convert((unsigned short)host.sourcePort) + ")");
+    log->onEvent( "Connecting to " + host.address + " on port "
+      + IntConvertor::convert((unsigned short)host.port)
+      + " (Source " + host.sourceAddress + ":"
+      + IntConvertor::convert((unsigned short)host.sourcePort)
+      + ") ReconnectInterval="
+      + IntConvertor::convert((int)m_reconnectInterval)
+    );
     socket_handle result = m_connector.connect(host.address, host.port, m_noDelay, m_sendBufSize, m_rcvBufSize, host.sourceAddress, host.sourcePort );
     setPending( s );
 

--- a/src/C++/ThreadedSSLSocketInitiator.cpp
+++ b/src/C++/ThreadedSSLSocketInitiator.cpp
@@ -168,7 +168,7 @@ void ThreadedSSLSocketInitiator::onConfigure(const SessionSettings &s) EXCEPT (C
 {
   const Dictionary &dict = s.get();
 
-  if (dict.has(RECONNECT_INTERVAL))
+  if (dict.has(RECONNECT_INTERVAL)) // ReconnectInterval in [DEFAULT]
     m_reconnectInterval = dict.getInt(RECONNECT_INTERVAL);
   if (dict.has(SOCKET_NODELAY))
     m_noDelay = dict.getBool(SOCKET_NODELAY);
@@ -289,6 +289,8 @@ void ThreadedSSLSocketInitiator::doConnect(const SessionID &s,
     Log *log = session->getLog();
 
     HostDetails host = m_hostDetailsProvider.getHost(s, d);
+    if( d.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [SESSION]
+      m_reconnectInterval = d.getInt( RECONNECT_INTERVAL );
 
     socket_handle socket = socket_createConnector();
     if (m_noDelay)
@@ -300,7 +302,9 @@ void ThreadedSSLSocketInitiator::doConnect(const SessionID &s,
 
     setPending(s);
     log->onEvent("Connecting to " + host.address + " on port " +
-                 IntConvertor::convert((unsigned short)host.port));
+                 IntConvertor::convert((unsigned short)host.port)
+                 + " ReconnectInterval=" +
+                 IntConvertor::convert((int)m_reconnectInterval));
 
     SSL *ssl = SSL_new(m_ctx);
     if (ssl == 0)

--- a/src/C++/ThreadedSocketInitiator.cpp
+++ b/src/C++/ThreadedSocketInitiator.cpp
@@ -62,7 +62,7 @@ EXCEPT ( ConfigError )
 {
   const Dictionary& dict = s.get();
 
-  if( dict.has( RECONNECT_INTERVAL ) )
+  if( dict.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [DEFAULT]
     m_reconnectInterval = dict.getInt( RECONNECT_INTERVAL );
   if( dict.has( SOCKET_NODELAY ) )
     m_noDelay = dict.getBool( SOCKET_NODELAY );
@@ -140,6 +140,8 @@ void ThreadedSocketInitiator::doConnect( const SessionID& s, const Dictionary& d
     Log* log = session->getLog();
 
     HostDetails host = m_hostDetailsProvider.getHost(s, d);
+    if( d.has( RECONNECT_INTERVAL ) ) // ReconnectInterval in [SESSION]
+      m_reconnectInterval = d.getInt( RECONNECT_INTERVAL );
 
     socket_handle socket = socket_createConnector();
     if( m_noDelay )
@@ -150,7 +152,11 @@ void ThreadedSocketInitiator::doConnect( const SessionID& s, const Dictionary& d
       socket_setsockopt( socket, SO_RCVBUF, m_rcvBufSize );
 
     setPending( s );
-    log->onEvent( "Connecting to " + host.address + " on port " + IntConvertor::convert((unsigned short)host.port) + " (Source " + host.sourceAddress + ":" + IntConvertor::convert((unsigned short)host.sourcePort) + ")");
+    log->onEvent( "Connecting to " + host.address + " on port " +
+      IntConvertor::convert((unsigned short)host.port) +
+      " (Source " + host.sourceAddress + ":" + IntConvertor::convert((unsigned short)host.sourcePort) +
+      ") ReconnectInterval=" +
+      IntConvertor::convert((int)m_reconnectInterval));
 
     ThreadedSocketConnection* pConnection =
       new ThreadedSocketConnection( s, socket, host.address, host.port, getLog(), host.sourceAddress, host.sourcePort );


### PR DESCRIPTION
This pull request to fix following issue
https://github.com/quickfix/quickfix/issues/604

Expected: ReconnectInterval value in [SESSION] dominates the value in [DEFAULT]
Bug: currently Initiator use ReconnectInterval value in [DEFAULT].

I'm sure that my solution can fix for an initiator (SocketInitiator, SSLSocketInitiator, ThreadedSSLSocketInitiator) but I'm not sure about an acceptor. 