### PR TITLE
Fix C4267 warnings: use size_t for message_order size parameter

### DIFF
--- a/src/C++/MessageSorters.cpp
+++ b/src/C++/MessageSorters.cpp
@@ -74,27 +74,27 @@ message_order::message_order(const int order[])
   setOrder(order, size);
 }
 
-message_order::message_order(const int order[], int size)
+message_order::message_order(const int order[], size_t size)
     : m_mode(group),
       m_delim(0),
       m_largest(0) {
   setOrder(order, size);
 }
 
-void message_order::setOrder(const int order[], int size) {
+void message_order::setOrder(const int order[], size_t size) {
   if (size < 1) {
     return;
   }
   m_largest = m_delim = order[0];
 
   // collect all fields and find the largest field number
-  for (int i = 1; i < size; ++i) {
+  for (size_t i = 1; i < size; ++i) {
     int field = order[i];
     m_largest = m_largest > field ? m_largest : field;
   }
 
   m_groupOrder = shared_array<int>::create(m_largest + 1);
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     m_groupOrder[order[i]] = i + 1;
   }
 }

--- a/src/C++/MessageSorters.h
+++ b/src/C++/MessageSorters.h
@@ -149,7 +149,7 @@ public:
         m_largest(0) {}
   message_order(int first, ...);
   message_order(const int order[]);
-  message_order(const int order[], int size);
+  message_order(const int order[], size_t size);
   message_order(const message_order &) = default;
   message_order(message_order &&) = default;
 
@@ -173,7 +173,7 @@ public:
   operator bool() const { return !m_groupOrder.empty(); }
 
 private:
-  void setOrder(const int order[], int size);
+  void setOrder(const int order[], size_t size);
 
   cmp_mode m_mode;
   int m_delim;


### PR DESCRIPTION
Change the message_order constructor and setOrder to accept size_t instead of int, eliminating implicit narrowing conversions from size_t when passing vector sizes on 64-bit builds.