### PR TITLE
Update FindPythonLibs to FindPython3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 set (quickfix_PROJECT_NAME quickfix)
 
@@ -99,8 +99,7 @@ message("-- Building with ODBC")
 endif()
 
 if (HAVE_PYTHON3)
-  find_package(PythonLibs 3 REQUIRED)
-  include_directories(${PYTHON_INCLUDE_DIRS})
+  find_package(Python3 REQUIRED COMPONENTS Development.Module)
 endif ()
 
 add_subdirectory(src)

--- a/src/python3/CMakeLists.txt
+++ b/src/python3/CMakeLists.txt
@@ -8,9 +8,9 @@ set(quickfix_python_lib_name _${PROJECT_NAME})
 
 add_library(${quickfix_python_lib_name} SHARED  ${quickfix_python_SOURCES})
 
-target_include_directories(${quickfix_python_lib_name} PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src/C++)
+target_include_directories(${quickfix_python_lib_name} PRIVATE ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/src/C++ ${PROJECT_SOURCE_DIR}/src/swig)
 
-target_link_libraries(${quickfix_python_lib_name} ${PROJECT_NAME})
+target_link_libraries(${quickfix_python_lib_name} ${PROJECT_NAME} Python3::Module)
 
 if (HAVE_SSL)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_SSL=1")


### PR DESCRIPTION
1. Resolve CMake warning [CMP0148](https://cmake.org/cmake/help/latest/policy/CMP0148.html)
2. Bump minimum CMake version to 3.18 for [`Development.Module`](https://cmake.org/cmake/help/latest/module/FindPython3.html)
3. Remove redundant `include_directories` already included via `target_link_libraries`
4. Add missing include directory required when building with `HAVE_PYTHON3=ON` and `HAVE_SSL=OFF`