### PR TITLE
MillisecondsInTimeStamp=N config

### DIFF
--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -201,7 +201,15 @@ Session* SessionFactory::create( const SessionID& sessionID,
   if ( settings.has( REFRESH_ON_LOGON ) )
     pSession->setRefreshOnLogon( settings.getBool( REFRESH_ON_LOGON ) );
   if ( settings.has( MILLISECONDS_IN_TIMESTAMP ) )
-    pSession->setTimestampPrecision(3);
+  {
+    bool useMilliseconds = true;
+    useMilliseconds = settings.getBool( MILLISECONDS_IN_TIMESTAMP );
+    if (useMilliseconds)
+      pSession->setTimestampPrecision(3);
+    else // MillisecondsInTimeStamp=N
+      pSession->setTimestampPrecision(0);
+
+  }
   if ( settings.has( TIMESTAMP_PRECISION ) )
     pSession->setTimestampPrecision(settings.getInt( TIMESTAMP_PRECISION ) );
   if ( settings.has( PERSIST_MESSAGES ) )

--- a/src/C++/SessionFactory.cpp
+++ b/src/C++/SessionFactory.cpp
@@ -201,15 +201,7 @@ Session* SessionFactory::create( const SessionID& sessionID,
   if ( settings.has( REFRESH_ON_LOGON ) )
     pSession->setRefreshOnLogon( settings.getBool( REFRESH_ON_LOGON ) );
   if ( settings.has( MILLISECONDS_IN_TIMESTAMP ) )
-  {
-    bool useMilliseconds = true;
-    useMilliseconds = settings.getBool( MILLISECONDS_IN_TIMESTAMP );
-    if (useMilliseconds)
-      pSession->setTimestampPrecision(3);
-    else // MillisecondsInTimeStamp=N
-      pSession->setTimestampPrecision(0);
-
-  }
+    pSession->setMillisecondsInTimeStamp( settings.getBool( MILLISECONDS_IN_TIMESTAMP ) );
   if ( settings.has( TIMESTAMP_PRECISION ) )
     pSession->setTimestampPrecision(settings.getInt( TIMESTAMP_PRECISION ) );
   if ( settings.has( PERSIST_MESSAGES ) )


### PR DESCRIPTION
This pull request to fix following issue
https://github.com/quickfix/quickfix/issues/615

On setting: MillisecondsInTimeStamp=N
Expected: in FIX message, Date-Time format will be YYYMMDD-HH:MM:SS (20241125-16:49:49), without fractional part of seconds.
Bug: Date-Time format still shows in milliseconds.