### PR TITLE
Use std::chrono features in the UNIX SocketMonitor class

### DIFF
--- a/src/C++/SocketMonitor_UNIX.cpp
+++ b/src/C++/SocketMonitor_UNIX.cpp
@@ -40,7 +40,7 @@ SocketMonitor::SocketMonitor(int timeout)
   socket_setnonblock(m_interrupt);
   m_readSockets.insert(m_interrupt);
 
-  m_ticks = clock();
+  m_ticks = Clock::now();
 }
 
 SocketMonitor::~SocketMonitor() {
@@ -117,9 +117,9 @@ inline int SocketMonitor::getTimeval(bool poll, double timeout) {
     return 0;
   }
 
-  double elapsed = (double)(clock() - m_ticks) / (double)CLOCKS_PER_SEC;
+  const double elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(Clock::now() - m_ticks).count();
   if (elapsed >= timeout || elapsed == 0.0) {
-    m_ticks = clock();
+    m_ticks = Clock::now();
     return (timeout * 1000);
   } else {
     return ((timeout - elapsed) * 1000);

--- a/src/C++/SocketMonitor_UNIX.h
+++ b/src/C++/SocketMonitor_UNIX.h
@@ -30,10 +30,10 @@
 #include <sys/time.h>
 #include <sys/types.h>
 
+#include <chrono>
 #include <poll.h>
 #include <queue>
 #include <set>
-#include <time.h>
 
 #include "Utility.h"
 
@@ -73,7 +73,8 @@ private:
   void processPollList(Strategy &strategy, struct pollfd *pfds, unsigned pfds_size);
 
   int m_timeout;
-  clock_t m_ticks;
+  using Clock = std::chrono::steady_clock;
+  Clock::time_point m_ticks;
 
   socket_handle m_signal;
   socket_handle m_interrupt;

--- a/src/C++/SocketMonitor_WIN32.h
+++ b/src/C++/SocketMonitor_WIN32.h
@@ -29,9 +29,9 @@
 #include <Winsock2.h>
 typedef int socklen_t;
 
+#include <chrono>
 #include <queue>
 #include <set>
-#include <chrono>
 
 namespace FIX {
 /// Monitors events on a collection of sockets.


### PR DESCRIPTION
Follows up on #707 which made the same fix to the Windows `SocketMonitor` implementation.

Replaces `clock()` / `clock_t` / `CLOCKS_PER_SEC` with `std::chrono::steady_clock` in `SocketMonitor_UNIX`. The motivations are the same as #707:

- `clock()` measures CPU time, not wall time — it can drift relative to elapsed real time under load
- `steady_clock` is monotonic and uses higher-resolution OS timers
- Consistent behavior between the UNIX and Windows implementations

## Changes

- `SocketMonitor_UNIX.h`: Replace `#include <time.h>` with `#include <chrono>`; replace `clock_t m_ticks` with `using Clock = std::chrono::steady_clock` and `Clock::time_point m_ticks`
- `SocketMonitor_UNIX.cpp`: Replace all `clock()` calls with `Clock::now()`; update elapsed time calculation to use `duration_cast<duration<double>>`

Builds cleanly with no new warnings.