### PR TITLE
Add SECURITY.md with private vulnerability reporting channel

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| Latest  | Yes       |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Use GitHub's private vulnerability reporting instead:
+[Report a vulnerability](https://github.com/quickfix/quickfix/security/advisories/new)
+
+Please include:
+- A description of the vulnerability and its impact
+- Steps to reproduce or a proof of concept
+- Any suggested mitigations if known


### PR DESCRIPTION
## Summary

- Adds `SECURITY.md` directing reporters to GitHub's private vulnerability reporting channel
- Instructs reporters not to use public issues for security findings

Prompted by issue #706.

🤖 Generated with [Claude Code](https://claude.com/claude-code)