### PR TITLE
Fix SSL build and add CI jobs

### DIFF
--- a/.github/workflows/build_test_cmake.yml
+++ b/.github/workflows/build_test_cmake.yml
@@ -12,6 +12,7 @@ jobs:
           matrix:
               runner: [windows-2022, ubuntu-latest, macos-latest]
               configuration: [Debug, Release]
+              ssl: ['OFF', 'ON']
               include:
                 - configuration: Debug
                   config: debug
@@ -27,12 +28,29 @@ jobs:
           event_name: ${{ github.event_name }}
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install OpenSSL (macOS)
+        if: matrix.ssl == 'ON' && matrix.runner == 'macos-latest'
+        run: brew install openssl
+      - name: Install OpenSSL (Linux)
+        if: matrix.ssl == 'ON' && matrix.runner == 'ubuntu-latest'
+        run: sudo apt-get install -y libssl-dev
+      - name: Set OPENSSL_ROOT_DIR (macOS)
+        if: matrix.ssl == 'ON' && matrix.runner == 'macos-latest'
+        shell: bash
+        run: echo "OPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl" >> $GITHUB_ENV
+      - name: Set OPENSSL_ROOT_DIR (Windows)
+        if: matrix.ssl == 'ON' && matrix.runner == 'windows-2022'
+        shell: bash
+        run: echo "OPENSSL_ROOT_DIR=C:/Program Files/OpenSSL" >> $GITHUB_ENV
       - name: Generate
         shell: bash
         run: |
-          cmake . -DCMAKE_BUILD_TYPE=$Configuration -DCMAKE_INSTALL_PREFIX=../install_prefix/$Configuration
+          cmake . -DCMAKE_BUILD_TYPE=$Configuration -DCMAKE_INSTALL_PREFIX=../install_prefix/$Configuration \
+            -DHAVE_SSL=$SSL ${OPENSSL_ROOT_DIR:+-DOPENSSL_ROOT_DIR="$OPENSSL_ROOT_DIR"}
         env:
           Configuration: ${{ matrix.configuration }}
+          SSL: ${{ matrix.ssl }}
+          OPENSSL_ROOT_DIR: ${{ env.OPENSSL_ROOT_DIR }}
       - name: Build
         shell: bash
         run: |

--- a/src/C++/SSLSocketConnection.h
+++ b/src/C++/SSLSocketConnection.h
@@ -185,6 +185,7 @@ public:
 
   bool didProcessQueueRequestToRead() const;
   bool didReadFromSocketRequestToWrite() const;
+  void disconnect();
 
 private:
   typedef std::deque<std::string, ALLOCATOR<std::string>> Queue;
@@ -194,7 +195,6 @@ private:
   bool readMessage(std::string &msg);
   void readMessages(SocketMonitor &s);
   bool send(const std::string &);
-  void disconnect();
 
   socket_handle m_socket;
   SSL *m_ssl;

--- a/src/C++/UtilitySSL.cpp
+++ b/src/C++/UtilitySSL.cpp
@@ -135,6 +135,9 @@
 
 #ifdef _MSC_VER
 
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
 #if !defined(snprintf)
 #define snprintf _snprintf
 #endif


### PR DESCRIPTION
The recent commit 63deeff9 ("Fix SSLSocketInitiator fd leak and CPU spin on connection failure") added a call to `pSocketConnection->disconnect()` in `SSLSocketInitiator.cpp`, but `disconnect()` is declared private in `SSLSocketConnection`. In addition, two required includes are missing on Windows. This breaks compilation when building with `-DHAVE_SSL=ON`.

This PR fixes this compile error and also adds SSL builds to the CI pipeline to catch this kind of error in the future.