### PR TITLE
Fix SSLSocketInitiator fd leak and CPU spin on connection failure

### DIFF
--- a/src/C++/SocketConnector.cpp
+++ b/src/C++/SocketConnector.cpp
@@ -53,8 +53,9 @@ private:
   }
 
   virtual void onError(SocketMonitor &monitor, socket_handle socket) override {
-    monitor.drop(socket);
-    m_strategy.onDisconnect(m_connector, socket);
+    if (monitor.drop(socket)) {
+      m_strategy.onDisconnect(m_connector, socket);
+    }
   }
 
   virtual void onError(SocketMonitor &) override { m_strategy.onError(m_connector); }

--- a/src/C++/test/SocketConnectorTestCase.cpp
+++ b/src/C++/test/SocketConnectorTestCase.cpp
@@ -35,6 +35,17 @@
 
 using namespace FIX;
 
+struct SocketConnectorTestStrategy : public SocketConnector::Strategy {
+  void onConnect(SocketConnector &, socket_handle) { connect++; }
+  void onWrite(SocketConnector &, socket_handle) {}
+  bool onData(SocketConnector &, socket_handle) { return true; }
+  void onDisconnect(SocketConnector &, socket_handle) { disconnect++; }
+  void onError(SocketConnector &) {}
+
+  int connect = 0;
+  int disconnect = 0;
+};
+
 TEST_CASE("SocketConnectorTests") {
   SECTION("accept") {
     SocketConnector object;
@@ -43,5 +54,26 @@ TEST_CASE("SocketConnectorTests") {
     CHECK(object.connect("127.0.0.1", TestSettings::port, false, 1024, 1024));
     CHECK(server.accept(socket));
     server.close();
+  }
+
+  SECTION("connect_to_dead_port_fires_disconnect_once") {
+    // Bind a server to get a free port, then close it so nothing is listening.
+    SocketServer server(0);
+    socket_handle serverSocket = server.add(0, true, true);
+    uint16_t port = socket_hostport(serverSocket);
+    server.close();
+
+    SocketConnector connector(1);
+    SocketConnectorTestStrategy strategy;
+    connector.connect("127.0.0.1", port, false, 1024, 1024);
+
+    process_sleep(0.1);
+    connector.block(strategy);
+    CHECK(1 == strategy.disconnect);
+
+    // Second block must not fire disconnect again: the socket must have been
+    // dropped from the monitor when the error was first processed.
+    connector.block(strategy);
+    CHECK(1 == strategy.disconnect);
   }
 }

--- a/src/C++/test/SocketServerTestCase.cpp
+++ b/src/C++/test/SocketServerTestCase.cpp
@@ -34,7 +34,7 @@
 
 using namespace FIX;
 
-struct TestStrategy : public SocketServer::Strategy {
+struct SocketServerTestStrategy : public SocketServer::Strategy {
   void onConnect(SocketServer &, socket_handle accept, socket_handle socket) {
     connect++;
     connectSocket = socket;
@@ -68,7 +68,7 @@ struct TestStrategy : public SocketServer::Strategy {
 };
 
 TEST_CASE("SocketServerTests") {
-  TestStrategy strategy;
+  SocketServerTestStrategy strategy;
 
   SECTION("accept") {
     SocketServer object(0);


### PR DESCRIPTION
## Summary

Fixes #682. Three related bugs that together cause file descriptor leaks and CPU spinning when the SSL initiator cannot connect (e.g. dead port, SSL handshake failure):

- **`UtilitySSL.cpp`** — `ssl_socket_close()` skipped `socket_close()` when an SSL object was present, relying on `SSL_free()` to close the fd. Because the BIO is created with `BIO_NOCLOSE` in `SSLSocketInitiator::doConnect`, `SSL_free()` never closes the underlying fd. Added `socket_close()` after the SSL_shutdown loop so the fd is always released.

- **`SocketConnector.cpp`** — `ConnectorWrapper::onError()` (connection-refused / POLLERR path) did not drop the socket from the monitor before notifying the strategy. On each subsequent `block()` call, `poll()` returned POLLERR again, spinning the CPU. Added `monitor.drop(socket)`, guarded by its return value to prevent a spurious second `onDisconnect` from the `m_dropped` replay queue on the next `block()` call.

- **`SSLSocketInitiator.cpp`** — `handshakeSSLAndHandleConnection()` deleted the `SSLSocketConnection` on SSL handshake failure without first calling `disconnect()`, leaving the socket in the monitor's read set. Call `pSocketConnection->disconnect()` before `pSession->disconnect()` so the specific failing socket is removed from the monitor immediately.

## Dependencies

Depends on #711 (POLLHUP handling) — this branch is rebased on top of `fix/pollhup-handling`. Please merge #711 first.

## Test plan

- [ ] New unit test `SocketConnectorTests/connect_to_dead_port_fires_disconnect_once` verifies that connecting to a closed port fires `onDisconnect` exactly once across two consecutive `block()` calls
- [ ] All 1948 unit test assertions pass
- [ ] All 468 acceptance tests pass