### PR TITLE
Remove redundant using std:: declarations from Utility.h

### DIFF
--- a/src/C++/Utility.h
+++ b/src/C++/Utility.h
@@ -232,24 +232,4 @@ std::string file_appendpath(const std::string &path, const std::string &file);
 #define STRING_SPRINTF sprintf
 #endif
 
-#if (!defined(_MSC_VER) || (_MSC_VER >= 1300))
-using std::abort;
-using std::abs;
-using std::atof;
-using std::atoi;
-using std::atol;
-using std::exit;
-using std::isdigit;
-using std::labs;
-using std::memcpy;
-using std::memset;
-using std::sprintf;
-using std::strcmp;
-using std::strerror;
-using std::strftime;
-using std::strlen;
-using std::strtod;
-using std::strtol;
-#endif
-
 #endif


### PR DESCRIPTION
## Summary

- Removes 18 \`using std::\` declarations for C stdlib functions (e.g. \`memcpy\`, \`strlen\`, \`abort\`) that were guarded by \`#if (!defined(_MSC_VER) || (_MSC_VER >= 1300))\`
- These functions are already available in the global namespace per the C++ standard, making the declarations redundant

## Test plan

- [ ] Build passes with \`cmake --build\`
- [ ] Unit tests pass (\`lib/ut\`)