### PR TITLE
Fix buffer overflow in SSL password callback

### DIFF
--- a/src/C++/SSLSocketAcceptor.cpp
+++ b/src/C++/SSLSocketAcceptor.cpp
@@ -397,11 +397,12 @@ void SSLSocketAcceptor::onTimeout(SocketServer &) {
 }
 
 int SSLSocketAcceptor::passwordHandleCallback(char *buf, size_t bufsize, int verify) {
-  if (m_password.length() > bufsize) {
+  if (m_password.length() >= bufsize) {
     return -1;
   }
 
-  std::strcpy(buf, m_password.c_str());
+  memcpy(buf, m_password.c_str(), m_password.length());
+  buf[m_password.length()] = '\0';
   return m_password.length();
 }
 } // namespace FIX

--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -546,11 +546,12 @@ void SSLSocketInitiator::disconnectPendingSSLHandshakesThatTakeTooLong(time_t no
 }
 
 int SSLSocketInitiator::passwordHandleCallback(char *buf, size_t bufsize, int verify) {
-  if (m_password.length() > bufsize) {
+  if (m_password.length() >= bufsize) {
     return -1;
   }
 
-  std::strcpy(buf, m_password.c_str());
+  memcpy(buf, m_password.c_str(), m_password.length());
+  buf[m_password.length()] = '\0';
   return m_password.length();
 }
 } // namespace FIX

--- a/src/C++/ThreadedSSLSocketAcceptor.cpp
+++ b/src/C++/ThreadedSSLSocketAcceptor.cpp
@@ -424,11 +424,12 @@ THREAD_PROC ThreadedSSLSocketAcceptor::socketConnectionThread(void *p) {
 }
 
 int ThreadedSSLSocketAcceptor::passwordHandleCallback(char *buf, size_t bufsize, int verify) {
-  if (m_password.length() > bufsize) {
+  if (m_password.length() >= bufsize) {
     return -1;
   }
 
-  std::strcpy(buf, m_password.c_str());
+  memcpy(buf, m_password.c_str(), m_password.length());
+  buf[m_password.length()] = '\0';
   return m_password.length();
 }
 } // namespace FIX

--- a/src/C++/ThreadedSSLSocketInitiator.cpp
+++ b/src/C++/ThreadedSSLSocketInitiator.cpp
@@ -422,11 +422,12 @@ THREAD_PROC ThreadedSSLSocketInitiator::socketThread(void *p) {
 }
 
 int ThreadedSSLSocketInitiator::passwordHandleCallback(char *buf, size_t bufsize, int verify) {
-  if (m_password.length() > bufsize) {
+  if (m_password.length() >= bufsize) {
     return -1;
   }
 
-  std::strcpy(buf, m_password.c_str());
+  memcpy(buf, m_password.c_str(), m_password.length());
+  buf[m_password.length()] = '\0';
   return m_password.length();
 }
 } // namespace FIX


### PR DESCRIPTION
Fixes buffer overflow in SSL password handling.

### Details

Off-by-one error: check allows passwords of length `bufsize` but `strcpy()` writes `bufsize+1` bytes.

### Nota bene

SSL compilation depends on #625 or #663 to be merged. This fix addresses a separate SSL issue.