### PR TITLE
Fix SocketInitiator Re-Logon After Scheduled Logout

### DIFF
--- a/src/C++/SocketConnector.cpp
+++ b/src/C++/SocketConnector.cpp
@@ -53,9 +53,8 @@ private:
   }
 
   virtual void onError(SocketMonitor &monitor, socket_handle socket) override {
-    if (monitor.drop(socket)) {
-      m_strategy.onDisconnect(m_connector, socket);
-    }
+    monitor.drop(socket, false);
+    m_strategy.onDisconnect(m_connector, socket);
   }
 
   virtual void onError(SocketMonitor &) override { m_strategy.onError(m_connector); }

--- a/src/C++/SocketMonitor_UNIX.cpp
+++ b/src/C++/SocketMonitor_UNIX.cpp
@@ -90,7 +90,7 @@ bool SocketMonitor::addWrite(socket_handle s) {
   return true;
 }
 
-bool SocketMonitor::drop(socket_handle s) {
+bool SocketMonitor::drop(socket_handle s, bool queueDropped) {
   Sockets::iterator i = m_readSockets.find(s);
   Sockets::iterator j = m_writeSockets.find(s);
   Sockets::iterator k = m_connectSockets.find(s);
@@ -100,7 +100,9 @@ bool SocketMonitor::drop(socket_handle s) {
     m_readSockets.erase(s);
     m_writeSockets.erase(s);
     m_connectSockets.erase(s);
-    m_dropped.push(s);
+    if (queueDropped) {
+      m_dropped.push(s);
+    }
     return true;
   }
   return false;

--- a/src/C++/SocketMonitor_UNIX.h
+++ b/src/C++/SocketMonitor_UNIX.h
@@ -49,7 +49,7 @@ public:
   bool addConnect(socket_handle socket);
   bool addRead(socket_handle socket);
   bool addWrite(socket_handle socket);
-  bool drop(socket_handle socket);
+  bool drop(socket_handle socket, bool queueDropped = true);
   void signal(socket_handle socket);
   void unsignal(socket_handle socket);
   void block(Strategy &strategy, bool poll = 0, double timeout = 0.0);

--- a/src/C++/SocketMonitor_WIN32.cpp
+++ b/src/C++/SocketMonitor_WIN32.cpp
@@ -94,7 +94,7 @@ bool SocketMonitor::addWrite(socket_handle s) {
   return true;
 }
 
-bool SocketMonitor::drop(socket_handle s) {
+bool SocketMonitor::drop(socket_handle s, bool queueDropped) {
   Sockets::iterator i = m_readSockets.find(s);
   Sockets::iterator j = m_writeSockets.find(s);
   Sockets::iterator k = m_connectSockets.find(s);
@@ -104,7 +104,9 @@ bool SocketMonitor::drop(socket_handle s) {
     m_readSockets.erase(s);
     m_writeSockets.erase(s);
     m_connectSockets.erase(s);
-    m_dropped.push(s);
+    if (queueDropped) {
+      m_dropped.push(s);
+    }
     return true;
   }
   return false;

--- a/src/C++/SocketMonitor_WIN32.h
+++ b/src/C++/SocketMonitor_WIN32.h
@@ -45,7 +45,7 @@ public:
   bool addConnect(socket_handle socket);
   bool addRead(socket_handle socket);
   bool addWrite(socket_handle socket);
-  bool drop(socket_handle socket);
+  bool drop(socket_handle socket, bool queueDropped = true);
   void signal(socket_handle socket);
   void unsignal(socket_handle socket);
   void block(Strategy &strategy, bool poll = 0, double timeout = 0.0);

--- a/src/C++/test/SocketConnectorTestCase.cpp
+++ b/src/C++/test/SocketConnectorTestCase.cpp
@@ -56,6 +56,33 @@ TEST_CASE("SocketConnectorTests") {
     server.close();
   }
 
+  SECTION("dropped_connected_socket_fires_disconnect_once") {
+    SocketServer server(0);
+    socket_handle serverSocket = server.add(0, true, true);
+
+    SocketConnector connector(1);
+    SocketConnectorTestStrategy strategy;
+    socket_handle clientSocket = connector.connect("127.0.0.1", socket_hostport(serverSocket), false, 1024, 1024);
+    CHECK(clientSocket != INVALID_SOCKET_HANDLE);
+
+    process_sleep(0.1);
+    socket_handle acceptedSocket = server.accept(serverSocket);
+    CHECK(acceptedSocket != INVALID_SOCKET_HANDLE);
+
+    connector.block(strategy, true);
+    CHECK(1 == strategy.connect);
+
+    CHECK(connector.getMonitor().drop(clientSocket));
+    connector.block(strategy, true);
+    CHECK(1 == strategy.disconnect);
+
+    connector.block(strategy, true);
+    CHECK(1 == strategy.disconnect);
+
+    destroySocket(acceptedSocket);
+    server.close();
+  }
+
 #ifndef _MSC_VER
   SECTION("connect_to_dead_port_fires_disconnect_once") {
     // Bind a server to get a free port, then close it so nothing is listening.


### PR DESCRIPTION
## Problem

<img width="1513" height="705" alt="image" src="https://github.com/user-attachments/assets/a7be9603-8cc1-4cfe-bd3f-12893f3a82ad" />

Commit `30622fa` changed `SocketConnector::onError()` to call `onDisconnect()` only when `monitor.drop(socket)` returns true. This prevents duplicate disconnect callbacks for failed connector connections, but it also suppresses the only cleanup callback for sockets that were intentionally dropped earlier and later replayed from `SocketMonitor::m_dropped`.

This breaks the `SocketInitiator` scheduled logout/re-logon lifecycle:

1. The initiator logs on successfully.
2. At scheduled `EndTime`, `Session::disconnect()` clears the responder and drops the socket.
3. On the next monitor cycle, the dropped socket is replayed, but `SocketConnector::onError()` skips `onDisconnect()` because the socket is already removed from the monitor.
4. The stale `SocketConnection` remains in `SocketInitiator::m_connections`, and the session is not moved back to `m_disconnected`.
5. At the next scheduled `StartTime`, the event log can show `Initiated logon request`, but no outgoing Logon (`35=A`) is written because `Session::send()` has no responder. The initiator then repeatedly times out waiting for a logon response.

## Solution

Preserve the failed-connection duplicate-disconnect fix while restoring cleanup for externally dropped sockets.

This change adds an optional `queueDropped` parameter to `SocketMonitor::drop()`, defaulting to the existing behavior. External callers still queue dropped sockets for replay. `SocketConnector::onError()` now drops active error sockets with `queueDropped = false` and immediately calls `onDisconnect()`, so failed connections are cleaned up once and do not generate a duplicate replay callback.

A regression test, `dropped_connected_socket_fires_disconnect_once`, verifies that a connected socket dropped through the monitor still produces exactly one `SocketConnector::Strategy::onDisconnect()` callback. This covers the cleanup path used by `SocketInitiator` after scheduled session logout.

Validation:

```text
SocketConnectorTests: All tests passed (8 assertions in 1 test case)
Full test suite: All tests passed (1993 assertions in 53 test cases)
```

<img width="1598" height="1035" alt="image" src="https://github.com/user-attachments/assets/b719badf-6ff7-4ef6-9e48-67bcfc3e2ca0" />
