### PR TITLE
Fix SSLSocketInitiator fd leak and CPU spin on connection failure

### DIFF
--- a/src/C++/SSLSocketInitiator.cpp
+++ b/src/C++/SSLSocketInitiator.cpp
@@ -411,6 +411,8 @@ void SSLSocketInitiator::handshakeSSLAndHandleConnection(SocketConnector &connec
   } else if (sslHandshakeStatus == SSL_HANDSHAKE_FAILED) {
     setDisconnected(pSocketConnection->getSession()->getSessionID());
 
+    pSocketConnection->disconnect();
+
     Session *pSession = pSocketConnection->getSession();
     if (pSession) {
       pSession->disconnect();

--- a/src/C++/SocketConnector.cpp
+++ b/src/C++/SocketConnector.cpp
@@ -52,7 +52,10 @@ private:
     }
   }
 
-  virtual void onError(SocketMonitor &, socket_handle socket) override { m_strategy.onDisconnect(m_connector, socket); }
+  virtual void onError(SocketMonitor &monitor, socket_handle socket) override {
+    monitor.drop(socket);
+    m_strategy.onDisconnect(m_connector, socket);
+  }
 
   virtual void onError(SocketMonitor &) override { m_strategy.onError(m_connector); }
 

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -380,6 +380,8 @@ void ssl_socket_close(socket_handle socket, SSL *ssl) {
       break;
     }
   }
+
+  socket_close(socket);
 }
 
 static void thread_setup(void) {


### PR DESCRIPTION
## Summary

Fixes three related bugs reported in #682 that cause file descriptor leaks and busy-spinning when `SSLSocketInitiator` cannot connect (e.g. configured port is unreachable):

- **`ssl_socket_close` never closed the socket fd when `ssl != NULL`** — the BIO is created with `BIO_NOCLOSE` in `doConnect`, so `SSL_free` doesn't close it either. Added `socket_close(socket)` after the `SSL_shutdown` loop so the fd is always released.

- **`ConnectorWrapper::onError` didn't drop the failing socket from the monitor** — on every subsequent `block()` call, `poll()` returned `POLLERR` for the same socket again, spinning the CPU. Added `monitor.drop(socket)` before notifying the strategy, matching the existing pattern in `ServerWrapper::onError`.

- **`handshakeSSLAndHandleConnection` deleted the connection on SSL handshake failure without calling `disconnect()`** — left the socket in the monitor's read set. Added `pSocketConnection->disconnect()` before `pSession->disconnect()` so the specific failing socket is removed from the monitor immediately, rather than going through the session's responder (which may have already been updated to a new connection on reconnect).

## Test plan

- [ ] Configure an `SSLSocketInitiator` session pointing at an unreachable port; confirm no fd accumulation in `/proc/<PID>/fd` and no CPU spin
- [ ] All 53 unit tests pass: `cd test && bash runut.sh`
