### PR TITLE
Require C++17 consistently

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
 
 set (quickfix_PROJECT_NAME quickfix)
 
@@ -13,7 +13,7 @@ project(${quickfix_PROJECT_NAME} VERSION 1.16.0 LANGUAGES CXX C)
 message("-- Project name ${CMAKE_PROJECT_NAME}")
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if( MSVC )
   add_compile_options(/MP)
@@ -41,10 +41,6 @@ if( MSVC AND STATIC_RUNTIME )
   set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /MT")
   set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MT")
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
-endif()
-
-if( CMAKE_CXX_STANDARD EQUAL 17 )
-  option( HAVE_CXX17 "Using C++17" ON)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
@@ -127,4 +123,3 @@ file(REMOVE config.h)
 configure_file(cmake_config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/include/quickfix/config.h @ONLY)
 
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/spec/ DESTINATION share/quickfix FILES_MATCHING PATTERN "FIX*.xml")
- 

--- a/cmake_config.h.in
+++ b/cmake_config.h.in
@@ -1,8 +1,6 @@
 #ifndef CONFIG_H_IN
 #define CONFIG_H_IN
 
-#cmakedefine HAVE_CXX17
-#cmakedefine HAVE_STD_SHARED_PTR
 #cmakedefine HAVE_MYSQL
 #cmakedefine HAVE_POSTGRESQL
 #cmakedefine HAVE_SSL 1

--- a/src/C++/CMakeLists.txt
+++ b/src/C++/CMakeLists.txt
@@ -89,7 +89,7 @@ if(HAVE_FTIME)
     target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_FTIME)
 endif()
 
-target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_11)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 target_include_directories(${PROJECT_NAME} INTERFACE ${PROJECT_SOURCE_DIR}/include)
 target_include_directories(${PROJECT_NAME} PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src ${PROJECT_SOURCE_DIR}/src/C++)
 

--- a/src/C++/Field.h
+++ b/src/C++/Field.h
@@ -32,10 +32,7 @@
 #include "Utility.h"
 #include <numeric>
 #include <sstream>
-
-#ifdef HAVE_CXX17
 #include <string_view>
-#endif
 #if defined(__SUNPRO_CC)
 #include <algorithm>
 #endif
@@ -238,9 +235,7 @@ public:
   void setValue(const std::string &value) { setString(value); }
   const std::string &getValue() const { return getString(); }
   operator const std::string &() const { return getString(); }
-#ifdef HAVE_CXX17
   operator std::string_view() const { return getString(); }
-#endif
 
   bool operator<(const StringField &rhs) const { return getString() < rhs.getString(); }
   bool operator>(const StringField &rhs) const { return getString() > rhs.getString(); }

--- a/src/C++/FieldMap.h
+++ b/src/C++/FieldMap.h
@@ -32,12 +32,9 @@
 #include "Utility.h"
 #include <algorithm>
 #include <map>
+#include <optional>
 #include <sstream>
 #include <vector>
-
-#ifdef HAVE_CXX17
-#include <optional>
-#endif
 
 namespace FIX {
 /**
@@ -149,12 +146,10 @@ public:
     return *reinterpret_cast<const T *>(&getFieldRef(T::tag));
   }
 
-#ifdef HAVE_CXX17
   template <typename F> std::optional<F> getFieldOptional() const {
     F field;
     return getFieldIfSet(field) ? std::optional<F>{field} : std::nullopt;
   }
-#endif
 
   /// Get a field without a field class
   const std::string &getField(int tag) const EXCEPT(FieldNotFound) { return getFieldRef(tag).getString(); }

--- a/src/C++/config.h
+++ b/src/C++/config.h
@@ -1,8 +1,6 @@
 #ifndef CONFIG_H_IN
 #define CONFIG_H_IN
 
-#define HAVE_CXX17
-/* #undef HAVE_STD_SHARED_PTR */
 /* #undef HAVE_MYSQL */
 /* #undef HAVE_POSTGRESQL */
 /* #undef HAVE_SSL */

--- a/src/C++/test/FieldBaseTestCase.cpp
+++ b/src/C++/test/FieldBaseTestCase.cpp
@@ -75,7 +75,6 @@ TEST_CASE("FieldBaseTests") {
     CHECK(!(stringField <= "str"));
   }
 
-#ifdef HAVE_CXX17
   SECTION("StringField_ImplicitConversionToStringView") {
     StringField stringField(1, "hello");
     std::string_view sv = stringField;
@@ -89,5 +88,4 @@ TEST_CASE("FieldBaseTests") {
     CHECK(stringField <= std::string_view{"string_long"});
     CHECK(!(stringField <= std::string_view{"str"}));
   }
-#endif
 }

--- a/src/C++/test/FieldMapTestCase.cpp
+++ b/src/C++/test/FieldMapTestCase.cpp
@@ -162,7 +162,6 @@ TEST_CASE("FieldMapTests") {
     CHECK("field18_new" == actualTag18.getString());
   }
 
-#ifdef HAVE_CXX17
   SECTION("getFieldOptional") {
     FieldMap fieldMap;
     fieldMap.setField(FIX::BeginSeqNo(42));
@@ -172,5 +171,4 @@ TEST_CASE("FieldMapTests") {
     auto endSeqNo = fieldMap.getFieldOptional<FIX::EndSeqNo>();
     CHECK(!endSeqNo.has_value());
   }
-#endif
 }


### PR DESCRIPTION
The README already lists a C++17-compatible compiler as a prerequisite, but the build system did not actually enforce this in a consistent way.

Changes:
- Set `CMAKE_CXX_STANDARD_REQUIRED=ON` to fail fast instead of silently degrading to a lower version.
- Set `target_compile_features` on the library target from `cxx_std_11` to `cxx_std_17` for consistency.
- Remove the unnecessary `HAVE_CXX17` cmake option and usages in the code.

Unrelated to those changes, I have bumped the minimum CMake version to 3.12 for consistency with FindODBC, which was added in that version.