### PR TITLE
Fix buffer overrun in ThreadedSocketConnection partial sends

### DIFF
--- a/src/C++/ThreadedSocketConnection.cpp
+++ b/src/C++/ThreadedSocketConnection.cpp
@@ -78,7 +78,7 @@ ThreadedSocketConnection::~ThreadedSocketConnection() {
 bool ThreadedSocketConnection::send(const std::string &msg) {
   ssize_t totalSent = 0;
   while (totalSent < (int)msg.length()) {
-    ssize_t sent = socket_send(m_socket, msg.c_str() + totalSent, msg.length());
+    ssize_t sent = socket_send(m_socket, msg.c_str() + totalSent, msg.length() - totalSent);
     if (sent < 0) {
       return false;
     }


### PR DESCRIPTION
The `send` method in `ThreadedSocketConnection` incorrectly passed the  total message length to `socket_send` on every iteration of the loop.  In the event of a partial send, advancing the buffer pointer while  keeping the size argument as the total message length caused the socket  to read past the end of the allocated string buffer. 

Updated the `socket_send` size argument to calculate the remaining  length (`msg.length() - totalSent`).