### PR TITLE
Handle POLLHUP in processPollList to detect peer-initiated disconnects

### DIFF
--- a/src/C++/SocketMonitor_UNIX.cpp
+++ b/src/C++/SocketMonitor_UNIX.cpp
@@ -219,7 +219,7 @@ void SocketMonitor::processPollList(Strategy &strategy, struct pollfd *pfds, uns
     if ((pfds[i].revents & POLLOUT)) {
       processWrite(strategy, pfds[i].fd);
     }
-    if ((pfds[i].revents & POLLERR)) {
+    if ((pfds[i].revents & POLLERR) || ((pfds[i].revents & POLLHUP) && !(pfds[i].revents & POLLIN))) {
       processError(strategy, pfds[i].fd);
     }
   }


### PR DESCRIPTION
## Summary

- `processPollList` in `SocketMonitor_UNIX.cpp` previously only checked `POLLERR` in the error path, ignoring `POLLHUP`
- On graceful TCP close, `poll()` returns `POLLIN | POLLHUP` simultaneously — the existing `POLLIN` path already handles this (reads 0 bytes and disconnects), so `POLLHUP` is only treated as an error when `POLLIN` is **not** also set
- The `POLLHUP`-only case covers abrupt connection termination (e.g. TCP RST, dead peer) where no data is pending

Fixes #674.

## Test plan

- [ ] Existing `SocketServerTests::block` test exercises the graceful-close path (POLLIN | POLLHUP) and verifies `disconnect == 1` (not 2)
- [ ] All 53 unit tests pass: `cd test && bash runut.sh`
