### PR TITLE
Use std::chrono features in the SocketMonitor class

### DIFF
--- a/src/C++/SocketMonitor_WIN32.cpp
+++ b/src/C++/SocketMonitor_WIN32.cpp
@@ -43,7 +43,7 @@ SocketMonitor::SocketMonitor(int timeout)
   m_timeval.tv_sec = 0;
   m_timeval.tv_usec = 0;
 #ifndef SELECT_DECREMENTS_TIME
-  m_ticks = clock();
+  m_ticks = Clock::now();
 #endif
 }
 
@@ -128,9 +128,9 @@ inline timeval *SocketMonitor::getTimeval(bool poll, double timeout) {
   }
   return &m_timeval;
 #else
-  double elapsed = (double)(clock() - m_ticks) / (double)CLOCKS_PER_SEC;
+  const double elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(Clock::now() - m_ticks).count();
   if (elapsed >= timeout || elapsed == 0.0) {
-    m_ticks = clock();
+    m_ticks = Clock::now();
     m_timeval.tv_sec = 0;
     m_timeval.tv_usec = (long)(timeout * 1000000);
   } else {

--- a/src/C++/SocketMonitor_WIN32.h
+++ b/src/C++/SocketMonitor_WIN32.h
@@ -31,7 +31,7 @@ typedef int socklen_t;
 
 #include <queue>
 #include <set>
-#include <time.h>
+#include <chrono>
 
 namespace FIX {
 /// Monitors events on a collection of sockets.
@@ -70,7 +70,8 @@ private:
   int m_timeout;
   timeval m_timeval;
 #ifndef SELECT_DECREMENTS_TIME
-  clock_t m_ticks;
+  using Clock = std::chrono::steady_clock;
+  Clock::time_point m_ticks;
 #endif
 
   socket_handle m_signal;


### PR DESCRIPTION
Resolves [Issue 142](https://github.com/quickfix/quickfix/issues/162).

As per [the 'Remarks' section of the clock() function's MSDN documentation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/clock?view=msvc-170#remarks): "You can use the ... or the Windows QueryPerformanceCounter function to record process elapsed times of many years."
As per [the 'Remarks' section of the steady_clock struct's MSDN documentation](https://learn.microsoft.com/en-us/cpp/standard-library/steady-clock-struct?view=msvc-170#remarks): "On Windows, steady_clock wraps the QueryPerformanceCounter function."

I am also pretty sure the same logic can be used in the UNIX implementation of the SocketMonitor class for consistency.
