### PR TITLE
Wrap over-long line in Message::toString

### DIFF
--- a/src/C++/Message.cpp
+++ b/src/C++/Message.cpp
@@ -227,7 +227,9 @@ std::string &Message::toString(std::string &str, int beginStringField, int bodyL
     return sum;
   };
   int bodyLengthFieldContrib = sumAsciiDigits(bodyLengthField) + '=' + sumAsciiDigits(bodyLength) + '\001';
-  int totalChecksum = (headerLengthAndTotal.total + bodyLengthAndTotal.total + trailerLengthAndTotal.total + bodyLengthFieldContrib) % 256;
+  int totalChecksum
+      = (headerLengthAndTotal.total + bodyLengthAndTotal.total + trailerLengthAndTotal.total + bodyLengthFieldContrib)
+        % 256;
 
   m_header.setField(IntField(bodyLengthField, bodyLength));
   m_trailer.setField(CheckSumField(checkSumField, totalChecksum));


### PR DESCRIPTION
The checksum expression added in 15253c38 is 139 characters, over the 120-column limit in .clang-format, so the clang-format CI check fails on master. Applied clang-format to the file; no behaviour change.