### PR TITLE
Fix warnings in message_order about type mismatch

### DIFF
--- a/src/C++/MessageSorters.cpp
+++ b/src/C++/MessageSorters.cpp
@@ -74,14 +74,14 @@ message_order::message_order(const int order[])
   setOrder(order, size);
 }
 
-message_order::message_order(const int order[], int size)
+message_order::message_order(const int order[], size_t size)
     : m_mode(group),
       m_delim(0),
       m_largest(0) {
   setOrder(order, size);
 }
 
-void message_order::setOrder(const int order[], int size) {
+void message_order::setOrder(const int order[], size_t size) {
   if (size < 1) {
     return;
   }

--- a/src/C++/MessageSorters.h
+++ b/src/C++/MessageSorters.h
@@ -149,7 +149,7 @@ public:
         m_largest(0) {}
   message_order(int first, ...);
   message_order(const int order[]);
-  message_order(const int order[], int size);
+  message_order(const int order[], size_t size);
   message_order(const message_order &) = default;
   message_order(message_order &&) = default;
 
@@ -166,14 +166,14 @@ public:
       return x < y;
     }
   }
-
+  
   message_order &operator=(const message_order &) = default;
   message_order &operator=(message_order &&) = default;
 
   operator bool() const { return !m_groupOrder.empty(); }
 
 private:
-  void setOrder(const int order[], int size);
+  void setOrder(const int order[], size_t size);
 
   cmp_mode m_mode;
   int m_delim;


### PR DESCRIPTION
This fixes three warnings about type mismatches. It fixes the same problem as https://github.com/quickfix/quickfix/pull/636 but by changing the function's parameter type instead of casting the inputs at the call sites. Negative sizes are not possible, so there's no reason to use a signed int or to require casting in order to avoid warnings.