### PR TITLE
fix: correct undeclared variable 'd' in SSLSocketInitiator::doConnect

### DIFF
--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -292,9 +292,9 @@ void SSLSocketInitiator::doConnect(const SessionID &sessionID, const Dictionary 
     Log *log = session->getLog();
 
     HostDetails host = m_hostDetailsProvider.getHost(sessionID, dictionary);
-    if (d.has(RECONNECT_INTERVAL)) // ReconnectInterval in [SESSION]
+    if (dictionary.has(RECONNECT_INTERVAL)) // ReconnectInterval in [SESSION]
     {
-      m_reconnectInterval = d.getInt(RECONNECT_INTERVAL);
+      m_reconnectInterval = dictionary.getInt(RECONNECT_INTERVAL);
     }
 
     log->onEvent(


### PR DESCRIPTION
Replaced incorrect reference to 'd' with the correct parameter name 'dictionary' in SSLSocketInitiator::doConnect. This resolves a compilation error due to the use of an undeclared variable.