### PR TITLE
Eliminating 3 warning

### DIFF
--- a/src/C++/DataDictionary.cpp
+++ b/src/C++/DataDictionary.cpp
@@ -420,7 +420,7 @@ message_order const &DataDictionary::getOrderedFields() const {
     return m_orderedFieldsArray;
   }
 
-  return m_orderedFieldsArray = message_order(m_orderedFields.data(), m_orderedFields.size());
+  return m_orderedFieldsArray = message_order(m_orderedFields.data(), static_cast<int>(m_orderedFields.size()));
 }
 
 message_order const &DataDictionary::getHeaderOrderedFields() const EXCEPT(ConfigError) {
@@ -432,7 +432,7 @@ message_order const &DataDictionary::getHeaderOrderedFields() const EXCEPT(Confi
     throw ConfigError("<Header> does not have a stored message order");
   }
 
-  return m_headerOrder = message_order(m_headerOrderedFields.data(), m_headerOrderedFields.size());
+  return m_headerOrder = message_order(m_headerOrderedFields.data(), static_cast<int>(m_headerOrderedFields.size()));
 }
 
 message_order const &DataDictionary::getTrailerOrderedFields() const EXCEPT(ConfigError) {
@@ -444,7 +444,7 @@ message_order const &DataDictionary::getTrailerOrderedFields() const EXCEPT(Conf
     throw ConfigError("<Trailer> does not have a stored message order");
   }
 
-  return m_trailerOrder = message_order(m_trailerOrderedFields.data(), m_trailerOrderedFields.size());
+  return m_trailerOrder = message_order(m_trailerOrderedFields.data(), static_cast<int>(m_trailerOrderedFields.size()));
 }
 
 const message_order &DataDictionary::getMessageOrderedFields(const std::string &msgType) const EXCEPT(ConfigError) {


### PR DESCRIPTION
The last 3 warning compile time warnings are eliminated.

Before these changes I got only 3 warnings in otherwise very clean code.
Those were :

> 1>.\SandBox\quickfix\src\C++\DataDictionary.cpp(**423**,91): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
> 1>.\SandBox\quickfix\src\C++\DataDictionary.cpp(**435**,96): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
> 1>.\SandBox\quickfix\src\C++\DataDictionary.cpp(**447**,99): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data

Those are due to size() returning **_size_t_** value. Luckily, those are collections of fields in the 3 parts of the FIX message and **_int_** value is more than enough to reflect the size of such collections.