### PR TITLE
Make C++17 mandatory in autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,9 +38,7 @@ AX_RUBY()
 
 AC_CANONICAL_HOST
 
-AX_CXX_COMPILE_STDCXX( [11], [noext], mandatory)
-AX_CXX_COMPILE_STDCXX( [14], [noext], optional)
-AX_CXX_COMPILE_STDCXX( [17], [noext], optional)
+AX_CXX_COMPILE_STDCXX([17], [noext], mandatory)
 
 ########################################
 # TBB


### PR DESCRIPTION
Make C++17 mandatory in autotools for consistency with CMake, which was already switched to C++17 in https://github.com/quickfix/quickfix/pull/725