### PR TITLE
Remove windows-2019 from CMake build matrix

### DIFF
--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -7,7 +7,7 @@ jobs:
       strategy:
           fail-fast: false
           matrix:
-              runner: [windows-2019, windows-2022, ubuntu-latest, macos-latest]
+              runner: [windows-2022, ubuntu-latest, macos-latest]
               configuration: [Debug, Release]
               include:
                 - configuration: Debug
@@ -38,7 +38,7 @@ jobs:
           Configuration: ${{ matrix.configuration }}
       - name: Set tests paths windows
         shell: bash
-        if: ${{ matrix.runner == 'windows-2019' || matrix.runner == 'windows-2022' }}
+        if: ${{ matrix.runner == 'windows-2022' }}
         run: |
           echo "at=$PWD/test/$Config/at/at.exe" >> GITHUB_ENV
           echo "pt=$PWD/test/$Config/pt/pt.exe" >> GITHUB_ENV
@@ -94,7 +94,7 @@ jobs:
           pt_check: ${{ env.pt_check }}
           ut_check: ${{ env.ut_check }}
       - name: Run acceptance tests for windows
-        if: ${{ env.at_check == 'true' && (matrix.runner == 'windows-2019' || matrix.runner == 'windows-2022') && github.event_name == 'pull_request' }}
+        if: ${{ env.at_check == 'true' && matrix.runner == 'windows-2022' && github.event_name == 'pull_request' }}
         shell: cmd
         working-directory: ./test
         run: |
@@ -105,7 +105,7 @@ jobs:
           PortBase: 6666
           Offset: ${{ matrix.portoffset }}
       - name: Run acceptance tests for ${{ matrix.runner }}
-        if: ${{ env.at_check == 'true' && (matrix.runner != 'windows-2019' && matrix.runner != 'windows-2022') && github.event_name == 'pull_request' }}
+        if: ${{ env.at_check == 'true' && matrix.runner != 'windows-2022' && github.event_name == 'pull_request' }}
         shell: bash
         working-directory: ./test
         run: |


### PR DESCRIPTION
## Summary
- Removes `windows-2019` from the runner matrix in `build_test_cmake.yml`
- Simplifies the Windows-specific `if` conditions to only check for `windows-2022`

## Test plan
- [ ] Verify CI runs on `windows-2022`, `ubuntu-latest`, and `macos-latest` (but not `windows-2019`)