### PR TITLE
Add FieldMap::tryGet() which returns a std::optional

### DIFF
--- a/src/C++/FieldMap.h
+++ b/src/C++/FieldMap.h
@@ -35,6 +35,10 @@
 #include <sstream>
 #include <vector>
 
+#if __cplusplus >= 201703L
+#include <optional>
+#endif
+
 namespace FIX {
 /**
  * Stores and organizes a collection of Fields.
@@ -144,6 +148,16 @@ public:
   template <typename T> const T &getField() const EXCEPT(FieldNotFound) {
     return *reinterpret_cast<const T *>(&getFieldRef(T::tag));
   }
+
+#if __cplusplus >= 201703L
+  template <typename F> std::optional<F> tryGet() const {
+    F field;
+    if (!getFieldIfSet(field)) {
+      return std::nullopt;
+    }
+    return field;
+  }
+#endif
 
   /// Get a field without a field class
   const std::string &getField(int tag) const EXCEPT(FieldNotFound) { return getFieldRef(tag).getString(); }

--- a/src/C++/test/FieldMapTestCase.cpp
+++ b/src/C++/test/FieldMapTestCase.cpp
@@ -26,6 +26,7 @@
 
 #include <FieldMap.h>
 #include <Message.h>
+#include <fix44/MarketDataRequest.h>
 #include <vector>
 
 #include "catch_amalgamated.hpp"
@@ -161,4 +162,16 @@ TEST_CASE("FieldMapTests") {
     CHECK(18 == actualTag18.getTag());
     CHECK("field18_new" == actualTag18.getString());
   }
+
+#if __cplusplus >= 201703L
+  SECTION("tryGet") {
+    FIX44::MarketDataRequest fieldMap;
+    fieldMap.setField(FIX::MarketDepth(3));
+    auto mdOpt = fieldMap.tryGet<MarketDepth>();
+    CHECK(mdOpt.has_value());
+    CHECK(mdOpt.value() == 3);
+    auto unset = fieldMap.tryGet<FIX::AggregatedBook>();
+    CHECK(!unset.has_value());
+  }
+#endif
 }


### PR DESCRIPTION
Fixed #645 

The templated `FieldMap::get` was not needed as it already exists as `getField<T>()` in the latest "version" (not published, hem hem) of quickfix.