### PR TITLE
Fix memory leak: GapFill does not clear queued out-of-order messages

### DIFF
--- a/src/C++/Session.cpp
+++ b/src/C++/Session.cpp
@@ -355,6 +355,10 @@ void Session::nextSequenceReset(const Message &sequenceReset, const UtcTimeStamp
 
     if (newSeqNo > getExpectedTargetNum()) {
       m_state.setNextTargetMsgSeqNum(MsgSeqNum(newSeqNo));
+      if (isGapFill) {
+        m_state.clearQueueUpTo(newSeqNo);
+        nextQueued(now);
+      }
     } else if (newSeqNo < getExpectedTargetNum()) {
       generateReject(sequenceReset, SessionRejectReason_VALUE_IS_INCORRECT);
     }

--- a/src/C++/SessionState.h
+++ b/src/C++/SessionState.h
@@ -151,6 +151,10 @@ public:
     Locker l(m_mutex);
     m_queue.clear();
   }
+  void clearQueueUpTo(SEQNUM msgSeqNum) {
+    Locker l(m_mutex);
+    m_queue.erase(m_queue.begin(), m_queue.lower_bound(msgSeqNum));
+  }
 
   bool set(SEQNUM s, const std::string &m) EXCEPT(IOException) {
     Locker l(m_mutex);

--- a/src/C++/test/SessionTestCase.cpp
+++ b/src/C++/test/SessionTestCase.cpp
@@ -2125,6 +2125,50 @@ TEST_CASE_METHOD(acceptorFixture, "AcceptorSessionTestCase") {
     CHECK(1 == disconnected);
   }
 
+  SECTION("gapFillClearsQueuedMessages") {
+    object->setResponder(this);
+    object->next(createLogon("ISLD", "TW", 1), now);
+    // Expected target is now 2.
+
+    // Messages at 5, 6, 7 arrive before the gap is filled — they get queued.
+    object->next(createTestRequest("ISLD", "TW", 5, "A"), now);
+    object->next(createTestRequest("ISLD", "TW", 6, "B"), now);
+    object->next(createTestRequest("ISLD", "TW", 7, "C"), now);
+    CHECK(0 == fromTestRequest);
+
+    // GapFill skips 2–7 entirely (newSeqNo=8). Queued items 5, 6, 7 should be
+    // discarded — they were part of the gap, not messages the app should see.
+    FIX42::SequenceReset gapFill = createSequenceReset("ISLD", "TW", 2, 8);
+    gapFill.set(GapFillFlag(true));
+    object->next(gapFill, now);
+    CHECK(8 == object->getExpectedTargetNum());
+    CHECK(0 == fromTestRequest);
+
+    // Next in-sequence message is processed normally with no queue backup.
+    object->next(createTestRequest("ISLD", "TW", 8, "D"), now);
+    CHECK(1 == fromTestRequest);
+    CHECK(9 == object->getExpectedTargetNum());
+  }
+
+  SECTION("gapFillDrainsQueuedMessagesAboveNewSeqNo") {
+    object->setResponder(this);
+    object->next(createLogon("ISLD", "TW", 1), now);
+    // Expected target is now 2.
+
+    // Message at seq 5 arrives and is queued; seq 6 arrives and is also queued.
+    object->next(createTestRequest("ISLD", "TW", 5, "A"), now);
+    object->next(createTestRequest("ISLD", "TW", 6, "B"), now);
+    CHECK(0 == fromTestRequest);
+
+    // GapFill covers only 2–4 (newSeqNo=5). The queued message at 5 should be
+    // processed immediately via nextQueued, and the one at 6 should follow.
+    FIX42::SequenceReset gapFill = createSequenceReset("ISLD", "TW", 2, 5);
+    gapFill.set(GapFillFlag(true));
+    object->next(gapFill, now);
+    CHECK(2 == fromTestRequest);
+    CHECK(7 == object->getExpectedTargetNum());
+  }
+
   SECTION("nextResendRequest") {
     object->next(createLogon("ISLD", "TW", 1), now);
     object->next(createTestRequest("ISLD", "TW", 2, "HELLO"), now);


### PR DESCRIPTION
## Summary

Fixes #44.

When messages arrive with a sequence number higher than expected, they are held in `SessionState::m_queue` pending replay of the gap. If the counterparty then sends a `SequenceReset(GapFillFlag=Y)` that skips over those sequence numbers, `nextSequenceReset` advances the expected target seq num but never touches the queue — leaving those messages stranded until the session disconnects.

**Changes:**

- `SessionState.h` — add `clearQueueUpTo(SEQNUM)`: erases all queued entries with seq num strictly less than the given value using `std::map::erase` + `lower_bound`, O(k log n) where k is the number of stale entries.
- `Session.cpp` — in `nextSequenceReset`, after advancing the expected seq num for a GapFill, call `clearQueueUpTo(newSeqNo)` to discard stale entries, then `nextQueued(now)` to immediately drain any entries at or above the new expected number (e.g. a message that arrived before the gap was filled).

## Test plan

- [ ] `gapFillClearsQueuedMessages` — queues messages at 5, 6, 7; GapFill skips to 8; verifies stale queue entries are discarded and seq 8 is processed normally
- [ ] `gapFillDrainsQueuedMessagesAboveNewSeqNo` — queues messages at 5, 6; GapFill covers only 2–4 (newSeqNo=5); verifies both queued messages are immediately processed via `nextQueued`
- [ ] All 1954 unit test assertions pass