### PR TITLE
fix: correct sendercompid/targetcompid for incoming messages in PostgreSQLLog

### DIFF
--- a/src/C++/PostgreSQLLog.cpp
+++ b/src/C++/PostgreSQLLog.cpp
@@ -220,7 +220,7 @@ void PostgreSQLLog::clear() {
 
 void PostgreSQLLog::backup() {}
 
-void PostgreSQLLog::insert(const std::string &table, const std::string value) {
+void PostgreSQLLog::insert(const std::string &table, const std::string value, bool isIncoming) {
   UtcTimeStamp time = UtcTimeStamp::now();
   int year, month, day, hour, minute, second, millis;
   time.getYMD(year, month, day);
@@ -240,8 +240,8 @@ void PostgreSQLLog::insert(const std::string &table, const std::string value) {
 
   if (m_pSessionID) {
     queryString << "'" << m_pSessionID->getBeginString().getValue() << "',"
-                << "'" << m_pSessionID->getSenderCompID().getValue() << "',"
-                << "'" << m_pSessionID->getTargetCompID().getValue() << "',";
+                << "'" << (isIncoming ? m_pSessionID->getTargetCompID().getValue() : m_pSessionID->getSenderCompID().getValue()) << "',"
+                << "'" << (isIncoming ? m_pSessionID->getSenderCompID().getValue() : m_pSessionID->getTargetCompID().getValue()) << "',";
     if (m_pSessionID->getSessionQualifier() == "") {
       queryString << "NULL" << ",";
     } else {

--- a/src/C++/PostgreSQLLog.h
+++ b/src/C++/PostgreSQLLog.h
@@ -19,14 +19,14 @@
 **
 ****************************************************************************/
 
-#ifndef FIX_POSTGRESQLLOG_H
-#define FIX_POSTGRESQLLOG_H
 
 #ifndef HAVE_POSTGRESQL
 #error PostgreSQLLog.h included, but HAVE_POSTGRESQL not defined
 #endif
 
 #ifdef HAVE_POSTGRESQL
+#ifndef FIX_POSTGRESQLLOG_H
+#define FIX_POSTGRESQLLOG_H
 
 #ifdef _MSC_VER
 #pragma warning(disable : 4503 4355 4786 4290)
@@ -66,13 +66,13 @@ public:
   void setOutgoingTable(const std::string &outgoingTable) { m_outgoingTable = outgoingTable; }
   void setEventTable(const std::string &eventTable) { m_eventTable = eventTable; }
 
-  void onIncoming(const std::string &value) { insert(m_incomingTable, value); }
+  void onIncoming(const std::string &value) { insert(m_incomingTable, value, true); }
   void onOutgoing(const std::string &value) { insert(m_outgoingTable, value); }
   void onEvent(const std::string &value) { insert(m_eventTable, value); }
 
 private:
   void init();
-  void insert(const std::string &table, const std::string value);
+  void insert(const std::string &table, const std::string value, bool isIncoming = false);
 
   std::string m_incomingTable;
   std::string m_outgoingTable;
@@ -82,7 +82,7 @@ private:
   SessionID *m_pSessionID;
 };
 
-/// Creates a MySQL based implementation of Log.
+/// Creates a PostgreSQL based implementation of Log.
 class PostgreSQLLogFactory : public LogFactory {
 public:
   static const std::string DEFAULT_DATABASE;


### PR DESCRIPTION
## Problem

When `PostgreSQLLog` logs incoming messages via `onIncoming()`, the
`sendercompid` and `targetcompid` columns in `messages_log` are always
populated from the local `SessionID` object perspective.

This means if your session is `SENDER -> TARGET`, an incoming message
FROM the counterparty appears in the database as:
- sendercompid = SENDER ← incorrect
- targetcompid = TARGET ← incorrect

When it should be:
- sendercompid = TARGET ← correct (actual sender)
- targetcompid = SENDER ← correct (actual recipient)

This makes it impossible to distinguish incoming from outgoing messages
by querying sendercompid/targetcompid columns without parsing the raw
FIX text field.

## Fix

Added `isIncoming` boolean parameter (default `false`) to `insert()`.
When `true` (called from `onIncoming()`), `getSenderCompID()` and
`getTargetCompID()` are swapped to correctly reflect actual message
direction.

No breaking changes — existing behavior preserved for outgoing and
event logging.

## Also Fixed

1. **Header guard order**: `#ifndef FIX_POSTGRESQLLOG_H` was placed
   before the `HAVE_POSTGRESQL` check. Restored correct order so the
   `HAVE_POSTGRESQL` error fires before the include guard is evaluated.

2. **Incorrect class comment**: `PostgreSQLLogFactory` was documented
   as "MySQL based implementation" — corrected to "PostgreSQL".

## Testing

Verified against a live FIX acceptor (FIXT.1.1) with multiple sessions.
After fix, `messages_log` correctly shows:
- Incoming: sendercompid = counterparty, targetcompid = local session
- Outgoing: sendercompid = local session, targetcompid = counterparty