### PR TITLE
Add AGENTS.md and bench-compare slash command

### DIFF
--- a/.claude/commands/bench-compare.md
+++ b/.claude/commands/bench-compare.md
@@ -1,0 +1,117 @@
+Compare QuickFIX performance benchmarks between the current branch and another branch or PR.
+
+Usage: /bench-compare <branch-name>
+       /bench-compare <PR-number>   (e.g. 712 or #712)
+
+The argument $ARGUMENTS is either a branch name or a PR number to compare against.
+
+## Steps
+
+1. **Validate** that `$ARGUMENTS` is provided. If not, tell the user:
+   `Usage: /bench-compare <branch-name|PR-number>`
+   and stop.
+
+2. **Resolve the comparison target**. Strip any leading `#` from `$ARGUMENTS`. If the result is a plain integer, treat it as a PR number:
+   ```
+   gh pr view <number> --json number,title,headRefName,headRepository
+   ```
+   - If the PR is from a fork (headRepository owner differs from the base repo owner), fetch the fork's branch:
+     ```
+     git fetch <fork-remote-url> <headRefName>:refs/remotes/pr/<number>
+     ```
+     Use `refs/remotes/pr/<number>` as the COMPARE_REF.
+   - If the PR is from the same repo, use the headRefName as COMPARE_REF.
+   - Record a human-readable COMPARE_LABEL like `PR #712: <title> (<headRefName>)`.
+   - If `gh pr view` fails, tell the user the PR was not found and stop.
+
+   If `$ARGUMENTS` is not a plain integer, treat it as a branch name:
+   ```
+   git rev-parse --verify $ARGUMENTS
+   ```
+   If that fails, tell the user the branch was not found and stop.
+   Set COMPARE_REF and COMPARE_LABEL both to `$ARGUMENTS`.
+
+3. **Record the current branch name** for reference:
+   ```
+   git rev-parse --abbrev-ref HEAD
+   ```
+
+4. **Build the `pt` binary on the current branch** (Release mode for reliable numbers). On macOS, pass the SDK's C++ headers explicitly to work around missing headers in the CLT include path:
+   ```
+   SDK_INCLUDE=$(xcrun --show-sdk-path)/usr/include/c++/v1
+   cmake -S . -B build-bench-current -DCMAKE_BUILD_TYPE=Release -DQUICKFIX_EXAMPLES=ON "-DCMAKE_CXX_FLAGS=-I${SDK_INCLUDE}" 2>&1
+   cmake --build build-bench-current --target pt 2>&1
+   ```
+   If the build fails, report the error and stop.
+
+   After building, locate the `pt` binary (its output location varies depending on whether the build dir is inside or outside the source tree):
+   ```
+   CURRENT_PT=$(find build-bench-current -name "pt" -type f | head -1)
+   # fallback: check lib/pt at project root (happens when build dir is inside source tree)
+   [ -z "$CURRENT_PT" ] && CURRENT_PT=lib/pt
+   ```
+
+5. **Run benchmarks on the current branch 3 times** from the `test/` directory, using a different port offset for each trial to avoid conflicts:
+   ```
+   cd test
+   ../${CURRENT_PT} -p 6671 -c 200000 2>&1   # trial 1
+   ../${CURRENT_PT} -p 6671 -c 200000 2>&1   # trial 2
+   ../${CURRENT_PT} -p 6671 -c 200000 2>&1   # trial 3
+   ```
+   Capture all three outputs as CURRENT_TRIAL_1, CURRENT_TRIAL_2, CURRENT_TRIAL_3.
+
+6. **Create a git worktree** for the comparison target:
+   ```
+   git worktree add /tmp/quickfix-bench-compare <COMPARE_REF> 2>&1
+   ```
+
+7. **Build the `pt` binary in the worktree**:
+   ```
+   SDK_INCLUDE=$(xcrun --show-sdk-path)/usr/include/c++/v1
+   cmake -S /tmp/quickfix-bench-compare -B /tmp/quickfix-bench-build -DCMAKE_BUILD_TYPE=Release -DQUICKFIX_EXAMPLES=ON "-DCMAKE_CXX_FLAGS=-I${SDK_INCLUDE}" 2>&1
+   cmake --build /tmp/quickfix-bench-build --target pt 2>&1
+   ```
+   If the build fails, clean up the worktree (`git worktree remove --force /tmp/quickfix-bench-compare`) and stop.
+
+   Locate the binary:
+   ```
+   COMPARE_PT=$(find /tmp/quickfix-bench-build -name "pt" -type f | head -1)
+   ```
+
+8. **Run benchmarks on the comparison target 3 times** from the worktree's `test/` directory:
+   ```
+   cd /tmp/quickfix-bench-compare/test
+   ${COMPARE_PT} -p 6672 -c 200000 2>&1   # trial 1
+   ${COMPARE_PT} -p 6672 -c 200000 2>&1   # trial 2
+   ${COMPARE_PT} -p 6672 -c 200000 2>&1   # trial 3
+   ```
+   Capture all three outputs as COMPARE_TRIAL_1, COMPARE_TRIAL_2, COMPARE_TRIAL_3.
+
+9. **Clean up** the worktree and build directory:
+   ```
+   git worktree remove --force /tmp/quickfix-bench-compare
+   rm -rf /tmp/quickfix-bench-build
+   ```
+
+10. **Parse and display results**. For each benchmark in each set of three trials, extract the `num_per_second` values and compute the **median** across the three trials. Use the median as the representative value for each branch.
+
+    Then for each benchmark present in both sets, compute:
+    - `Δ%` = `(current_median - compare_median) / compare_median * 100` (positive = current branch is faster)
+
+    Present a Markdown table:
+
+    ```
+    ## Benchmark Comparison
+    Current branch: <current-branch>  vs  <COMPARE_LABEL>
+
+    | Benchmark                                    | Current median (ops/s) | <COMPARE_LABEL> median (ops/s) | Δ%     |
+    |----------------------------------------------|------------------------|--------------------------------|--------|
+    | Converting integers to strings               |          4,250,000     |              4,100,000         | +3.7%  |
+    | ...                                          |                        |                                |        |
+
+    > Count: 200,000 iterations per benchmark × 3 trials, median reported | Build: Release
+    ```
+
+    Highlight any benchmark where `|Δ%| >= 5%` with a note at the end.
+
+    If a benchmark is present in one output but not the other, note it as `N/A`.

--- a/.claude/commands/bench-compare.md
+++ b/.claude/commands/bench-compare.md
@@ -44,21 +44,31 @@ The argument $ARGUMENTS is either a branch name or a PR number to compare agains
    ```
    If the build fails, report the error and stop.
 
-   After building, locate the `pt` binary (its output location varies depending on whether the build dir is inside or outside the source tree):
+   After building, locate the `pt` binary as an absolute path:
    ```
-   CURRENT_PT=$(find build-bench-current -name "pt" -type f | head -1)
-   # fallback: check lib/pt at project root (happens when build dir is inside source tree)
-   [ -z "$CURRENT_PT" ] && CURRENT_PT=lib/pt
+   CURRENT_PT=$(find $(pwd)/build-bench-current -name "pt" -type f | head -1)
+   [ -z "$CURRENT_PT" ] && CURRENT_PT=$(pwd)/lib/pt
    ```
 
-5. **Run benchmarks on the current branch 3 times** from the `test/` directory, using a different port offset for each trial to avoid conflicts:
+5. **Run benchmarks on the current branch 3 times** from the `test/` directory. Each trial consists of two runs: non-network benchmarks, then network benchmarks (with fewer samples since each involves real socket setup).
+
    ```
    cd test
-   ../${CURRENT_PT} -p 6671 -c 200000 2>&1   # trial 1
-   ../${CURRENT_PT} -p 6671 -c 200000 2>&1   # trial 2
-   ../${CURRENT_PT} -p 6671 -c 200000 2>&1   # trial 3
+
+   # Trial 1
+   ${CURRENT_PT} --quickfix-spec-path ../spec -# "~[network]" 2>&1
+   ${CURRENT_PT} --quickfix-spec-path ../spec --port 54322 "[network]" --benchmark-samples 5 2>&1
+
+   # Trial 2
+   ${CURRENT_PT} --quickfix-spec-path ../spec -# "~[network]" 2>&1
+   ${CURRENT_PT} --quickfix-spec-path ../spec --port 54322 "[network]" --benchmark-samples 5 2>&1
+
+   # Trial 3
+   ${CURRENT_PT} --quickfix-spec-path ../spec -# "~[network]" 2>&1
+   ${CURRENT_PT} --quickfix-spec-path ../spec --port 54322 "[network]" --benchmark-samples 5 2>&1
    ```
-   Capture all three outputs as CURRENT_TRIAL_1, CURRENT_TRIAL_2, CURRENT_TRIAL_3.
+
+   Capture the combined output of each trial pair as CURRENT_TRIAL_1, CURRENT_TRIAL_2, CURRENT_TRIAL_3.
 
 6. **Create a git worktree** for the comparison target:
    ```
@@ -73,19 +83,30 @@ The argument $ARGUMENTS is either a branch name or a PR number to compare agains
    ```
    If the build fails, clean up the worktree (`git worktree remove --force /tmp/quickfix-bench-compare`) and stop.
 
-   Locate the binary:
+   Locate the binary as an absolute path:
    ```
    COMPARE_PT=$(find /tmp/quickfix-bench-build -name "pt" -type f | head -1)
    ```
 
-8. **Run benchmarks on the comparison target 3 times** from the worktree's `test/` directory:
+8. **Run benchmarks on the comparison target 3 times** from the worktree's `test/` directory (using a different port for network benchmarks to avoid conflicts if runs overlap):
+
    ```
    cd /tmp/quickfix-bench-compare/test
-   ${COMPARE_PT} -p 6672 -c 200000 2>&1   # trial 1
-   ${COMPARE_PT} -p 6672 -c 200000 2>&1   # trial 2
-   ${COMPARE_PT} -p 6672 -c 200000 2>&1   # trial 3
+
+   # Trial 1
+   ${COMPARE_PT} --quickfix-spec-path ../spec -# "~[network]" 2>&1
+   ${COMPARE_PT} --quickfix-spec-path ../spec --port 54332 "[network]" --benchmark-samples 5 2>&1
+
+   # Trial 2
+   ${COMPARE_PT} --quickfix-spec-path ../spec -# "~[network]" 2>&1
+   ${COMPARE_PT} --quickfix-spec-path ../spec --port 54332 "[network]" --benchmark-samples 5 2>&1
+
+   # Trial 3
+   ${COMPARE_PT} --quickfix-spec-path ../spec -# "~[network]" 2>&1
+   ${COMPARE_PT} --quickfix-spec-path ../spec --port 54332 "[network]" --benchmark-samples 5 2>&1
    ```
-   Capture all three outputs as COMPARE_TRIAL_1, COMPARE_TRIAL_2, COMPARE_TRIAL_3.
+
+   Capture the combined output of each trial pair as COMPARE_TRIAL_1, COMPARE_TRIAL_2, COMPARE_TRIAL_3.
 
 9. **Clean up** the worktree and build directory:
    ```
@@ -93,7 +114,24 @@ The argument $ARGUMENTS is either a branch name or a PR number to compare agains
    rm -rf /tmp/quickfix-bench-build
    ```
 
-10. **Parse and display results**. For each benchmark in each set of three trials, extract the `num_per_second` values and compute the **median** across the three trials. Use the median as the representative value for each branch.
+10. **Parse and display results**. The Catch2 output has this structure for each benchmark:
+
+    ```
+    BenchmarkName                      100         12345     2.7474 ms
+                                 1.0262 ns    1.02135 ns    1.04603 ns
+                               0.043910 ns  0.007503 ns   0.103297 ns
+    ```
+
+    - Line 1: benchmark name (left-justified, no leading whitespace), followed by samples, iterations, estimated time
+    - Line 2: mean, low mean, high mean — each as `<value> <unit>` (unit is one of `ns`, `µs`, `ms`, `s`)
+    - Line 3: std dev stats (ignore for comparison)
+
+    To parse each trial output:
+    - Identify benchmark name lines: non-empty lines that don't start with whitespace, aren't all dashes, and aren't the column-header line (`benchmark name ... samples ...`). The benchmark name is all text before the first run of 2+ spaces.
+    - The immediately following non-empty line (starts with whitespace) contains the mean as the first `<value> <unit>` pair.
+    - Convert mean to ops/sec: divide 1 by the mean expressed in seconds (`ns` → ×10⁻⁹, `µs` → ×10⁻⁶, `ms` → ×10⁻³, `s` → ×1).
+
+    For each benchmark, extract the mean-derived ops/sec from all three trials and compute the **median** as the representative value for each branch.
 
     Then for each benchmark present in both sets, compute:
     - `Δ%` = `(current_median - compare_median) / compare_median * 100` (positive = current branch is faster)
@@ -106,10 +144,11 @@ The argument $ARGUMENTS is either a branch name or a PR number to compare agains
 
     | Benchmark                                    | Current median (ops/s) | <COMPARE_LABEL> median (ops/s) | Δ%     |
     |----------------------------------------------|------------------------|--------------------------------|--------|
-    | Converting integers to strings               |          4,250,000     |              4,100,000         | +3.7%  |
+    | IntegerToString                              |      975,000,000       |          942,000,000           | +3.7%  |
+    | Socket/SendMessage                           |          1,250         |              1,180             | +5.9%  |
     | ...                                          |                        |                                |        |
 
-    > Count: 200,000 iterations per benchmark × 3 trials, median reported | Build: Release
+    > 3 trials, median reported | Catch2 statistical benchmarks | Build: Release
     ```
 
     Highlight any benchmark where `|Δ%| >= 5%` with a note at the end.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,133 @@
+# QuickFIX Agent Guidelines
+
+QuickFIX is a C++17 implementation of the FIX (Financial Information eXchange) protocol,
+supporting FIX 4.0 through 5.0 SP2 and FIXT 1.1.
+
+## Build
+
+```bash
+# Configure (from repo root)
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+# Build
+cmake --build build
+
+# Test
+cmake --build build --target test
+```
+
+Optional CMake flags: `-DHAVE_SSL=ON`, `-DHAVE_MYSQL=ON`, `-DHAVE_POSTGRESQL=ON`,
+`-DHAVE_PYTHON3=ON`, `-DQUICKFIX_SHARED_LIBS=ON`.
+
+Legacy Autotools build: `./bootstrap && ./configure && make && make check`.
+
+## Tests
+
+| Suite | Binary | Purpose |
+|-------|--------|---------|
+| Unit  | `ut`   | Function/class-level tests |
+| Acceptance | `at` | End-to-end FIX session tests |
+| Performance | `pt` | Throughput benchmark (Release only) |
+
+Run all: `cmake --build build --target test`  
+Unit only: `./test/ut`
+
+Acceptance tests require a network port and a config file under `test/cfg/`.
+Do **not** run acceptance tests in environments where ports 6666–6670 are unavailable.
+
+## Code Style
+
+Formatting is enforced by `.clang-format`. Before committing:
+
+```bash
+git diff --name-only | grep -E '\.(cpp|h)$' | xargs clang-format -i
+```
+
+CI runs a format-check workflow on every PR — unformatted code will fail.
+
+Key rules (all sourced from `.clang-format`):
+- **Indent:** 2 spaces, no tabs
+- **Line length:** 120 characters
+- **Braces:** Attach style
+- **Includes:** Clang-format managed; corresponding header first for `.cpp` files
+
+## Naming Conventions
+
+| Element | Style | Example |
+|---------|-------|---------|
+| Classes / types | PascalCase | `SessionID`, `SocketAcceptor` |
+| Methods / functions | camelCase | `sendMessage()`, `getSessionID()` |
+| Member variables | `m_` prefix + camelCase | `m_sessionID`, `m_port` |
+| Constants / macros | `UPPER_CASE` | `MAX_BUFFER_SIZE` |
+| Namespace | `FIX` | `namespace FIX { ... }` |
+
+All production code lives in the `FIX` namespace.
+
+## Header Files
+
+- Use `#pragma once` (preferred over include guards in new code).
+- One class per header file (general rule).
+- Inline simple accessors directly in the class body.
+- Mark all non-mutating methods `const`.
+
+## C++ Standards
+
+- Minimum: **C++17** (`set(CMAKE_CXX_STANDARD 17)` in CMakeLists.txt).
+- Use RAII; prefer `std::unique_ptr` / `std::shared_ptr` over raw owning pointers.
+- Use move semantics where appropriate.
+
+## Error Handling
+
+QuickFIX uses a custom exception macro pattern:
+
+```cpp
+void fromApp(const Message& message, const SessionID& sessionID)
+    EXCEPT(FieldNotFound, IncorrectDataFormat, IncorrectTagValue, UnsupportedMessageType);
+```
+
+Custom exception types are declared with the `EXCEPT` macro defined in `include/quickfix/Exceptions.h`.
+Do not silently swallow exceptions; propagate or log them explicitly.
+
+## File Layout
+
+```
+include/quickfix/   Public headers (installed with the library)
+src/C++/            Core implementation (.cpp files)
+src/python3/        Python 3 SWIG bindings
+src/ruby/           Ruby SWIG bindings
+test/               Acceptance, unit, and performance tests
+test/cfg/           Test configuration files
+spec/               FIX XML specification files
+examples/           Sample applications (executor, ordermatch, tradeclient)
+doc/                Doxygen-generated HTML documentation
+```
+
+## Documentation
+
+Public API changes must include Doxygen-style comments (`///` or `/** */`).
+User-visible changes (new settings, new features) require updates to the relevant
+files in `doc/html/` — particularly `configuration.html` and `building.html`.
+
+Generate docs: `cd doc && ./document.sh` (Unix) or `document.bat` (Windows).
+
+## Copyright Header
+
+Every new `.cpp` and `.h` file must begin with the standard copyright block:
+
+```cpp
+// Copyright (c) 2001-2010 quickfixengine.org  All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met: ...
+```
+
+Copy the full block from any existing file (e.g., `include/quickfix/Session.h`).
+
+## CI / PR Checklist
+
+- `clang-format` passes (CI enforces this automatically).
+- All three test suites pass on the target platform(s).
+- No new compiler warnings introduced (especially C4267/size_t narrowing on MSVC).
+- Documentation updated for any user-facing change.
+- No breaking API changes without discussion.


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` with build instructions, test suite overview, code style rules, and naming conventions — giving AI agents (and new contributors) a concise orientation to the codebase.
- Adds `.claude/commands/bench-compare.md`, a Claude Code slash command (`/bench-compare <branch|PR>`) that builds both branches in Release mode, runs the Catch2 `pt` benchmarks 3×, and prints a Markdown comparison table with Δ% per benchmark.

## Test plan

- [ ] Verify `AGENTS.md` build commands work from a clean clone
- [ ] Run `/bench-compare <another-branch>` in Claude Code and confirm it produces a comparison table
- [ ] Confirm network and non-network benchmarks are run with separate ports to avoid conflicts