### PR TITLE
we need to dealllocate returned pointer of string_concat

### DIFF
--- a/src/C++/Utility.cpp
+++ b/src/C++/Utility.cpp
@@ -87,7 +87,7 @@ char *string_concat(const char *a, ...) {
 
   va_end(adummy);
 
-  /* Allocate the required string */
+  /* Allocate the required string. We need to dealllocate after used. */
 
   res = new char[len + 1];
   cp = res;

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -746,6 +746,7 @@ STACK_OF(X509_NAME) * findCAList(const char *cpCAfile, const char *cpCApath) {
 #endif
       cp = string_concat(cpCApath, SLASH, direntry->d_name, 0);
       sk = SSL_load_client_CA_file(cp);
+      delete [] cp;
       for (n = 0; sk != 0 && n < sk_X509_NAME_num(sk); n++) {
         // TODO log->onEvent(std::string("CA certificate: %s") +
         //           X509_NAME_oneline(sk_X509_NAME_value(sk, n), 0, 0));

--- a/src/C++/test/UtilityTestCase.cpp
+++ b/src/C++/test/UtilityTestCase.cpp
@@ -61,7 +61,9 @@ TEST_CASE("UtilityTests") {
   }
 
   SECTION("stringConcat_ConcatsStrings") {
-    std::string actual = string_concat("ABC", "123", "!@#", 0);
+    char* ch = string_concat("ABC", "123", "!@#", 0);
+    std::string actual(ch);
+    delete [] ch;
     std::string expected = "ABC123!@#";
     CHECK(expected == actual);
   }


### PR DESCRIPTION
#654 
string_concat function allocated array and returned it. After used, we need to deallocate it.